### PR TITLE
Rename event action to info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .stack-work/
+stack.yaml.lock
 /tags
 /.vscode
 

--- a/core-program/core-program.cabal
+++ b/core-program/core-program.cabal
@@ -58,7 +58,7 @@ library
     , bytestring
     , chronologique
     , core-data >=0.2.1.9
-    , core-text >=0.3.0
+    , core-text >=0.3.3.0
     , directory
     , exceptions
     , filepath

--- a/core-program/core-program.cabal
+++ b/core-program/core-program.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           core-program
-version:        0.2.11.0
+version:        0.2.12.0
 synopsis:       Opinionated Haskell Interoperability
 description:    A library to help build command-line programs, both tools and
                 longer-running daemons.
@@ -27,7 +27,7 @@ license:        MIT
 license-file:   LICENSE
 build-type:     Simple
 tested-with:
-    GHC == 8.10.6
+    GHC == 8.10.7
 
 source-repository head
   type: git

--- a/core-program/lib/Core/Program/Arguments.hs
+++ b/core-program/lib/Core/Program/Arguments.hs
@@ -129,6 +129,8 @@ data Config
 A completely empty configuration, without the default debugging and logging
 options. Your program won't process any command-line options or arguments,
 which would be weird in most cases. Prefer 'simple'.
+
+@since 0.2.9
 -}
 blankConfig :: Config
 blankConfig = Blank
@@ -197,6 +199,8 @@ Required arguments:
 
 For information on how to use the multi-line string literals shown here,
 see 'quote' in "Core.Text.Utilities".
+
+@since 0.2.9
 -}
 simpleConfig :: [Options] -> Config
 simpleConfig options = Simple (options ++ baselineOptions)
@@ -285,6 +289,8 @@ The resultant program could be invoked as in these examples:
 
 For information on how to use the multi-line string literals shown here,
 see 'quote' in "Core.Text.Utilities".
+
+@since 0.2.9
 -}
 complexConfig :: [Commands] -> Config
 complexConfig commands = Complex (commands ++ [Global baselineOptions])

--- a/core-program/lib/Core/Program/Execute.hs
+++ b/core-program/lib/Core/Program/Execute.hs
@@ -161,7 +161,7 @@ escapeHandlers context =
          in do
                 subProgram context $ do
                     setVerbosityLevel Debug
-                    event text
+                    info text
                 pure (ExitFailure 127)
 
 --
@@ -208,7 +208,7 @@ trap_ action =
         ( \(e :: SomeException) ->
             let text = intoRope (displayException e)
              in do
-                    event "Trapped uncaught exception"
+                    info "Trapped uncaught exception"
                     debug "e" text
         )
 

--- a/core-program/lib/Core/Program/Logging.hs
+++ b/core-program/lib/Core/Program/Logging.hs
@@ -275,6 +275,8 @@ nanosecond precision, but you don't need that kind of resolution in in
 ordinary debugging).
 
 Messages sent to syslog will be logged at @Info@ level severity.
+
+@since 0.2.12
 -}
 info :: Rope -> Program τ ()
 info text = do

--- a/core-program/package.yaml
+++ b/core-program/package.yaml
@@ -35,7 +35,7 @@ dependencies:
 library:
   dependencies:
    - async
-   - core-text >= 0.3.0
+   - core-text >= 0.3.3.0
    - core-data >= 0.2.1.9
    - chronologique
    - directory

--- a/core-program/package.yaml
+++ b/core-program/package.yaml
@@ -1,5 +1,5 @@
 name: core-program
-version: 0.2.11.0
+version: 0.2.12.0
 synopsis: Opinionated Haskell Interoperability
 description: |
   A library to help build command-line programs, both tools and
@@ -18,7 +18,7 @@ license-file: LICENSE
 author: Andrew Cowie <istathar@gmail.com>
 maintainer: Andrew Cowie <istathar@gmail.com>
 copyright: © 2018-2021 Athae Eredh Siniath and Others
-tested-with: GHC == 8.10.6
+tested-with: GHC == 8.10.7
 category: System
 ghc-options: -Wall -Wwarn -fwarn-tabs
 github: aesiniath/unbeliever

--- a/core-telemetry/core-telemetry.cabal
+++ b/core-telemetry/core-telemetry.cabal
@@ -1,0 +1,55 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.34.4.
+--
+-- see: https://github.com/sol/hpack
+
+name:           core-telemetry
+version:        0.1.0.0
+synopsis:       Advanced telemetry
+description:    This is part of a library to help build command-line programs, both tools and
+                longer-running daemons.
+                .
+                This package in particular adds helpers for sending telemetry objects
+                to a logging service.
+                .
+                See "Core.Program.Telemetry" to get started.
+category:       System
+stability:      experimental
+homepage:       https://github.com/aesiniath/unbeliever#readme
+bug-reports:    https://github.com/aesiniath/unbeliever/issues
+author:         Andrew Cowie <istathar@gmail.com>
+maintainer:     Andrew Cowie <istathar@gmail.com>
+copyright:      © 2021 Athae Eredh Siniath and Others
+license:        MIT
+license-file:   LICENSE
+build-type:     Simple
+tested-with:
+    GHC == 8.10.5
+
+source-repository head
+  type: git
+  location: https://github.com/aesiniath/unbeliever
+
+library
+  exposed-modules:
+      Core.Program.Telemetry
+  hs-source-dirs:
+      lib
+  ghc-options: -Wall -Wwarn -fwarn-tabs
+  build-depends:
+      async
+    , base >=4.11 && <5
+    , bytestring
+    , chronologique
+    , core-data
+    , core-program
+    , core-text >=0.3.2
+    , exceptions
+    , mtl
+    , safe-exceptions
+    , scientific
+    , stm
+    , template-haskell >=2.14 && <3
+    , text
+  default-language: Haskell2010

--- a/core-text/core-text.cabal
+++ b/core-text/core-text.cabal
@@ -4,10 +4,10 @@ cabal-version: 1.18
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: d719fa79fab6ad850ba4da43e6ed770fea1f87608ac3e2b7013ead11677acc55
+-- hash: 1170f4aae9d7c4827c667036d000df599dbeda1372c18e6fb0447b91caa36837
 
 name:           core-text
-version:        0.3.2.1
+version:        0.3.3.0
 synopsis:       A rope type based on a finger tree over UTF-8 fragments
 description:    A rope data type for text, built as a finger tree over UTF-8 text
                 fragments. The package also includes utiltiy functions for breaking and
@@ -46,11 +46,11 @@ library
   exposed-modules:
       Core.Text
       Core.Text.Bytes
+      Core.Text.Colour
       Core.Text.Rope
       Core.Text.Utilities
   other-modules:
       Core.Text.Breaking
-      Core.Text.Colour
       Core.Text.Parsing
   hs-source-dirs:
       lib

--- a/core-text/core-text.cabal
+++ b/core-text/core-text.cabal
@@ -4,10 +4,10 @@ cabal-version: 1.18
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 5360f5729fffd35e21f13c06edbd41bdc1ffc7334f3f456b64bb16738bcc742d
+-- hash: d719fa79fab6ad850ba4da43e6ed770fea1f87608ac3e2b7013ead11677acc55
 
 name:           core-text
-version:        0.3.2.0
+version:        0.3.2.1
 synopsis:       A rope type based on a finger tree over UTF-8 fragments
 description:    A rope data type for text, built as a finger tree over UTF-8 text
                 fragments. The package also includes utiltiy functions for breaking and
@@ -33,7 +33,7 @@ copyright:      © 2018-2021 Athae Eredh Siniath and Others
 license:        MIT
 license-file:   LICENSE
 tested-with:
-    GHC == 8.10.6
+    GHC == 8.10.7
 build-type:     Simple
 extra-doc-files:
     AnsiColours.png
@@ -50,6 +50,7 @@ library
       Core.Text.Utilities
   other-modules:
       Core.Text.Breaking
+      Core.Text.Colour
       Core.Text.Parsing
   hs-source-dirs:
       lib

--- a/core-text/lib/Core/Text.hs
+++ b/core-text/lib/Core/Text.hs
@@ -25,10 +25,12 @@ module Core.Text
 
     -- |
     -- Useful functions for common use cases.
+    module Core.Text.Colour,
     module Core.Text.Utilities,
   )
 where
 
 import Core.Text.Bytes
+import Core.Text.Colour
 import Core.Text.Rope
 import Core.Text.Utilities

--- a/core-text/lib/Core/Text/Colour.hs
+++ b/core-text/lib/Core/Text/Colour.hs
@@ -1,0 +1,202 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_HADDOCK not-home #-}
+
+module Core.Text.Colour (
+    AnsiColour (..),
+    intoEscapes,
+    bold,
+    dullRed,
+    brightRed,
+    pureRed,
+    dullGreen,
+    brightGreen,
+    pureGreen,
+    dullBlue,
+    brightBlue,
+    pureBlue,
+    dullCyan,
+    brightCyan,
+    pureCyan,
+    dullMagenta,
+    brightMagenta,
+    pureMagenta,
+    dullYellow,
+    brightYellow,
+    pureYellow,
+    pureBlack,
+    dullGrey,
+    brightGrey,
+    pureGrey,
+    pureWhite,
+    dullWhite,
+    brightWhite,
+    resetColour,
+) where
+
+import Core.Text.Rope
+import Data.Colour.SRGB (sRGB, sRGB24read)
+import System.Console.ANSI.Codes (setSGRCode)
+import System.Console.ANSI.Types (ConsoleIntensity (..), ConsoleLayer (..), SGR (..))
+
+{- |
+An accumulation of ANSI escape codes used to add colour when pretty printing
+to console.
+-}
+newtype AnsiColour = Escapes [SGR]
+
+intoEscapes :: AnsiColour -> Rope
+intoEscapes (Escapes codes) = intoRope (setSGRCode codes)
+
+-- | Medium \"Scarlet Red\" (@#cc0000@ from the Tango color palette).
+dullRed :: AnsiColour
+dullRed =
+    Escapes [SetRGBColor Foreground (sRGB24read "#CC0000")]
+
+-- | Highlighted \"Scarlet Red\" (@#ef2929@ from the Tango color palette).
+brightRed :: AnsiColour
+brightRed =
+    Escapes [SetRGBColor Foreground (sRGB24read "#EF2929")]
+
+-- | Pure \"Red\" (full RGB red channel only).
+pureRed :: AnsiColour
+pureRed =
+    Escapes [SetRGBColor Foreground (sRGB 1 0 0)]
+
+-- | Shadowed \"Chameleon\" (@#4e9a06@ from the Tango color palette).
+dullGreen :: AnsiColour
+dullGreen =
+    Escapes [SetRGBColor Foreground (sRGB24read "#4E9A06")]
+
+-- | Highlighted \"Chameleon\" (@#8ae234@ from the Tango color palette).
+brightGreen :: AnsiColour
+brightGreen =
+    Escapes [SetRGBColor Foreground (sRGB24read "#8AE234")]
+
+-- | Pure \"Green\" (full RGB green channel only).
+pureGreen :: AnsiColour
+pureGreen =
+    Escapes [SetRGBColor Foreground (sRGB 0 1 0)]
+
+-- | Medium \"Sky Blue\" (@#3465a4@ from the Tango color palette).
+dullBlue :: AnsiColour
+dullBlue =
+    Escapes [SetRGBColor Foreground (sRGB24read "#3465A4")]
+
+-- | Highlighted \"Sky Blue\" (@#729fcf@ from the Tango color palette).
+brightBlue :: AnsiColour
+brightBlue =
+    Escapes [SetRGBColor Foreground (sRGB24read "#729FCF")]
+
+-- | Pure \"Blue\" (full RGB blue channel only).
+pureBlue :: AnsiColour
+pureBlue =
+    Escapes [SetRGBColor Foreground (sRGB 0 0 1)]
+
+-- | Dull \"Cyan\" (from the __gnome-terminal__ console theme).
+dullCyan :: AnsiColour
+dullCyan =
+    Escapes [SetRGBColor Foreground (sRGB24read "#06989A")]
+
+-- | Bright \"Cyan\" (from the __gnome-terminal__ console theme).
+brightCyan :: AnsiColour
+brightCyan =
+    Escapes [SetRGBColor Foreground (sRGB24read "#34E2E2")]
+
+-- | Pure \"Cyan\" (full RGB blue + green channels).
+pureCyan :: AnsiColour
+pureCyan =
+    Escapes [SetRGBColor Foreground (sRGB 0 1 1)]
+
+-- | Medium \"Plum\" (@#75507b@ from the Tango color palette).
+dullMagenta :: AnsiColour
+dullMagenta =
+    Escapes [SetRGBColor Foreground (sRGB24read "#75507B")]
+
+-- | Highlighted \"Plum\" (@#ad7fa8@ from the Tango color palette).
+brightMagenta :: AnsiColour
+brightMagenta =
+    Escapes [SetRGBColor Foreground (sRGB24read "#AD7FA8")]
+
+-- | Pure \"Magenta\" (full RGB red + blue channels).
+pureMagenta :: AnsiColour
+pureMagenta =
+    Escapes [SetRGBColor Foreground (sRGB 1 0 1)]
+
+-- | Shadowed \"Butter\" (@#c4a000@ from the Tango color palette).
+dullYellow :: AnsiColour
+dullYellow =
+    Escapes [SetRGBColor Foreground (sRGB24read "#C4A000")]
+
+-- | Highlighted \"Butter\" (@#fce94f@ from the Tango color palette).
+brightYellow :: AnsiColour
+brightYellow =
+    Escapes [SetRGBColor Foreground (sRGB24read "#FCE94F")]
+
+-- | Pure \"Yellow\" (full RGB red + green channels).
+pureYellow :: AnsiColour
+pureYellow =
+    Escapes [SetRGBColor Foreground (sRGB 1 1 0)]
+
+-- | Pure \"Black\" (zero in all RGB channels).
+pureBlack :: AnsiColour
+pureBlack =
+    Escapes [SetRGBColor Foreground (sRGB 0 0 0)]
+
+-- | Shadowed \"Deep Aluminium\" (@#2e3436@ from the Tango color palette).
+dullGrey :: AnsiColour
+dullGrey =
+    Escapes [SetRGBColor Foreground (sRGB24read "#2E3436")]
+
+-- | Medium \"Dark Aluminium\" (from the Tango color palette).
+brightGrey :: AnsiColour
+brightGrey =
+    Escapes [SetRGBColor Foreground (sRGB24read "#555753")]
+
+-- | Pure \"Grey\" (set at @#999999@, being just over half in all RGB channels).
+pureGrey :: AnsiColour
+pureGrey =
+    Escapes [SetRGBColor Foreground (sRGB24read "#999999")]
+
+-- | Pure \"White\" (fully on in all RGB channels).
+pureWhite :: AnsiColour
+pureWhite =
+    Escapes [SetRGBColor Foreground (sRGB 1 1 1)]
+
+-- | Medium \"Light Aluminium\" (@#d3d7cf@ from the Tango color palette).
+dullWhite :: AnsiColour
+dullWhite =
+    Escapes [SetRGBColor Foreground (sRGB24read "#D3D7CF")]
+
+-- | Highlighted \"Light Aluminium\" (@#eeeeec@ from the Tango color palette).
+brightWhite :: AnsiColour
+brightWhite =
+    Escapes [SetRGBColor Foreground (sRGB24read "#EEEEEC")]
+
+{- |
+Given an 'AnsiColour', lift it to bold intensity.
+
+Note that many console fonts do /not/ have a bold face variant, and terminal
+emulators that "support bold" do so by doubling the thickness of the lines in
+the glyphs. This may or may not be desirable from a readibility standpoint but
+really there's only so much you can do to keep users who make poor font
+choices from making poor font choices.
+-}
+bold :: AnsiColour -> AnsiColour
+bold (Escapes list) =
+    Escapes (SetConsoleIntensity BoldIntensity : list)
+
+instance Semigroup AnsiColour where
+    (<>) (Escapes list1) (Escapes list2) = Escapes (list1 <> list2)
+
+instance Monoid AnsiColour where
+    mempty = Escapes []
+
+{- |
+This is not a colour, obviously, but it represents reseting to the default
+terminal foreground colour, whatever the user has that set to.
+-}
+resetColour :: AnsiColour
+resetColour =
+    Escapes [Reset]

--- a/core-text/lib/Core/Text/Colour.hs
+++ b/core-text/lib/Core/Text/Colour.hs
@@ -10,7 +10,7 @@ Support for colour in the terminal.
 module Core.Text.Colour (
     AnsiColour,
     intoEscapes,
-    bold,
+    boldColour,
     dullRed,
     brightRed,
     pureRed,
@@ -191,8 +191,8 @@ the glyphs. This may or may not be desirable from a readibility standpoint but
 really there's only so much you can do to keep users who make poor font
 choices from making poor font choices.
 -}
-bold :: AnsiColour -> AnsiColour
-bold (Escapes list) =
+boldColour :: AnsiColour -> AnsiColour
+boldColour (Escapes list) =
     Escapes (SetConsoleIntensity BoldIntensity : list)
 
 instance Semigroup AnsiColour where

--- a/core-text/lib/Core/Text/Colour.hs
+++ b/core-text/lib/Core/Text/Colour.hs
@@ -1,10 +1,14 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# OPTIONS_HADDOCK not-home #-}
 
+{- |
+Support for colour in the terminal.
+
+![ANSI colours](AnsiColours.png)
+-}
 module Core.Text.Colour (
-    AnsiColour (..),
+    AnsiColour,
     intoEscapes,
     bold,
     dullRed,
@@ -46,6 +50,10 @@ to console.
 -}
 newtype AnsiColour = Escapes [SGR]
 
+{-|
+Convert an AnsiColour into the ANSI escape sequences which will make that
+colour appear in the user's terminal.
+-}
 intoEscapes :: AnsiColour -> Rope
 intoEscapes (Escapes codes) = intoRope (setSGRCode codes)
 

--- a/core-text/lib/Core/Text/Utilities.hs
+++ b/core-text/lib/Core/Text/Utilities.hs
@@ -6,7 +6,7 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
-{-# OPTIONS_HADDOCK prune #-}
+{-# OPTIONS_HADDOCK prune, not-home #-}
 
 {- |
 Useful tools for working with 'Rope's. Support for pretty printing, multi-line
@@ -15,35 +15,8 @@ strings, and...
 module Core.Text.Utilities (
     -- * Pretty printing
     Render (..),
-    AnsiColour,
-    bold,
     render,
     renderNoAnsi,
-    dullRed,
-    brightRed,
-    pureRed,
-    dullGreen,
-    brightGreen,
-    pureGreen,
-    dullBlue,
-    brightBlue,
-    pureBlue,
-    dullCyan,
-    brightCyan,
-    pureCyan,
-    dullMagenta,
-    brightMagenta,
-    pureMagenta,
-    dullYellow,
-    brightYellow,
-    pureYellow,
-    pureBlack,
-    dullGrey,
-    brightGrey,
-    pureGrey,
-    pureWhite,
-    dullWhite,
-    brightWhite,
 
     -- * Helpers
     indefinite,
@@ -63,14 +36,19 @@ module Core.Text.Utilities (
     intoPieces,
     intoChunks,
     byteChunk,
+
+    -- * Deprecated
     intoDocA,
+    module Core.Text.Colour,
+    bold,
+    -- | AnsiColour and colour constants moved to this module.
 ) where
 
 import Core.Text.Breaking
 import Core.Text.Bytes
+import Core.Text.Colour
 import Core.Text.Parsing
 import Core.Text.Rope
-import Core.Text.Colour
 import Data.Bits (Bits (..))
 import qualified Data.ByteString as B (ByteString, length, splitAt, unpack)
 import Data.Char (intToDigit)
@@ -131,6 +109,10 @@ class Render α where
 intoDocA :: α -> Doc (Token α)
 intoDocA = error "Nothing should be invoking this method directly."
 {-# DEPRECATED intoDocA "method'intoDocA' has been renamed 'highlight'; implement that instead." #-}
+
+bold :: AnsiColour -> AnsiColour
+bold = boldColour
+{-# DEPRECATED bold "Import Core.Text.Colour and use 'boldColour' instead" #-}
 
 instance Render Rope where
     type Token Rope = ()

--- a/core-text/lib/Core/Text/Utilities.hs
+++ b/core-text/lib/Core/Text/Utilities.hs
@@ -11,8 +11,6 @@
 {- |
 Useful tools for working with 'Rope's. Support for pretty printing, multi-line
 strings, and...
-
-![ANSI colours](AnsiColours.png)
 -}
 module Core.Text.Utilities (
     -- * Pretty printing

--- a/core-text/lib/Core/Text/Utilities.hs
+++ b/core-text/lib/Core/Text/Utilities.hs
@@ -72,10 +72,10 @@ import Core.Text.Breaking
 import Core.Text.Bytes
 import Core.Text.Parsing
 import Core.Text.Rope
+import Core.Text.Colour
 import Data.Bits (Bits (..))
 import qualified Data.ByteString as B (ByteString, length, splitAt, unpack)
 import Data.Char (intToDigit)
-import Data.Colour.SRGB (sRGB, sRGB24read)
 import qualified Data.FingerTree as F (ViewL (..), viewl, (<|))
 import qualified Data.List as List (dropWhileEnd, foldl', splitAt)
 import qualified Data.Text as T
@@ -108,17 +108,6 @@ import qualified Data.Text.Short as S (
 import Data.Word (Word8)
 import Language.Haskell.TH (litE, stringL)
 import Language.Haskell.TH.Quote (QuasiQuoter (QuasiQuoter))
-import System.Console.ANSI.Codes (setSGRCode)
-import System.Console.ANSI.Types (ConsoleIntensity (..), ConsoleLayer (..), SGR (..))
-
-{- |
-An accumulation of ANSI escape codes used to add colour when pretty printing
-to console.
--}
-newtype AnsiColour = Escapes [SGR]
-
--- change AnsiStyle to a custom token type, perhaps Ansi, which
--- has the escape codes already converted to Rope.
 
 {- |
 Types which can be rendered "prettily", that is, formatted by a pretty printer
@@ -144,150 +133,6 @@ class Render α where
 intoDocA :: α -> Doc (Token α)
 intoDocA = error "Nothing should be invoking this method directly."
 {-# DEPRECATED intoDocA "method'intoDocA' has been renamed 'highlight'; implement that instead." #-}
-
--- | Medium \"Scarlet Red\" (@#cc0000@ from the Tango color palette).
-dullRed :: AnsiColour
-dullRed =
-    Escapes [SetRGBColor Foreground (sRGB24read "#CC0000")]
-
--- | Highlighted \"Scarlet Red\" (@#ef2929@ from the Tango color palette).
-brightRed :: AnsiColour
-brightRed =
-    Escapes [SetRGBColor Foreground (sRGB24read "#EF2929")]
-
--- | Pure \"Red\" (full RGB red channel only).
-pureRed :: AnsiColour
-pureRed =
-    Escapes [SetRGBColor Foreground (sRGB 1 0 0)]
-
--- | Shadowed \"Chameleon\" (@#4e9a06@ from the Tango color palette).
-dullGreen :: AnsiColour
-dullGreen =
-    Escapes [SetRGBColor Foreground (sRGB24read "#4E9A06")]
-
--- | Highlighted \"Chameleon\" (@#8ae234@ from the Tango color palette).
-brightGreen :: AnsiColour
-brightGreen =
-    Escapes [SetRGBColor Foreground (sRGB24read "#8AE234")]
-
--- | Pure \"Green\" (full RGB green channel only).
-pureGreen :: AnsiColour
-pureGreen =
-    Escapes [SetRGBColor Foreground (sRGB 0 1 0)]
-
--- | Medium \"Sky Blue\" (@#3465a4@ from the Tango color palette).
-dullBlue :: AnsiColour
-dullBlue =
-    Escapes [SetRGBColor Foreground (sRGB24read "#3465A4")]
-
--- | Highlighted \"Sky Blue\" (@#729fcf@ from the Tango color palette).
-brightBlue :: AnsiColour
-brightBlue =
-    Escapes [SetRGBColor Foreground (sRGB24read "#729FCF")]
-
--- | Pure \"Blue\" (full RGB blue channel only).
-pureBlue :: AnsiColour
-pureBlue =
-    Escapes [SetRGBColor Foreground (sRGB 0 0 1)]
-
--- | Dull \"Cyan\" (from the __gnome-terminal__ console theme).
-dullCyan :: AnsiColour
-dullCyan =
-    Escapes [SetRGBColor Foreground (sRGB24read "#06989A")]
-
--- | Bright \"Cyan\" (from the __gnome-terminal__ console theme).
-brightCyan :: AnsiColour
-brightCyan =
-    Escapes [SetRGBColor Foreground (sRGB24read "#34E2E2")]
-
--- | Pure \"Cyan\" (full RGB blue + green channels).
-pureCyan :: AnsiColour
-pureCyan =
-    Escapes [SetRGBColor Foreground (sRGB 0 1 1)]
-
--- | Medium \"Plum\" (@#75507b@ from the Tango color palette).
-dullMagenta :: AnsiColour
-dullMagenta =
-    Escapes [SetRGBColor Foreground (sRGB24read "#75507B")]
-
--- | Highlighted \"Plum\" (@#ad7fa8@ from the Tango color palette).
-brightMagenta :: AnsiColour
-brightMagenta =
-    Escapes [SetRGBColor Foreground (sRGB24read "#AD7FA8")]
-
--- | Pure \"Magenta\" (full RGB red + blue channels).
-pureMagenta :: AnsiColour
-pureMagenta =
-    Escapes [SetRGBColor Foreground (sRGB 1 0 1)]
-
--- | Shadowed \"Butter\" (@#c4a000@ from the Tango color palette).
-dullYellow :: AnsiColour
-dullYellow =
-    Escapes [SetRGBColor Foreground (sRGB24read "#C4A000")]
-
--- | Highlighted \"Butter\" (@#fce94f@ from the Tango color palette).
-brightYellow :: AnsiColour
-brightYellow =
-    Escapes [SetRGBColor Foreground (sRGB24read "#FCE94F")]
-
--- | Pure \"Yellow\" (full RGB red + green channels).
-pureYellow :: AnsiColour
-pureYellow =
-    Escapes [SetRGBColor Foreground (sRGB 1 1 0)]
-
--- | Pure \"Black\" (zero in all RGB channels).
-pureBlack :: AnsiColour
-pureBlack =
-    Escapes [SetRGBColor Foreground (sRGB 0 0 0)]
-
--- | Shadowed \"Deep Aluminium\" (@#2e3436@ from the Tango color palette).
-dullGrey :: AnsiColour
-dullGrey =
-    Escapes [SetRGBColor Foreground (sRGB24read "#2E3436")]
-
--- | Medium \"Dark Aluminium\" (from the Tango color palette).
-brightGrey :: AnsiColour
-brightGrey =
-    Escapes [SetRGBColor Foreground (sRGB24read "#555753")]
-
--- | Pure \"Grey\" (set at @#999999@, being just over half in all RGB channels).
-pureGrey :: AnsiColour
-pureGrey =
-    Escapes [SetRGBColor Foreground (sRGB24read "#999999")]
-
--- | Pure \"White\" (fully on in all RGB channels).
-pureWhite :: AnsiColour
-pureWhite =
-    Escapes [SetRGBColor Foreground (sRGB 1 1 1)]
-
--- | Medium \"Light Aluminium\" (@#d3d7cf@ from the Tango color palette).
-dullWhite :: AnsiColour
-dullWhite =
-    Escapes [SetRGBColor Foreground (sRGB24read "#D3D7CF")]
-
--- | Highlighted \"Light Aluminium\" (@#eeeeec@ from the Tango color palette).
-brightWhite :: AnsiColour
-brightWhite =
-    Escapes [SetRGBColor Foreground (sRGB24read "#EEEEEC")]
-
-{- |
-Given an 'AnsiColour', lift it to bold intensity.
-
-Note that many console fonts do /not/ have a bold face variant, and terminal
-emulators that "support bold" do so by doubling the thickness of the lines in
-the glyphs. This may or may not be desirable from a readibility standpoint but
-really there's only so much you can do to keep users who make poor font
-choices from making poor font choices.
--}
-bold :: AnsiColour -> AnsiColour
-bold (Escapes list) =
-    Escapes (SetConsoleIntensity BoldIntensity : list)
-
-instance Semigroup AnsiColour where
-    (<>) (Escapes list1) (Escapes list2) = Escapes (list1 <> list2)
-
-instance Monoid AnsiColour where
-    mempty = Escapes []
 
 instance Render Rope where
     type Token Rope = ()
@@ -427,10 +272,10 @@ render columns (thing :: α) =
                     (a : _) -> convert a <> go as' xs
 
     convert :: AnsiColour -> Rope
-    convert (Escapes codes) = intoRope (setSGRCode codes)
+    convert = intoEscapes
 
     reset :: Rope
-    reset = intoRope (setSGRCode [Reset])
+    reset = intoEscapes resetColour
 
 {- |
 Having gone to all the trouble to colourize your rendered types... sometimes

--- a/core-text/package.yaml
+++ b/core-text/package.yaml
@@ -1,5 +1,5 @@
 name: core-text
-version: 0.3.2.1
+version: 0.3.3.0
 synopsis: A rope type based on a finger tree over UTF-8 fragments
 description: |
   A rope data type for text, built as a finger tree over UTF-8 text
@@ -46,11 +46,11 @@ library:
   exposed-modules:
    - Core.Text
    - Core.Text.Bytes
+   - Core.Text.Colour
    - Core.Text.Rope
    - Core.Text.Utilities
   other-modules:
    - Core.Text.Breaking
-   - Core.Text.Colour
    - Core.Text.Parsing
 
 extra-doc-files:

--- a/core-text/package.yaml
+++ b/core-text/package.yaml
@@ -1,5 +1,5 @@
 name: core-text
-version: 0.3.2.0
+version: 0.3.2.1
 synopsis: A rope type based on a finger tree over UTF-8 fragments
 description: |
   A rope data type for text, built as a finger tree over UTF-8 text
@@ -23,7 +23,7 @@ license-file: LICENSE
 author: Andrew Cowie <istathar@gmail.com>
 maintainer: Andrew Cowie <istathar@gmail.com>
 copyright: © 2018-2021 Athae Eredh Siniath and Others
-tested-with: GHC == 8.10.6
+tested-with: GHC == 8.10.7
 category: System
 ghc-options: -Wall -Wwarn -fwarn-tabs
 github: aesiniath/unbeliever
@@ -50,6 +50,7 @@ library:
    - Core.Text.Utilities
   other-modules:
    - Core.Text.Breaking
+   - Core.Text.Colour
    - Core.Text.Parsing
 
 extra-doc-files:


### PR DESCRIPTION
"events" turn out to be the vocabulary in observability systems like Honeycomb (and to a lesser extent OpenTelemetry) whereas calling `event` was about these are local log messages. So {shrug} go with the terminology that's been around for years, and change to `info`.