### PR TITLE
Access source location metadata without requiring TemplateHaskell

### DIFF
--- a/core-program/core-program.cabal
+++ b/core-program/core-program.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           core-program
-version:        0.4.2.0
+version:        0.4.2.1
 synopsis:       Opinionated Haskell Interoperability
 description:    A library to help build command-line programs, both tools and
                 longer-running daemons.

--- a/core-program/core-program.cabal
+++ b/core-program/core-program.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           core-program
-version:        0.4.2.1
+version:        0.4.3.0
 synopsis:       Opinionated Haskell Interoperability
 description:    A library to help build command-line programs, both tools and
                 longer-running daemons.

--- a/core-program/lib/Core/Program/Context.hs
+++ b/core-program/lib/Core/Program/Context.hs
@@ -528,6 +528,15 @@ handleTelemetryChoice context = do
 {- |
 A utility exception for those occasions when you just need to go "boom".
 
+@
+    case 'Core.Data.Structures.containsKey' \"James Bond\" agents of
+        False -> do
+            evilPlan
+        True ->  do
+            'Core.Program.Logging.write' \"No Mr Bond, I expect you to die!\"
+            'Core.System.Base.throw' 'Boom'
+@
+
 @since 0.3.2
 -}
 data Boom = Boom

--- a/core-program/lib/Core/Program/Metadata.hs
+++ b/core-program/lib/Core/Program/Metadata.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE DeriveLift #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 
 {- |
 Dig metadata out of the description of your project.
@@ -24,6 +26,7 @@ module Core.Program.Metadata (
 
 import Core.Data
 import Core.System (IOMode (..), withFile)
+import Core.System.Pretty
 import Core.Text
 import Data.List (intersperse)
 import qualified Data.List as List (find, isSuffixOf)
@@ -214,3 +217,15 @@ __LOCATION__ =
             , srcLocEndLine = 0
             , srcLocEndCol = 0
             }
+
+instance Render SrcLoc where
+    type Token SrcLoc = ()
+    colourize = const pureWhite
+    highlight loc =
+        pretty (srcLocPackage loc)
+            <> "."
+            <> pretty (srcLocModule loc)
+            <> " "
+            <> pretty (srcLocFile loc)
+            <> ":"
+            <> pretty (show (srcLocStartLine loc))

--- a/core-program/lib/Core/Program/Metadata.hs
+++ b/core-program/lib/Core/Program/Metadata.hs
@@ -180,12 +180,17 @@ that @CPP@ gives you; the double underscore convention holds across many
 languages and stands out as a very meta thing, even if it is a proper Haskell
 value.
 
-You can have the output formatted like the stack traces like you sometimes see
-from Haskell exceptions via the 'Show' instance. We also have a 'Render'
-instance that prints a lighter weight version of the stack trace information.
+We have a 'Render' instance that simply prints the filename and line number.
+Doing:
 
 @
     writeR __LOCATION__
+@
+
+will give you:
+
+@
+tests/Snipppet.hs:32
 @
 
 This isn't the full stack trace, just information about the current line. If
@@ -222,10 +227,6 @@ instance Render SrcLoc where
     type Token SrcLoc = ()
     colourize = const pureWhite
     highlight loc =
-        pretty (srcLocPackage loc)
-            <> "."
-            <> pretty (srcLocModule loc)
-            <> " "
-            <> pretty (srcLocFile loc)
+        pretty (srcLocFile loc)
             <> ":"
             <> pretty (show (srcLocStartLine loc))

--- a/core-program/package.yaml
+++ b/core-program/package.yaml
@@ -1,5 +1,5 @@
 name: core-program
-version: 0.4.2.0
+version: 0.4.2.1
 synopsis: Opinionated Haskell Interoperability
 description: |
   A library to help build command-line programs, both tools and

--- a/core-program/package.yaml
+++ b/core-program/package.yaml
@@ -1,5 +1,5 @@
 name: core-program
-version: 0.4.2.1
+version: 0.4.3.0
 synopsis: Opinionated Haskell Interoperability
 description: |
   A library to help build command-line programs, both tools and

--- a/tests/CheckProgramMonad.hs
+++ b/tests/CheckProgramMonad.hs
@@ -8,8 +8,10 @@ import qualified Control.Exception.Safe as Safe
 import Core.Data.Structures
 import Core.Program.Arguments
 import Core.Program.Execute
+import Core.Program.Metadata
 import Core.Program.Unlift
 import Core.System.Base
+import Core.Text.Utilities (render)
 import Test.Hspec hiding (context)
 
 options :: [Options]
@@ -82,3 +84,7 @@ checkProgramMonad = do
             context <- configure "0.1" None blankConfig
             subProgram context $ do
                 Safe.catch (Safe.throw Boom) (\(_ :: Boom) -> return ())
+
+    describe "Package metadata" $ do
+        it "The source location is accessible" $ do
+            render 80 __LOCATION__ `shouldBe` "tests/CheckProgramMonad.hs:90"


### PR DESCRIPTION
Expose the current source location as the symbol `__LOCATION__`.

This name was chosen to make in reminiscent of the values you can get from using the CPP extension in Haskell and other languages, but as noted in the code

> This works because the call stack has the most recent frame at the head of the list. Huge credit to @parsonsmatt for having pointed out this technique at <https://twitter.com/mattoflambda/status/1460769133923028995>

it does not actually require CPP! Amazing.

Add a Render instance to simply format the file and line number as 

```
tests/Snippet:32
```
if you need more you've got the SrcLoc, and if you need the stack trace, well, you access `callStack`. Very cool.


