### PR TITLE
Change output channel to be a channel of functions

### DIFF
--- a/lib/Core/Program/Context.hs
+++ b/lib/Core/Program/Context.hs
@@ -77,7 +77,7 @@ data Context τ = Context {
     , startTimeFrom :: TimeStamp
     , terminalWidthFrom :: Int
     , verbosityLevelFrom :: MVar Verbosity
-    , outputChannelFrom :: TQueue Rope
+    , outputChannelFrom :: TQueue (Handle -> IO ())
     , loggerChannelFrom :: TQueue Message
     , applicationDataFrom :: MVar τ
 }

--- a/lib/Core/Program/Logging.hs
+++ b/lib/Core/Program/Logging.hs
@@ -50,7 +50,7 @@ putMessage context message@(Message now _ text potentialValue) = do
     let result = formatLogMessage start now display
 
     atomically $ do
-        writeTQueue output result
+        writeTQueue output (\handle -> hWrite handle result)
         writeTQueue logger message
 
 

--- a/lib/Core/Text/Utilities.hs
+++ b/lib/Core/Text/Utilities.hs
@@ -14,6 +14,7 @@ module Core.Text.Utilities (
       {-* Pretty printing -}
       Render(..)
     , render
+    , render'
       {-* Helpers -}
     , indefinite
     , wrap
@@ -29,7 +30,7 @@ import qualified Data.Text as T
 import qualified Data.Text.Lazy.Builder as T
 import qualified Data.Text.Short as S (ShortText, uncons, toText)
 import Data.Text.Prettyprint.Doc (Doc, layoutPretty , reAnnotateS
-    , pretty, emptyDoc
+    , pretty, emptyDoc, SimpleDocStream
     , LayoutOptions(LayoutOptions)
     , PageWidth(AvailablePerLine))
 import Data.Text.Prettyprint.Doc.Render.Terminal (renderStrict, AnsiStyle)
@@ -114,6 +115,17 @@ render columns (thing :: α) =
     options = LayoutOptions (AvailablePerLine (columns - 1) 1.0)
   in
     intoRope . renderStrict . reAnnotateS (colourize @α)
+                . layoutPretty options . intoDocA $ thing
+
+-- used internally in output queues to avoid allocating a strict Text
+-- and then wrapping it in a Rope; prettyprint-ansi-terminal provides a
+-- `renderIO` function which we use at the output site.
+render' :: Render α => Int -> α -> SimpleDocStream AnsiStyle
+render' columns (thing :: α) =
+  let
+    options = LayoutOptions (AvailablePerLine (columns - 1) 1.0)
+  in
+    reAnnotateS (colourize @α)
                 . layoutPretty options . intoDocA $ thing
 
 --


### PR DESCRIPTION
Experiment with changing the output channel from a

```haskell
 :: TQueue Rope
```

to a

```haskell
 :: TQueue (Handle -> IO)
```

so that we can use `renderIO` when writing things that are saturated with Ansi escape codes; **prettyprinter** and **prettyprinter-ansi-terminal** works internally in Data.Text fragments and there's not much reason to fight that when they supply an action which dumps the stream of their fragments directly into an output handle.

Obviously this costs allocating a function each time someone does an output. How does that compare to allocating the output into a Rope?