### PR TITLE
Implement takeRope function

### DIFF
--- a/core-text/lib/Core/Text/Rope.hs
+++ b/core-text/lib/Core/Text/Rope.hs
@@ -356,6 +356,14 @@ splitRope i text@(Rope x) =
             F.OnRight -> (text, Rope F.empty)
             F.Nowhere -> error "Position not found in split. Probable cause: predicate function given not monotonic. This is supposed to be unreachable"
 
+{- |
+Take the first _n_ characters from the beginning of the Rope.
+
+@
+λ> __takeRope 3 \"123456789\"__
+\"123\"
+@
+-}
 takeRope :: Int -> Rope -> Rope
 takeRope i text =
     let (before, _) = splitRope i text

--- a/core-text/lib/Core/Text/Rope.hs
+++ b/core-text/lib/Core/Text/Rope.hs
@@ -79,6 +79,7 @@ module Core.Text.Rope (
     replicateChar,
     widthRope,
     splitRope,
+    takeRope,
     insertRope,
     containsCharacter,
     findIndexRope,
@@ -354,6 +355,11 @@ splitRope i text@(Rope x) =
             F.OnLeft -> (Rope F.empty, text)
             F.OnRight -> (text, Rope F.empty)
             F.Nowhere -> error "Position not found in split. Probable cause: predicate function given not monotonic. This is supposed to be unreachable"
+
+takeRope :: Int -> Rope -> Rope
+takeRope i text =
+    let (before, _) = splitRope i text
+     in before
 
 {- |
 Insert a new piece of text into an existing @Rope@ at the specified offset.

--- a/core-text/package.yaml
+++ b/core-text/package.yaml
@@ -1,5 +1,5 @@
 name: core-text
-version: 0.3.1.0
+version: 0.3.2.0
 synopsis: A rope type based on a finger tree over UTF-8 fragments
 description: |
   A rope data type for text, built as a finger tree over UTF-8 text

--- a/package.yaml
+++ b/package.yaml
@@ -45,7 +45,7 @@ github: aesiniath/unbeliever
 
 dependencies:
  - base >= 4.11 && < 5
- - core-text >= 0.3.0.0
+ - core-text >= 0.3.2.0
  - core-data >= 0.2.1.9
  - core-program >= 0.2.6.0
 

--- a/tests/CheckRopeBehaviour.hs
+++ b/tests/CheckRopeBehaviour.hs
@@ -111,6 +111,16 @@ checkRopeBehaviour = do
             splitRope 23 compound `shouldBe` ("3-ethyl-4-methylhexane", "")
             splitRope (-1) compound `shouldBe` ("", "3-ethyl-4-methylhexane")
 
+        it "takes from beginning" $ do
+            List.take 0 ("123456789" :: String) `shouldBe` ""
+            List.take 3 ("123456789" :: String) `shouldBe` "123"
+            List.take 10 ("123456789" :: String) `shouldBe` "123456789"
+
+            -- expect same behaviour of Rope
+            takeRope 0 ("123456789" :: Rope) `shouldBe` ""
+            takeRope 3 ("123456789" :: Rope) `shouldBe` "123"
+            takeRope 10 ("123456789" :: Rope) `shouldBe` "123456789"
+
         it "does insertion correctly" $ do
             insertRope 3 "two" "onethree" `shouldBe` "onetwothree"
             insertRope 3 "Con" "Def 1" `shouldBe` "DefCon 1"


### PR DESCRIPTION
This would probably admit a more efficient implementation, but for as the **fingertree** documentation points out `take` is just a special case of `search`, which is what powers `splitRope`. So using that lazily should give us about the same thing anyway.