### PR TITLE
Minor improvements to Bytes type

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,32 +1,19 @@
-Opinionated Haskell Interoperability
+Copyright © 2018-2021 Athae Eredh Siniath and Others
 
-Copyright © 2018-2019 Athae Eredh Siniath and Others
-All rights reserved.
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
 
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions
-are met:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
 
-    1. Redistributions of source code must retain the above copyright
-       notice, this list of conditions and the following disclaimer.
-
-    2. Redistributions in binary form must reproduce the above
-       copyright notice, this list of conditions and the following
-       disclaimer in the documentation and/or other materials provided
-       with the distribution.
-      
-    3. Neither the name of the project nor the names of its contributors
-       may be used to endorse or promote products derived from this 
-       software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/core-data/package.yaml
+++ b/core-data/package.yaml
@@ -12,7 +12,7 @@ description: |
   on GitHub.
 
 stability: experimental
-license: BSD3
+license: MIT
 license-file: LICENSE
 author: Andrew Cowie <istathar@gmail.com>
 maintainer: Andrew Cowie <istathar@gmail.com>

--- a/core-program/lib/Core/Program/Execute.hs
+++ b/core-program/lib/Core/Program/Execute.hs
@@ -64,6 +64,7 @@ module Core.Program.Execute (
     lookupOptionFlag,
     lookupOptionValue,
     lookupArgument,
+    lookupEnvironmentValue,
     getProgramName,
     setProgramName,
     getVerbosityLevel,
@@ -649,6 +650,18 @@ lookupOptionFlag name params =
         Nothing -> Nothing
         Just argument -> case argument of
             _ -> Just True -- nom, nom
+
+{- |
+Look to see if the user supplied the named environment variable and if so,
+return what its value was.
+-}
+lookupEnvironmentValue :: LongName -> Parameters -> Maybe String
+lookupEnvironmentValue name params =
+    case lookupKeyValue name (environmentValuesFrom params) of
+        Nothing -> Nothing
+        Just param -> case param of
+            Empty -> Nothing
+            Value str -> Just str
 
 {- |
 Illegal internal state resulting from what should be unreachable code or

--- a/core-program/package.yaml
+++ b/core-program/package.yaml
@@ -13,7 +13,7 @@ description: |
   See "Core.Program.Execute" to get started.
 
 stability: experimental
-license: BSD3
+license: MIT
 license-file: LICENSE
 author: Andrew Cowie <istathar@gmail.com>
 maintainer: Andrew Cowie <istathar@gmail.com>

--- a/core-program/package.yaml
+++ b/core-program/package.yaml
@@ -1,5 +1,5 @@
 name: core-program
-version: 0.2.7.1
+version: 0.2.8.1
 synopsis: Opinionated Haskell Interoperability
 description: |
   A library to help build command-line programs, both tools and

--- a/core-text/lib/Core/Text/Bytes.hs
+++ b/core-text/lib/Core/Text/Bytes.hs
@@ -25,6 +25,7 @@ bytes.
 -}
 module Core.Text.Bytes (
     Bytes,
+    packBytes,
     Binary (fromBytes, intoBytes),
     hOutput,
     hInput,
@@ -35,12 +36,16 @@ module Core.Text.Bytes (
 
 import qualified Data.ByteString as B (
     ByteString,
+    empty,
     hGetContents,
     hPut,
     pack,
     unpack,
  )
 import qualified Data.ByteString.Builder as B (Builder, byteString, toLazyByteString)
+import qualified Data.ByteString.Char8 as C (
+    pack
+ )
 import qualified Data.ByteString.Lazy as L (ByteString, fromStrict, toStrict)
 import Data.Hashable (Hashable)
 import Data.Word (Word8)
@@ -104,6 +109,19 @@ instance Binary [Word8] where
     intoBytes = StrictBytes . B.pack
 
 {- |
+For the annoyingly common case of needing to take a literal ASCII string in
+your code and use it as a bunch of bytes.
+
+Done via "Data.ByteString.Char8" so all @Char@s will be truncated to 8 bits
+(/i.e./ Latin-1 characters less than 255). You should probably consider this
+to be unsafe. Also note that we deliberately do not have a @[Char]@ instance
+of 'Binary'; if you need to come back to a textual representation use
+'intoRope'.
+-}
+packBytes :: String -> Bytes
+packBytes = StrictBytes . C.pack
+
+{- |
 Output the content of the 'Bytes' to the specified 'Handle'.
 
 @
@@ -143,9 +161,3 @@ hInput :: Handle -> IO Bytes
 hInput handle = do
     contents <- B.hGetContents handle
     return (StrictBytes contents)
-
-{-
-instance Show Bytes where
-    show x = case x of
-        StrictBytes b' ->
--}

--- a/core-text/lib/Core/Text/Bytes.hs
+++ b/core-text/lib/Core/Text/Bytes.hs
@@ -25,6 +25,7 @@ bytes.
 -}
 module Core.Text.Bytes (
     Bytes,
+    emptyBytes,
     packBytes,
     Binary (fromBytes, intoBytes),
     hOutput,
@@ -109,8 +110,14 @@ instance Binary [Word8] where
     intoBytes = StrictBytes . B.pack
 
 {- |
-For the annoyingly common case of needing to take a literal ASCII string in
-your code and use it as a bunch of bytes.
+A zero-length 'Bytes'.
+-}
+emptyBytes :: Bytes
+emptyBytes = StrictBytes B.empty
+
+{- |
+For the annoyingly common case of needing to take an ASCII string literal in
+your code and use it as a bunch of 'Bytes'.
 
 Done via "Data.ByteString.Char8" so all @Char@s will be truncated to 8 bits
 (/i.e./ Latin-1 characters less than 255). You should probably consider this

--- a/core-text/lib/Core/Text/Rope.hs
+++ b/core-text/lib/Core/Text/Rope.hs
@@ -266,7 +266,7 @@ instance Monoid Rope where
     mappend = (<>)
 
 {- |
-An zero-length 'Rope'. You can also use @\"\"@ presuming the
+A zero-length 'Rope'. You can also use @\"\"@ presuming the
 __@OverloadedStrings@__ language extension is turned on in your source file.
 -}
 emptyRope :: Rope

--- a/core-text/package.yaml
+++ b/core-text/package.yaml
@@ -18,7 +18,7 @@ description: |
   on GitHub.
 
 stability: experimental
-license: BSD3
+license: MIT
 license-file: LICENSE
 author: Andrew Cowie <istathar@gmail.com>
 maintainer: Andrew Cowie <istathar@gmail.com>

--- a/core-text/package.yaml
+++ b/core-text/package.yaml
@@ -1,5 +1,5 @@
 name: core-text
-version: 0.3.0.0
+version: 0.3.1.0
 synopsis: A rope type based on a finger tree over UTF-8 fragments
 description: |
   A rope data type for text, built as a finger tree over UTF-8 text

--- a/package.yaml
+++ b/package.yaml
@@ -33,7 +33,7 @@ description: |
   access patterns.
 
 stability: experimental
-license: BSD3
+license: MIT
 license-file: LICENSE
 author: Andrew Cowie <istathar@gmail.com>
 maintainer: Andrew Cowie <istathar@gmail.com>

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-17.12
+resolver: lts-18.0
 packages:
  - ./core-data
  - ./core-text


### PR DESCRIPTION
The ergonomics of creating a Bytes from a string literal in code were getting a bit tedious, so add `packBytes` taking a String.