### PR TITLE
Reuse Connection in Honeycomb exporter

### DIFF
--- a/core-telemetry/core-telemetry.cabal
+++ b/core-telemetry/core-telemetry.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           core-telemetry
-version:        0.1.7.1
+version:        0.1.7.2
 synopsis:       Advanced telemetry
 description:    This is part of a library to help build command-line programs, both tools and
                 longer-running daemons.

--- a/core-telemetry/package.yaml
+++ b/core-telemetry/package.yaml
@@ -1,5 +1,5 @@
 name: core-telemetry
-version: 0.1.7.1
+version: 0.1.7.2
 synopsis: Advanced telemetry
 description: |
   This is part of a library to help build command-line programs, both tools and


### PR DESCRIPTION
Stash the Connection in an IORef so that we don't redo the SSL handshake every burst of telemetry.

Closes #70 