### PR TITLE
Fix a ghcid nit.

### DIFF
--- a/tests/CheckProgramMonad.hs
+++ b/tests/CheckProgramMonad.hs
@@ -7,7 +7,7 @@ module CheckProgramMonad where
 import qualified Control.Exception.Safe as Safe
 import Core.Data.Structures
 import Core.Program.Arguments
-import Core.Program.Execute
+import Core.Program.Execute hiding (Boom)
 import Core.Program.Unlift
 import Core.System.Base
 import Test.Hspec hiding (context)


### PR DESCRIPTION
Staggering re-write, brilliant thought leadership, truly blinding, titanic 10x engineer prowess.

No but seriously:

`ghcid` had a nit about one of the test files. This is the fix.