### PR TITLE
Enable use of bracket from Program monad

### DIFF
--- a/core-program/core-program.cabal
+++ b/core-program/core-program.cabal
@@ -3,11 +3,9 @@ cabal-version: 1.12
 -- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
---
--- hash: 7ef8b1887a1354fbfa0d647d220186bf240e0cacd7b36d144b0682efac37a8cd
 
 name:           core-program
-version:        0.2.9.1
+version:        0.2.10.0
 synopsis:       Opinionated Haskell Interoperability
 description:    A library to help build command-line programs, both tools and
                 longer-running daemons.
@@ -27,9 +25,9 @@ maintainer:     Andrew Cowie <istathar@gmail.com>
 copyright:      © 2018-2021 Athae Eredh Siniath and Others
 license:        MIT
 license-file:   LICENSE
+build-type:     Simple
 tested-with:
     GHC == 8.10.6
-build-type:     Simple
 
 source-repository head
   type: git

--- a/core-program/lib/Core/Program/Context.hs
+++ b/core-program/lib/Core/Program/Context.hs
@@ -220,20 +220,9 @@ wrap/export **safe-exceptions**'s variants of the functions.
 instance MonadThrow (Program τ) where
     throwM = liftIO . Safe.throw
 
-unHandler :: (ε -> Program τ α) -> (ε -> ReaderT (Context τ) IO α)
-unHandler = fmap unProgram
+deriving instance MonadCatch (Program τ)
 
-instance MonadCatch (Program τ) where
-    catch :: Exception ε => (Program τ) α -> (ε -> (Program τ) α) -> (Program τ) α
-    catch program handler =
-        let r = unProgram program
-            h = unHandler handler
-         in do
-                context <- ask
-                liftIO $ do
-                    Safe.catch
-                        (runReaderT r context)
-                        (\e -> runReaderT (h e) context)
+deriving instance MonadMask (Program t)
 
 {- |
 Initialize the programs's execution context. This takes care of various

--- a/core-program/lib/Core/Program/Context.hs
+++ b/core-program/lib/Core/Program/Context.hs
@@ -27,8 +27,8 @@ module Core.Program.Context (
 import Chrono.TimeStamp (TimeStamp, getCurrentTimeNanoseconds)
 import Control.Concurrent.MVar (MVar, newEmptyMVar, newMVar, readMVar)
 import Control.Concurrent.STM.TQueue (TQueue, newTQueueIO)
-import qualified Control.Exception.Safe as Safe (catch, throw)
-import Control.Monad.Catch (MonadCatch (catch), MonadThrow (throwM))
+import qualified Control.Exception.Safe as Safe (throw)
+import Control.Monad.Catch (MonadCatch, MonadMask, MonadThrow (throwM))
 import Control.Monad.Reader.Class (MonadReader (..))
 import Control.Monad.Trans.Reader (ReaderT (..))
 import Core.Data.Structures

--- a/core-program/package.yaml
+++ b/core-program/package.yaml
@@ -1,5 +1,5 @@
 name: core-program
-version: 0.2.9.1
+version: 0.2.10.0
 synopsis: Opinionated Haskell Interoperability
 description: |
   A library to help build command-line programs, both tools and


### PR DESCRIPTION
Derive a MonadMask instance so that `bracket` can be used when working in the Program monad. It also turns out we can derive MonadCatch (that powers `catch`) rather than the hand written instance we had preivously.