### PR TITLE
Fix exception handling

### DIFF
--- a/core-program/core-program.cabal
+++ b/core-program/core-program.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           core-program
-version:        0.2.10.0
+version:        0.2.10.5
 synopsis:       Opinionated Haskell Interoperability
 description:    A library to help build command-line programs, both tools and
                 longer-running daemons.

--- a/core-program/package.yaml
+++ b/core-program/package.yaml
@@ -1,5 +1,5 @@
 name: core-program
-version: 0.2.10.0
+version: 0.2.10.5
 synopsis: Opinionated Haskell Interoperability
 description: |
   A library to help build command-line programs, both tools and

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-18.6
+resolver: lts-18.12
 packages:
  - ./core-data
  - ./core-text


### PR DESCRIPTION
The exception handling logic was severly lacking, and had what appear too be if not race conditions then severe inconsistencies. Resolve by not using catches _inside_ `async`, but instead letting **async** do it's own thing with exceptions (which it needs to do with AsyncCancelled for managing threads); notably, refactor to use `race` instead.

Simplify `executionAction` by removing it and calling `subProgram` directly inline.

