### PR TITLE
Tweak help output of option values and arguments

### DIFF
--- a/core-program/core-program.cabal
+++ b/core-program/core-program.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           core-program
-version:        0.3.4.2
+version:        0.3.5.0
 synopsis:       Opinionated Haskell Interoperability
 description:    A library to help build command-line programs, both tools and
                 longer-running daemons.

--- a/core-program/core-program.cabal
+++ b/core-program/core-program.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           core-program
-version:        0.3.5.0
+version:        0.3.5.1
 synopsis:       Opinionated Haskell Interoperability
 description:    A library to help build command-line programs, both tools and
                 longer-running daemons.

--- a/core-program/lib/Core/Program/Arguments.hs
+++ b/core-program/lib/Core/Program/Arguments.hs
@@ -172,14 +172,14 @@ with @--help@, would result in:
 \$ __./snippet --help__
 Usage:
 
-    snippet [OPTIONS] filename
+    snippet [OPTIONS] <filename>
 
 Available options:
 
   -h, --host     Specify an alternate host to connect to when performing the
                  frobnication. The default is \"localhost\".
   -p, --port     Specify an alternate port to connect to when frobnicating.
-      --dry-run=TIME
+      --dry-run=<TIME>
                  Perform a trial run at the specified time but don't
                  actually do anything.
   -q, --quiet    Supress normal output.
@@ -189,7 +189,7 @@ Available options:
 
 Required arguments:
 
-  filename       The file you want to frobnicate.
+  <filename>     The file you want to frobnicate.
 \$ __|__
 @
 

--- a/core-program/lib/Core/Program/Arguments.hs
+++ b/core-program/lib/Core/Program/Arguments.hs
@@ -870,7 +870,7 @@ buildUsage config mode = case config of
         Nothing -> "COMMAND..."
 
     argumentsSummary :: [Options] -> Doc ann
-    argumentsSummary as = " " <> fillSep (fmap pretty (extractRequiredArguments as))
+    argumentsSummary as = " " <> fillSep (fmap (\x -> "<" <> pretty x <> ">") (extractRequiredArguments as))
 
     argumentsHeading as = if length as > 0 then hardline <> "Required arguments:" <> hardline else emptyDoc
 
@@ -911,11 +911,11 @@ buildUsage config mode = case config of
                 Empty ->
                     fillBreak 16 (s <> l <> " ") <+> align (reflow d) <> hardline <> acc
                 Value label ->
-                    fillBreak 16 (s <> l <> "=" <> pretty label <> " ") <+> align (reflow d) <> hardline <> acc
+                    fillBreak 16 (s <> l <> "=<" <> pretty label <> "> ") <+> align (reflow d) <> hardline <> acc
     g acc (Argument longname description) =
         let l = pretty longname
             d = fromRope description
-         in fillBreak 16 ("  " <> l <> " ") <+> align (reflow d) <> hardline <> acc
+         in fillBreak 16 ("  <" <> l <> "> ") <+> align (reflow d) <> hardline <> acc
     g acc (Remaining description) =
         let d = fromRope description
          in fillBreak 16 ("  " <> "... ") <+> align (reflow d) <> hardline <> acc

--- a/core-program/lib/Core/Program/Execute.hs
+++ b/core-program/lib/Core/Program/Execute.hs
@@ -61,6 +61,7 @@ module Core.Program.Execute (
 
     -- * Accessing program context
     getCommandLine,
+    queryCommandName,
     queryOptionFlag,
     queryOptionValue,
     queryArgument,
@@ -929,6 +930,22 @@ lookupEnvironmentValue name params =
             Empty -> Nothing
             Value str -> Just str
 {-# DEPRECATED lookupEnvironmentValue "Use queryEnvironment instead" #-}
+
+{- |
+Retreive the sub-command mode selected by the user. This assumes your program
+was set up to take sub-commands via 'complexConfig'.
+
+@
+    mode <- queryCommandName
+@
+-}
+queryCommandName :: Program τ Rope
+queryCommandName = do
+    context <- ask
+    let params = commandLineFrom context
+    case commandNameFrom params of
+        Just (LongName name) -> pure (intoRope name)
+        Nothing -> error "Attempted lookup of command but not a Complex Config"
 
 {- |
 Illegal internal state resulting from what should be unreachable code or

--- a/core-program/package.yaml
+++ b/core-program/package.yaml
@@ -1,5 +1,5 @@
 name: core-program
-version: 0.3.4.2
+version: 0.3.5.0
 synopsis: Opinionated Haskell Interoperability
 description: |
   A library to help build command-line programs, both tools and

--- a/core-program/package.yaml
+++ b/core-program/package.yaml
@@ -1,5 +1,5 @@
 name: core-program
-version: 0.3.5.0
+version: 0.3.5.1
 synopsis: Opinionated Haskell Interoperability
 description: |
   A library to help build command-line programs, both tools and


### PR DESCRIPTION
There are different conventions out there, but one has the options and arguments surrounded by < and > to indicate the variable nature (as opposed to a compulsory string). Adapt to that here.