### PR TITLE
Add warning- and critical-level informational message actions

### DIFF
--- a/core-program/lib/Core/Program/Context.hs
+++ b/core-program/lib/Core/Program/Context.hs
@@ -15,7 +15,6 @@ module Core.Program.Context (
     None (..),
     isNone,
     configure,
-    Message (..),
     Verbosity (..),
     Program (..),
     unProgram,
@@ -79,7 +78,7 @@ data Context τ = Context
     , terminalWidthFrom :: Int
     , verbosityLevelFrom :: MVar Verbosity
     , outputChannelFrom :: TQueue Rope
-    , loggerChannelFrom :: TQueue Message
+    , loggerChannelFrom :: TQueue () -- FIXME
     , applicationDataFrom :: MVar τ
     }
 
@@ -120,8 +119,6 @@ data None = None
 
 isNone :: None -> Bool
 isNone _ = True
-
-data Message = Message TimeStamp Verbosity Rope (Maybe Rope)
 
 {- |
 The verbosity level of the logging subsystem. You can override the level

--- a/core-program/lib/Core/Program/Context.hs
+++ b/core-program/lib/Core/Program/Context.hs
@@ -121,12 +121,18 @@ isNone :: None -> Bool
 isNone _ = True
 
 {- |
-The verbosity level of the logging subsystem. You can override the level
-specified on the command-line using 'Core.Program.Execute.setVerbosityLevel'
-from within the 'Program' monad.
+The verbosity level of the output logging subsystem. You can override the
+level specified on the command-line by calling
+'Core.Program.Execute.setVerbosityLevel' from within the 'Program' monad.
 -}
-data Verbosity = Output | Event | Debug
+data Verbosity
+    = Output
+    | Event
+    | Verbose  -- ^ @since 0.2.12
+    | Debug
     deriving (Show)
+
+{-# DEPRECATED Event "Use Verbose instead" #-}
 
 {- |
 The type of a top-level program.

--- a/core-program/lib/Core/Program/Execute.hs
+++ b/core-program/lib/Core/Program/Execute.hs
@@ -151,7 +151,8 @@ import Prelude hiding (log)
 --
 escapeHandlers :: Context c -> [Handler IO ExitCode]
 escapeHandlers context =
-    [ Handler (\(ExceptionInLinkedThread _ e) -> bail e)
+    [ Handler (\(code :: ExitCode) -> pure code)
+    , Handler (\(ExceptionInLinkedThread _ e) -> bail e)
     , Handler (\(e :: SomeException) -> bail e)
     ]
   where

--- a/core-program/lib/Core/Program/Execute.hs
+++ b/core-program/lib/Core/Program/Execute.hs
@@ -162,7 +162,7 @@ escapeHandlers context =
          in do
                 subProgram context $ do
                     setVerbosityLevel Debug
-                    info text
+                    critical text
                 pure (ExitFailure 127)
 
 --
@@ -317,7 +317,7 @@ processStandardOutput out =
         )
         (collapseHandler "output processing collapsed")
 
-processDebugMessages :: TQueue Message -> IO ()
+processDebugMessages :: TQueue () -> IO ()
 processDebugMessages log =
     Safe.catch
         ( do

--- a/core-program/lib/Core/Program/Execute.hs
+++ b/core-program/lib/Core/Program/Execute.hs
@@ -209,7 +209,7 @@ trap_ action =
         ( \(e :: SomeException) ->
             let text = intoRope (displayException e)
              in do
-                    info "Trapped uncaught exception"
+                    warn "Trapped uncaught exception"
                     debug "e" text
         )
 

--- a/core-program/lib/Core/Program/Logging.hs
+++ b/core-program/lib/Core/Program/Logging.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -Wno-deprecations #-}
 {-# OPTIONS_HADDOCK prune #-}
 
 {- |
@@ -334,12 +335,14 @@ isEvent :: Verbosity -> Bool
 isEvent level = case level of
     Output -> False
     Event -> True
+    Verbose -> True
     Debug -> True
 
 isDebug :: Verbosity -> Bool
 isDebug level = case level of
     Output -> False
     Event -> False
+    Verbose -> False
     Debug -> True
 
 {- |

--- a/core-program/lib/Core/Program/Signal.hs
+++ b/core-program/lib/Core/Program/Signal.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_GHC -fno-warn-unused-do-bind #-}
+{-# OPTIONS_GHC -Wno-deprecations #-}
 
 module Core.Program.Signal (
     setupSignalHandlers,
@@ -53,6 +54,7 @@ logLevelHandler v = Catch $ do
         ( \level -> case level of
             Output -> pure Debug
             Event -> pure Debug
+            Verbose -> pure Debug
             Debug -> pure Output
         )
 

--- a/tests/SimpleExperiment.hs
+++ b/tests/SimpleExperiment.hs
@@ -86,7 +86,7 @@ program = do
 
     forkThread $ do
         sleepThread 1.5
-        event "Wakey wakey"
+        warn "Wakey wakey"
         throw Boom
 
     replicateM_ 5 $ do


### PR DESCRIPTION
Introduce `warn` and `critical` logging actions to complement `info`, and give them distinctive colours when output.

Document the toggling behaviour of sending SIGUSR1 to a **core-program** program.

Begin removing mention of a separate duplicate logging channel. Logs are to `stdout`.