### PR TITLE
Implement logging to different back-ends

### DIFF
--- a/lib/Core/Program/Arguments.hs
+++ b/lib/Core/Program/Arguments.hs
@@ -164,6 +164,9 @@ Available options:
   -v, --verbose  Turn on event tracing. By default the logging stream will go
                  to standard output on your terminal.
       --debug    Turn on debug level logging. Implies --verbose.
+      --logging=WHERE
+                 Change where log messages are sent. Valid values are
+                 \"console\", \"file:\/path\/to\/filename.log\", and \"syslog\".
 
 Required arguments:
 
@@ -384,6 +387,10 @@ baselineOptions =
     |]
     , Option "debug" Nothing Empty [quote|
         Turn on debug level logging. Implies --verbose.
+    |]
+    , Option "logging" Nothing (Value "WHERE") [quote|
+        Change where log messages are sent. Valid values are "console",
+        "file:/path/to/filename.log", and "syslog".
     |]
     ]
 

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: unbeliever
-version: 0.6.2
+version: 0.6.3
 synopsis: Opinionated Haskell Interoperability
 description: |
   A library to help build command-line programs, both tools and


### PR DESCRIPTION
Originally we had the idea for there to be a `--logging` option, specifying where to send the log stream to (ie output of `event` and `debug*`) separate from what gets written to stdout by `write*`. We removed it so as not to confuse users of **publish** but we do intend to finish implementing the feature.