### PR TITLE
Implement function to divide a Rope in two, splitting on a Rope

### DIFF
--- a/lib/Core/Text/Breaking.hs
+++ b/lib/Core/Text/Breaking.hs
@@ -82,11 +82,12 @@ breakPieces predicate text =
        Nothing -> result
        Just piece -> intoRope piece : result
 
-{-
-Was the previous piece a match, or are we in the middle of a run of
-characters? If we were, then join the previous run to the current piece
-before processing into chunks.
--}
+--
+-- Was the previous piece a match, or are we in the middle of a run of
+-- characters? If we were, then join the previous run to the current piece
+-- before processing into chunks.
+--
+
 -- now for right fold
 intoPieces :: (Char -> Bool) -> S.ShortText -> (Maybe S.ShortText,[Rope]) -> (Maybe S.ShortText,[Rope])
 intoPieces predicate piece (stream,list) =
@@ -118,18 +119,18 @@ intoPieces predicate piece (stream,list) =
 -- (""," ")
 --
 
-{-
-This was more easily expressed as 
-
-  let
-    remainder' = S.drop 1 remainder
-  in
-    if remainder == " "
-
-for the case when we were breaking on spaces. But generalized to a predicate
-we have to strip off the leading character and test that its the only character;
-this is cheaper than S.length etc.
--}
+--
+-- This was more easily expressed as
+--
+--   let
+--     remainder' = S.drop 1 remainder
+--   in
+--     if remainder == " "
+--
+-- for the case when we were breaking on spaces. But generalized to a
+-- predicate we have to strip off the leading character and test that its
+-- the only character; this is cheaper than S.length etc.
+--
 intoChunks :: (Char -> Bool) -> S.ShortText -> [Rope]
 intoChunks _ piece | S.null piece = []
 intoChunks predicate piece =
@@ -150,13 +151,30 @@ intoChunks predicate piece =
 
 ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ----
 
+{-|
+Search for a Rope in a larger Rope and split it into two sub-Ropes if
+found: the part preceeding that location, and the remainder from
+that point onward (including the text you searched for).
+
+Examples:
+
+@
+λ> __divideRope \"Wor\" \"Hello World\"__
+[\"Hello \",\"World\")
+@
+-}
+-- this is officially terrible. Converting a Rope into a single ShortText is bad.
+-- We should be folding over its pieces in a manner similar to breakPieces.
 divideRope :: Rope -> Rope -> (Rope,Rope)
 divideRope needle haystack =
     find needle' haystack' emptyRope
   where
     needle' = fromRope needle
-    haystack' = fromRope haystack   -- this is officially terrible
+    haystack' = fromRope haystack
 
+-- this is officially even worse. We're taking the huge single ShortText
+-- and breaking it into pieces that are only needle length long, then
+-- recombining them into a Rope.
 find :: S.ShortText -> S.ShortText -> Rope -> (Rope,Rope)
 find needle haystack previous =
   let

--- a/lib/Core/Text/Utilities.hs
+++ b/lib/Core/Text/Utilities.hs
@@ -20,6 +20,7 @@ module Core.Text.Utilities (
     , breakWords
     , breakLines
     , breakPieces
+    , divideRope
     , wrap
     , underline
       {-* Multi-line strings -}

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: unbeliever
-version: 0.9.3.2
+version: 0.9.4.0
 synopsis: Opinionated Haskell Interoperability
 description: |
   A library to help build command-line programs, both tools and

--- a/tests/CheckRopeBehaviour.hs
+++ b/tests/CheckRopeBehaviour.hs
@@ -215,10 +215,12 @@ Third line.
             divideRope "Hell" "Hello World" `shouldBe` ("","Hello World")
             divideRope "Wor" "Hello World" `shouldBe` ("Hello ","World")
             divideRope "Wor" "Hello World World²" `shouldBe` ("Hello ","World World²")
+            divideRope "Hello World" "Hello World" `shouldBe` ("","Hello World")
 
         it "handles not-found cases" $ do
             divideRope "x" "Hello World" `shouldBe` ("Hello World","")
             divideRope "xyz" "Hello World" `shouldBe` ("Hello World","")
+            divideRope "Hello Worldx" "Hello World" `shouldBe` ("Hello World","")
 
     describe "Formatting paragraphs" $ do
         it "multi-line paragraph rewraps correctly" $

--- a/tests/CheckRopeBehaviour.hs
+++ b/tests/CheckRopeBehaviour.hs
@@ -204,6 +204,22 @@ Third line.
                 , "Third line."
                 ]
 
+    describe "Dividing into subropes" $ do
+        it "finds single characters" $ do
+            divideRope "" "" `shouldBe` ("","")
+            divideRope "H" "Hello World" `shouldBe` ("","Hello World")
+            divideRope "W" "Hello World" `shouldBe` ("Hello ","World")
+            divideRope " " "Hello World" `shouldBe` ("Hello"," World")
+
+        it "finds contiguous strings" $ do
+            divideRope "Hell" "Hello World" `shouldBe` ("","Hello World")
+            divideRope "Wor" "Hello World" `shouldBe` ("Hello ","World")
+            divideRope "Wor" "Hello World World²" `shouldBe` ("Hello ","World World²")
+
+        it "handles not-found cases" $ do
+            divideRope "x" "Hello World" `shouldBe` ("Hello World","")
+            divideRope "xyz" "Hello World" `shouldBe` ("Hello World","")
+
     describe "Formatting paragraphs" $ do
         it "multi-line paragraph rewraps correctly" $
           let


### PR DESCRIPTION
Add new function `divideRope`, analogous to `split`/`break` functions but splitting the haystack Rope on occurence of needle as a Rope, rather than a Char (or Char -> Bool predicate).

This implementation is _very expensive_. I'd like to think someone smarter than me can come up with a better way to write it, perhaps as a fold in the style of `breakPieces`. There are tests in place to define and guard the behaviour, so please feel free to experiment.

