### PR TITLE
Allow timer reset

### DIFF
--- a/core-program/lib/Core/Program/Context.hs
+++ b/core-program/lib/Core/Program/Context.hs
@@ -75,7 +75,7 @@ data Context τ = Context
     , versionFrom :: Version
     , commandLineFrom :: Parameters
     , exitSemaphoreFrom :: MVar ExitCode
-    , startTimeFrom :: TimeStamp
+    , startTimeFrom :: MVar TimeStamp
     , terminalWidthFrom :: Int
     , verbosityLevelFrom :: MVar Verbosity
     , outputChannelFrom :: TQueue Rope
@@ -248,6 +248,7 @@ configure version t config = do
     n <- newMVar (intoRope arg0)
     p <- handleCommandLine version config
     q <- newEmptyMVar
+    i <- newMVar start
     columns <- getConsoleWidth
     out <- newTQueueIO
     log <- newTQueueIO
@@ -261,7 +262,7 @@ configure version t config = do
             , versionFrom = version
             , commandLineFrom = p
             , exitSemaphoreFrom = q
-            , startTimeFrom = start
+            , startTimeFrom = i
             , terminalWidthFrom = columns
             , verbosityLevelFrom = l
             , outputChannelFrom = out

--- a/core-program/lib/Core/Program/Context.hs
+++ b/core-program/lib/Core/Program/Context.hs
@@ -201,16 +201,15 @@ subProgram :: Context τ -> Program τ α -> IO α
 subProgram context (Program r) = do
     runReaderT r context
 
---
--- This is complicated. The **safe-exceptions** library exports a
--- `throwM` which is not the `throwM` class method from MonadThrow.
--- See https://github.com/fpco/safe-exceptions/issues/31 for
--- discussion. In any event, the re-exports flow back to
--- Control.Monad.Catch from **exceptions** and Control.Exceptions in
--- ** base**. In the execute actions, we need to catch everything (including
--- asynchronous exceptions); elsewhere we will use and wrap/export
--- ** safe-exceptions**'s variants of the functions.
---
+{-
+This is complicated. The **safe-exceptions** library exports a `throwM` which
+is not the `throwM` class method from MonadThrow. See
+https://github.com/fpco/safe-exceptions/issues/31 for discussion. In any
+event, the re-exports flow back to Control.Monad.Catch from **exceptions** and
+Control.Exceptions in **base**. In the execute actions, we need to catch
+everything (including asynchronous exceptions); elsewhere we will use and
+wrap/export **safe-exceptions**'s variants of the functions.
+-}
 instance MonadThrow (Program τ) where
     throwM = liftIO . Safe.throw
 

--- a/core-program/lib/Core/Program/Execute.hs
+++ b/core-program/lib/Core/Program/Execute.hs
@@ -499,12 +499,12 @@ of the total elapsed program time, then fork a new thread for your worker and
 reset the timer there.
 
 @
-    fork $ do
-        resetTimer
+    'fork' $ do
+        'resetTimer'
         ...
 @
 
-and times output in the log messages will be relative to that call to
+then times output in the log messages will be relative to that call to
 'resetTimer', not the program start.
 -}
 resetTimer :: Program τ ()
@@ -541,7 +541,7 @@ operation.
 
 (this wraps __async__'s 'wait')
 -}
-wait :: Thread α ->  Program τ α
+wait :: Thread α -> Program τ α
 wait (Thread a) = liftIO $ Async.wait a
 
 {- |
@@ -551,7 +551,7 @@ explicily deal with the unused return value:
 
 @
     _ <- 'wait' t1
-    return ()
+    'return' ()
 @
 
 which is a bit tedious. Instead, you can just use this:
@@ -560,11 +560,12 @@ which is a bit tedious. Instead, you can just use this:
     'wait_' t1
 @
 
-The trailing underscore follows the same convetion as found in "Control.Monad"
-which has 'Control.Monad.mapM_' to compliment 'Control.Monad.mapM' but
-likewise discarding the return value.
+The trailing underscore in the name of this function follows the same
+convetion as found in "Control.Monad" which has 'Control.Monad.mapM_' which
+does the same as 'Control.Monad.mapM' but which likewise discards the return
+value.
 -}
-wait_ :: Thread α ->  Program τ ()
+wait_ :: Thread α -> Program τ ()
 wait_ = void . wait
 
 {- |

--- a/core-program/lib/Core/Program/Execute.hs
+++ b/core-program/lib/Core/Program/Execute.hs
@@ -502,9 +502,35 @@ sleep seconds =
     let us = floor (toRational (seconds * 1e6))
      in liftIO $ threadDelay us
 
+{- |
+Wait for the completion of a thread, returning the result. This is a blocking
+operation.
+
+(this wraps __async__'s 'wait')
+-}
 wait :: Thread α ->  Program τ α
 wait (Thread a) = liftIO $ Async.wait a
 
+{- |
+Wait for the completion of a thread, discarding its result. This is
+particularly useful at the end of a do-block as otherwise you have to
+explicily deal with the unused return value:
+
+@
+    _ <- 'wait' t1
+    return ()
+@
+
+which is a bit tedious. Instead, you can just use this:
+
+@
+    'wait_' t1
+@
+
+The trailing underscore follows the same convetion as found in "Control.Monad"
+which has 'Control.Monad.mapM_' to compliment 'Control.Monad.mapM' but
+likewise discarding the return value.
+-}
 wait_ :: Thread α ->  Program τ ()
 wait_ = void . wait
 

--- a/core-program/lib/Core/Program/Logging.hs
+++ b/core-program/lib/Core/Program/Logging.hs
@@ -189,11 +189,11 @@ formatLogMessage start now message =
                 now
 
         -- I hate doing math in Haskell
-        elapsed = fromRational (toRational (now' - start') / 1e9) :: Fixed E3
+        elapsed = fromRational (toRational (now' - start') / 1e9) :: Fixed E1
      in mconcat
             [ intoRope stampZ
             , " ("
-            , padWithZeros 9 (show elapsed)
+            , padWithZeros 4 (show elapsed)
             , ") "
             , message
             ]
@@ -268,7 +268,7 @@ message. This:
 
 will result in
 
-> 13:05:55Z (0000.001) Starting...
+> 13:05:55Z (00.1) Starting...
 
 appearing on stdout /and/ the message being sent down the logging
 channel. The output string is current time in UTC, and time elapsed
@@ -312,7 +312,7 @@ record the value of a variable when debugging code.  This:
 
 will result in
 
-> 13:05:58Z (0003.141) programName = hello
+> 13:05:58Z (03.4) programName = hello
 
 appearing on stdout /and/ the message being sent down the logging channel,
 assuming these actions executed about three seconds after program start.

--- a/core-program/lib/Core/Program/Logging.hs
+++ b/core-program/lib/Core/Program/Logging.hs
@@ -156,7 +156,8 @@ class Monad m => MonadLog a m where
 
 putMessage :: Context τ -> Message -> IO ()
 putMessage context message@(Message now _ text potentialValue) = do
-    let start = startTimeFrom context
+    let i = startTimeFrom context
+    start <- readMVar i
     let output = outputChannelFrom context
     let logger = loggerChannelFrom context
 

--- a/core-program/lib/Core/Program/Logging.hs
+++ b/core-program/lib/Core/Program/Logging.hs
@@ -190,11 +190,11 @@ formatLogMessage start now message =
                 now
 
         -- I hate doing math in Haskell
-        elapsed = fromRational (toRational (now' - start') / 1e9) :: Fixed E1
+        elapsed = fromRational (toRational (now' - start') / 1e9) :: Fixed E3
      in mconcat
             [ intoRope stampZ
             , " ("
-            , padWithZeros 4 (show elapsed)
+            , padWithZeros 6 (show elapsed)
             , ") "
             , message
             ]
@@ -269,7 +269,7 @@ message. This:
 
 will result in
 
-> 13:05:55Z (00.1) Starting...
+> 13:05:55Z (00.112) Starting...
 
 appearing on stdout /and/ the message being sent down the logging
 channel. The output string is current time in UTC, and time elapsed
@@ -313,7 +313,7 @@ record the value of a variable when debugging code.  This:
 
 will result in
 
-> 13:05:58Z (03.4) programName = hello
+> 13:05:58Z (03.141) programName = hello
 
 appearing on stdout /and/ the message being sent down the logging channel,
 assuming these actions executed about three seconds after program start.

--- a/core-program/package.yaml
+++ b/core-program/package.yaml
@@ -1,5 +1,5 @@
 name: core-program
-version: 0.2.7.0
+version: 0.2.7.1
 synopsis: Opinionated Haskell Interoperability
 description: |
   A library to help build command-line programs, both tools and

--- a/core-program/package.yaml
+++ b/core-program/package.yaml
@@ -1,5 +1,5 @@
 name: core-program
-version: 0.2.6.0
+version: 0.2.7.0
 synopsis: Opinionated Haskell Interoperability
 description: |
   A library to help build command-line programs, both tools and

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-17.4
+resolver: lts-17.5
 packages:
  - ./core-data
  - ./core-text

--- a/tests/SimpleExperiment.hs
+++ b/tests/SimpleExperiment.hs
@@ -26,99 +26,100 @@ k = JsonKey "intro"
 v = JsonString "Hello"
 
 j =
-  JsonObject
-    [ (k, v),
-      (JsonKey "song", JsonString "Thriller"),
-      ("other", "A very long name for the \"shadow of the moon\"."),
-      ( JsonKey "four",
-        JsonObject
-          [ (JsonKey "n1", r)
-          ]
-      )
-    ]
+    JsonObject
+        [ (k, v)
+        , (JsonKey "song", JsonString "Thriller")
+        , ("other", "A very long name for the \"shadow of the moon\".")
+        ,
+            ( JsonKey "four"
+            , JsonObject
+                [ (JsonKey "n1", r)
+                ]
+            )
+        ]
 
 b = intoBytes (S.pack "{\"cost\": 4500}")
 
 r = JsonArray [JsonBool False, JsonNull, 42]
 
 data Boom = Boom
-  deriving (Show)
+    deriving (Show)
 
 instance Exception Boom
 
 program :: Program None ()
 program = do
-  event "Starting..."
+    event "Starting..."
 
-  params <- getCommandLine
-  debugS "params" params
+    params <- getCommandLine
+    debugS "params" params
 
-  level <- getVerbosityLevel
-  debugS "level" level
+    level <- getVerbosityLevel
+    debugS "level" level
 
-  name <- getProgramName
-  debug "programName" name
+    name <- getProgramName
+    debug "programName" name
 
-  setProgramName "hello"
+    setProgramName "hello"
 
-  name <- getProgramName
-  debug "programName" name
+    name <- getProgramName
+    debug "programName" name
 
-  debugR "key" k
-  event "Verify internal values"
+    debugR "key" k
+    event "Verify internal values"
 
-  state <- getApplicationState
-  debugS "state" state
+    state <- getApplicationState
+    debugS "state" state
 
-  let x = encodeToUTF8 j
-  writeS x
+    let x = encodeToUTF8 j
+    writeS x
 
-  let (Just y) = decodeFromUTF8 b
-  writeS y
-  writeS (encodeToUTF8 y)
-  writeR (encodeToUTF8 y)
-  writeS (encodeToUTF8 r)
+    let (Just y) = decodeFromUTF8 b
+    writeS y
+    writeS (encodeToUTF8 y)
+    writeR (encodeToUTF8 y)
+    writeS (encodeToUTF8 r)
 
-  debugR "packet" j
+    debugR "packet" j
 
-  event "Clock..."
+    event "Clock..."
 
-  fork $ do
-    sleep 1.5
-    event "Wakey wakey"
-    throw Boom
+    fork $ do
+        sleep 1.5
+        event "Wakey wakey"
+        throw Boom
 
-  replicateM_ 5 $ do
-    sleep 0.5
-    event "tick"
+    replicateM_ 5 $ do
+        sleep 0.5
+        event "tick"
 
-  event "Brr! It's cold"
-  terminate 0
+    event "Brr! It's cold"
+    terminate 0
 
 version :: Version
 version = $(fromPackage)
 
 main :: IO ()
 main = do
-  context <-
-    configure
-      version
-      None
-      ( simple
-          [ Option
-              "quiet"
-              (Just 'q')
-              Empty
-              [quote|
-            Supress normal output.
-          |],
-            Argument
-              "filename"
-              [quote|
+    context <-
+        configure
+            version
+            None
+            ( simple
+                [ Option
+                    "quiet"
+                    (Just 'q')
+                    Empty
+                    [quote|
+            Supress normal output.ZZZZKz
+          |]
+                , Argument
+                    "filename"
+                    [quote|
             The file you want to frobnicate.
-          |],
-            Variable "HOME" "Home directory"
-          ]
-      )
+          |]
+                , Variable "HOME" "Home directory"
+                ]
+            )
 
-  executeWith context program
+    executeWith context program

--- a/tests/SimpleExperiment.hs
+++ b/tests/SimpleExperiment.hs
@@ -84,7 +84,7 @@ program = do
 
     event "Clock..."
 
-    fork $ do
+    forkThread $ do
         sleep 1.5
         event "Wakey wakey"
         throw Boom
@@ -111,7 +111,7 @@ main = do
                     (Just 'q')
                     Empty
                     [quote|
-            Supress normal output.ZZZZKz
+            Supress normal output.
           |]
                 , Argument
                     "filename"


### PR DESCRIPTION
Enable resetting the elapsed timer shown in log messages by adding new function `resetTimer` in the Program monad.

Change the precision in log messages to (00.000); there really isn't a need for 5 digits of seconds but, on reflection, keeping milliseconds is nice.