### PR TITLE
Expose parameter lookups as query actions

### DIFF
--- a/core-program/core-program.cabal
+++ b/core-program/core-program.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           core-program
-version:        0.3.3.0
+version:        0.3.4.0
 synopsis:       Opinionated Haskell Interoperability
 description:    A library to help build command-line programs, both tools and
                 longer-running daemons.

--- a/core-program/lib/Core/Program/Execute.hs
+++ b/core-program/lib/Core/Program/Execute.hs
@@ -431,7 +431,7 @@ loopForever action v out queue = do
                         start
                         now
                         SeverityInternal
-                        ("sent = " <> desc)
+                        ("telemetry: sent " <> desc)
             atomically $ do
                 writeTQueue out (Just message)
 

--- a/core-program/lib/Core/Program/Logging.hs
+++ b/core-program/lib/Core/Program/Logging.hs
@@ -464,4 +464,4 @@ internal label value = do
         when (isDebug level) $ do
             now <- getCurrentTimeNanoseconds
             !value' <- evaluate value
-            putMessage context (Message now SeverityInternal label (Just value'))
+            putMessage context (Message now SeverityInternal (label <> value') Nothing)

--- a/core-program/package.yaml
+++ b/core-program/package.yaml
@@ -1,5 +1,5 @@
 name: core-program
-version: 0.3.3.0
+version: 0.3.4.0
 synopsis: Opinionated Haskell Interoperability
 description: |
   A library to help build command-line programs, both tools and

--- a/core-telemetry/lib/Core/Telemetry/Observability.hs
+++ b/core-telemetry/lib/Core/Telemetry/Observability.hs
@@ -381,7 +381,8 @@ encloseSpan label action = do
     context <- getContext
 
     unique <- generateIdentifierBase62
-    internal "span" unique
+    internal label emptyRope
+    internal "span = " unique
 
     liftIO $ do
         -- prepare new span
@@ -525,10 +526,10 @@ usingTrace trace possibleParent action = do
 
     case possibleParent of
         Nothing -> do
-            internal "trace" (unTrace trace)
+            internal "trace = " (unTrace trace)
         Just parent -> do
-            internal "trace" (unTrace trace)
-            internal "parent" (unSpan parent)
+            internal "trace = " (unTrace trace)
+            internal "parent = " (unSpan parent)
 
     liftIO $ do
         -- prepare new span


### PR DESCRIPTION
To improve the ergonomics of working with command-line parameters, change the lookup functions to actions in the Program monad, following the naming convention `query*`. Simplify the return types so that the unnecessary Maybe wrappers are no longer exposed. 