### PR TITLE
Fmap context

### DIFF
--- a/core-program/lib/Core/Program/Context.hs
+++ b/core-program/lib/Core/Program/Context.hs
@@ -84,7 +84,7 @@ data Context τ = Context
   }
 
 -- I would happily accept critique as to whether this is safe or not. I think
--- so? The only way to get to the underying top-level application data is
+-- so? The only way to get to the underlying top-level application data is
 -- through 'getApplicationState' which is in Program monad so the fact that it
 -- is implemented within an MVar should be irrelevant.
 instance Functor Context where

--- a/core-program/lib/Core/Program/Context.hs
+++ b/core-program/lib/Core/Program/Context.hs
@@ -83,9 +83,16 @@ data Context τ = Context
     applicationDataFrom :: MVar τ
   }
 
+-- I would happily accept critique as to whether this is safe or not. I think
+-- so? The only way to get to the underying top-level application data is
+-- through 'getApplicationState' which is in Program monad so the fact that it
+-- is implemented within an MVar should be irrelevant.
 instance Functor Context where
   fmap f = unsafePerformIO . fmapContext f
 
+-- |
+-- Map a function over the underlying user-data inside the 'Context', changing
+-- it from type@τ1@ to @τ2@.
 fmapContext :: (τ1 -> τ2) -> Context τ1 -> IO (Context τ2)
 fmapContext f context = do
   state <- readMVar (applicationDataFrom context)

--- a/core-program/package.yaml
+++ b/core-program/package.yaml
@@ -1,5 +1,5 @@
 name: core-program
-version: 0.2.4.5
+version: 0.2.5.0
 synopsis: Opinionated Haskell Interoperability
 description: |
   A library to help build command-line programs, both tools and
@@ -15,10 +15,10 @@ description: |
 stability: experimental
 license: BSD3
 license-file: LICENSE
-author: Andrew Cowie <andrew@operationaldynamics.com>
-maintainer: Andrew Cowie <andrew@operationaldynamics.com>
+author: Andrew Cowie <istathar@gmail.com>
+maintainer: Andrew Cowie <istathar@gmail.com>
 copyright: © 2018-2020 Athae Eredh Siniath and Others
-tested-with: GHC == 8.8.3
+tested-with: GHC == 8.8.4
 category: System
 ghc-options: -Wall -Wwarn -fwarn-tabs
 github: aesiniath/unbeliever
@@ -26,8 +26,8 @@ github: aesiniath/unbeliever
 dependencies:
  - base >= 4.11 && < 5
  - bytestring
- - hashable >= 1.2 && < 1.4
- - prettyprinter >= 1.2.1.1 && < 1.8
+ - hashable >= 1.2
+ - prettyprinter >= 1.2.1.1
  - prettyprinter-ansi-terminal
  - template-haskell >= 2.14 && < 3
  - text

--- a/package.yaml
+++ b/package.yaml
@@ -65,6 +65,8 @@ tests:
      - safe-exceptions
      - text
      - text-short
+     - unordered-containers
+     - prettyprinter
     ghc-options: -threaded
     source-dirs:
      - tests

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-16.14
+resolver: lts-16.18
 packages:
  - ./core-data
  - ./core-text


### PR DESCRIPTION
Add `fmapContext` for the Context type and a Functor instance thereof.

As commented in the code, I would happily accept critique as to whether this is safe or not. I think so? The only way to get to the underlying top-level application data is through `getApplicationState` which is in Program monad so the fact that it is implemented within an MVar should be irrelevant.