### PR TITLE
Emit trace and span identifiers per W3C Trace Context

### DIFF
--- a/core-program/lib/Core/Program/Context.hs
+++ b/core-program/lib/Core/Program/Context.hs
@@ -102,7 +102,7 @@ continuing an inherited trace and passed the identifier of the parent span you
 can specify it using this constructor.
 -}
 newtype Span = Span Rope
-    deriving (Show, IsString)
+    deriving (Show, Eq, IsString)
 
 unSpan :: Span -> Rope
 unSpan (Span text) = text
@@ -116,7 +116,7 @@ this program or request handler, and you can specify it by using
 'Core.Telemetry.Observability.usingTrace'.
 -}
 newtype Trace = Trace Rope
-    deriving (Show, IsString)
+    deriving (Show, Eq, IsString)
 
 unTrace :: Trace -> Rope
 unTrace (Trace text) = text

--- a/core-telemetry/core-telemetry.cabal
+++ b/core-telemetry/core-telemetry.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           core-telemetry
-version:        0.1.8.1
+version:        0.1.8.2
 synopsis:       Advanced telemetry
 description:    This is part of a library to help build command-line programs, both tools and
                 longer-running daemons.

--- a/core-telemetry/core-telemetry.cabal
+++ b/core-telemetry/core-telemetry.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           core-telemetry
-version:        0.1.8.2
+version:        0.1.8.3
 synopsis:       Advanced telemetry
 description:    This is part of a library to help build command-line programs, both tools and
                 longer-running daemons.
@@ -59,6 +59,7 @@ library
     , http-streams
     , io-streams
     , mtl
+    , network-info
     , random
     , safe-exceptions
     , scientific
@@ -66,5 +67,4 @@ library
     , template-haskell >=2.14 && <3
     , text
     , unix
-    , uuid
   default-language: Haskell2010

--- a/core-telemetry/core-telemetry.cabal
+++ b/core-telemetry/core-telemetry.cabal
@@ -58,7 +58,6 @@ library
     , exceptions
     , http-streams
     , io-streams
-    , locators
     , mtl
     , random
     , safe-exceptions

--- a/core-telemetry/core-telemetry.cabal
+++ b/core-telemetry/core-telemetry.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           core-telemetry
-version:        0.1.8.3
+version:        0.1.8.4
 synopsis:       Advanced telemetry
 description:    This is part of a library to help build command-line programs, both tools and
                 longer-running daemons.
@@ -42,6 +42,7 @@ library
       Core.Telemetry.Console
       Core.Telemetry.General
       Core.Telemetry.Honeycomb
+      Core.Telemetry.Identifiers
       Core.Telemetry.Observability
       Core.Telemetry.Structured
   hs-source-dirs:

--- a/core-telemetry/lib/Core/Telemetry/Identifiers.hs
+++ b/core-telemetry/lib/Core/Telemetry/Identifiers.hs
@@ -1,0 +1,200 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralisedNewtypeDeriving #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE RankNTypes #-}
+{-# OPTIONS_HADDOCK hide #-}
+
+module Core.Telemetry.Identifiers (
+    createIdentifierTrace,
+    createIdentifierSpan,
+    toHexNormal64,
+    toHexReversed64,
+    toHexNormal32,
+    toHexReversed32,
+    knownMachineIdentity,
+) where
+
+import Core.Program.Context
+import Core.System (unsafePerformIO)
+import Core.System.Base (liftIO)
+import Core.System.External (TimeStamp (unTimeStamp))
+import Core.Text.Rope
+import Data.Bits (shiftR, (.&.))
+import Data.Text.Internal.Unsafe.Char (unsafeChr8)
+import GHC.Word
+import Network.Info (MAC (..), NetworkInterface, getNetworkInterfaces, mac)
+
+{-
+Get the MAC address of the first interface that's not the loopback device. If
+something goes weird then we return a valid but bogus address (in the locally
+administered addresses block).
+-}
+knownMachineIdentity :: MAC
+knownMachineIdentity = unsafePerformIO $ do
+    interfaces <- getNetworkInterfaces
+    pure (go interfaces)
+  where
+    go :: [NetworkInterface] -> MAC
+    go [] = bogusAddress
+    go (interface : remainder) =
+        let address = mac interface
+         in if address /= loopbackAddress
+                then address
+                else go remainder
+
+    loopbackAddress = MAC 00 00 00 00 00 00
+    bogusAddress = MAC 0xfe 0xff 0xff 0xff 0xff 0xff
+{-# NOINLINE knownMachineIdentity #-}
+
+{- |
+Generate an identifier suitable for use in a trace context. Trace identifiers
+are 16 bytes. We incorporate the time to nanosecond precision, the host
+system's MAC address, and a random element. This is similar to a version 1
+UUID, but we render the least significant bits of the time stamp ordered first
+so that visual distinctiveness is on the left. The MAC address in the lower 48
+bits is /not/ reversed, leaving the most distinctiveness [the actual host as
+opposed to manufacturer OIN] hanging on the right hand edge of the identifier.
+The two bytes of randomness are in the middle.
+-}
+createIdentifierTrace :: TimeStamp -> Word16 -> MAC -> Trace
+createIdentifierTrace time rand address =
+    let p1 = packRope (toHexReversed64 (fromIntegral time))
+        p2 = packRope (toHexNormal16 rand)
+        p3 = packRope (convertMACToHex address)
+     in Trace
+            (p1 <> p2 <> p3)
+
+convertMACToHex :: MAC -> [Char]
+convertMACToHex (MAC b1 b2 b3 b4 b5 b6) =
+    nibbleToHex b1 4 :
+    nibbleToHex b1 0 :
+    nibbleToHex b2 4 :
+    nibbleToHex b2 0 :
+    nibbleToHex b3 4 :
+    nibbleToHex b3 0 :
+    nibbleToHex b4 4 :
+    nibbleToHex b4 0 :
+    nibbleToHex b5 4 :
+    nibbleToHex b5 0 :
+    nibbleToHex b6 4 :
+    nibbleToHex b6 0 :
+    []
+  where
+    nibbleToHex w = unsafeToDigit . fromIntegral . (.&.) 0x0f . shiftR w
+
+toHexReversed64 :: Word64 -> [Char]
+toHexReversed64 w =
+    nibbleToHex 00 :
+    nibbleToHex 04 :
+    nibbleToHex 08 :
+    nibbleToHex 12 :
+    nibbleToHex 16 :
+    nibbleToHex 20 :
+    nibbleToHex 24 :
+    nibbleToHex 28 : -- Word32
+    nibbleToHex 32 :
+    nibbleToHex 36 :
+    nibbleToHex 40 :
+    nibbleToHex 44 :
+    nibbleToHex 48 :
+    nibbleToHex 52 :
+    nibbleToHex 56 :
+    nibbleToHex 60 :
+    []
+  where
+    nibbleToHex = unsafeToDigit . fromIntegral . (.&.) 0x0f . shiftR w
+
+toHexNormal64 :: Word64 -> [Char]
+toHexNormal64 w =
+    nibbleToHex 60 :
+    nibbleToHex 56 :
+    nibbleToHex 52 :
+    nibbleToHex 48 :
+    nibbleToHex 44 :
+    nibbleToHex 40 :
+    nibbleToHex 36 :
+    nibbleToHex 32 :
+    nibbleToHex 28 : -- Word32
+    nibbleToHex 24 :
+    nibbleToHex 20 :
+    nibbleToHex 16 :
+    nibbleToHex 12 :
+    nibbleToHex 08 :
+    nibbleToHex 04 :
+    nibbleToHex 00 :
+    []
+  where
+    nibbleToHex = unsafeToDigit . fromIntegral . (.&.) 0x0f . shiftR w
+
+--
+-- Convert a 32-bit word to eight characters, but reversed so the least
+-- significant bits are first.
+--
+toHexReversed32 :: Word32 -> [Char]
+toHexReversed32 w =
+    nibbleToHex 00 :
+    nibbleToHex 04 :
+    nibbleToHex 08 :
+    nibbleToHex 12 :
+    nibbleToHex 16 :
+    nibbleToHex 20 :
+    nibbleToHex 24 :
+    nibbleToHex 28 :
+    []
+  where
+    nibbleToHex = unsafeToDigit . fromIntegral . (.&.) 0x0f . shiftR w
+
+toHexNormal32 :: Word32 -> [Char]
+toHexNormal32 w =
+    nibbleToHex 28 :
+    nibbleToHex 24 :
+    nibbleToHex 20 :
+    nibbleToHex 16 :
+    nibbleToHex 12 :
+    nibbleToHex 08 :
+    nibbleToHex 04 :
+    nibbleToHex 00 :
+    []
+  where
+    nibbleToHex = unsafeToDigit . fromIntegral . (.&.) 0x0f . shiftR w
+
+toHexNormal16 :: Word16 -> [Char]
+toHexNormal16 w =
+    nibbleToHex 12 :
+    nibbleToHex 08 :
+    nibbleToHex 04 :
+    nibbleToHex 00 :
+    []
+  where
+    nibbleToHex = unsafeToDigit . fromIntegral . (.&.) 0x0f . shiftR w
+
+{-
+byteToHex :: Word8 -> [Char]
+byteToHex c =
+    let !low = unsafeToDigit (c .&. 0x0f)
+        !hi = unsafeToDigit ((c .&. 0xf0) `shiftR` 4)
+     in hi : low : []
+-}
+
+-- convert a nibble to its hexidecimal character equivalent
+unsafeToDigit :: Word8 -> Char
+unsafeToDigit w =
+    if w < 10
+        then unsafeChr8 (48 + w)
+        else unsafeChr8 (97 + w - 10)
+
+{- |
+Generate an identifier for a span. We only have 8 bytes to work with. We use
+the nanosecond prescision timestamp with the nibbles reversed, and then
+overwrite the bottom two bytes with a random value.
+-}
+createIdentifierSpan :: TimeStamp -> Word16 -> Span
+createIdentifierSpan time rand =
+    let w = fromIntegral (unTimeStamp time) :: Word64
+     in Span
+            ( packRope
+                ( toHexReversed64 w
+                )
+            )

--- a/core-telemetry/lib/Core/Telemetry/Identifiers.hs
+++ b/core-telemetry/lib/Core/Telemetry/Identifiers.hs
@@ -31,7 +31,7 @@ import Core.System (unsafePerformIO)
 import Core.System.Base (liftIO)
 import Core.System.External (TimeStamp (unTimeStamp))
 import Core.Text.Rope
-import Data.Bits (shiftR, (.&.))
+import Data.Bits (shiftL, shiftR, (.&.), (.|.))
 import Data.Text.Internal.Unsafe.Char (unsafeChr8)
 import GHC.Word
 import Network.Info (MAC (..), NetworkInterface, getNetworkInterfaces, mac)
@@ -202,7 +202,9 @@ overwrite the last two bytes with a random value.
 -}
 createIdentifierSpan :: TimeStamp -> Word16 -> Span
 createIdentifierSpan time rand =
-    let w = fromIntegral (unTimeStamp time) :: Word64
+    let t = fromIntegral (unTimeStamp time) :: Word64
+        r = fromIntegral rand :: Word64
+        w = (t .&. 0x0000ffffffffffff) .|. (shiftL r 48)
      in Span
             ( packRope
                 ( toHexReversed64 w

--- a/core-telemetry/lib/Core/Telemetry/Observability.hs
+++ b/core-telemetry/lib/Core/Telemetry/Observability.hs
@@ -145,6 +145,7 @@ module Core.Telemetry.Observability (
     setServiceName,
     -- for testing
     convertToTrace64,
+    convertToSpan32,
     toHexNormal,
     toHexReversed,
 
@@ -465,13 +466,16 @@ right hand edge of the identifier.
 generateIdentifierTrace64 :: Program τ Rope
 generateIdentifierTrace64 = do
     uuid <- getUniqueId
+    pure (convertToTrace64 uuid)
+
+convertToTrace64 :: UUID -> Rope
+convertToTrace64 uuid =
     let (w1, w2, w3, w4) = toWords uuid
         l1 = convertL w1
         l2 = convertL w2
         l3 = convertB w3
         l4 = convertB w4
-        result = l1 <> l2 <> l3 <> l4
-    pure result
+     in l1 <> l2 <> l3 <> l4
   where
     convertL = intoRope . toHexReversed
     convertB = intoRope . toHexNormal
@@ -528,14 +532,17 @@ Generate an identifier for a span. We only have 8 bytes to work with. We use the
 nanosecond prescision timestamp with the nibbles reversed.
 -}
 generateIdentifierSpan32 :: TimeStamp -> Program τ Rope
-generateIdentifierSpan32 start = do
-    let w = fromIntegral (unTimeStamp start) :: Word64
+generateIdentifierSpan32 t = do
+    pure (convertToSpan32 t)
+
+convertToSpan32 :: TimeStamp -> Rope
+convertToSpan32 t =
+    let w = fromIntegral (unTimeStamp t) :: Word64
         w1 = fromIntegral ((.&.) 0xffffffff (shiftR w 32))
         w2 = fromIntegral ((.&.) 0xffffffff w)
         b1 = convertL w1
         b2 = convertL w2
-        result = b2 <> b1
-    pure result
+     in b2 <> b1
   where
     convertL = intoRope . toHexReversed
 

--- a/core-telemetry/lib/Core/Telemetry/Observability.hs
+++ b/core-telemetry/lib/Core/Telemetry/Observability.hs
@@ -143,6 +143,10 @@ module Core.Telemetry.Observability (
     beginTrace,
     usingTrace,
     setServiceName,
+    -- for testing
+    convertToTrace64,
+    toHexNormal,
+    toHexReversed,
 
     -- * Spans
     Label,

--- a/core-telemetry/lib/Core/Telemetry/Observability.hs
+++ b/core-telemetry/lib/Core/Telemetry/Observability.hs
@@ -158,10 +158,6 @@ module Core.Telemetry.Observability (
     -- * Events
     sendEvent,
     clearMetrics,
-
-    -- * Internals
-    createIdentifierTrace,
-    createIdentifierSpan,
 ) where
 
 import Control.Concurrent.MVar (modifyMVar_, newMVar, readMVar)
@@ -469,7 +465,7 @@ beginTrace action = do
     rand <- liftIO $ do
         (randomIO :: IO Word16)
 
-    let trace = createIdentifierTrace now rand knownMachineIdentity
+    let trace = createIdentifierTrace now rand hostMachineIdentity
 
     usingTrace trace Nothing action
 

--- a/core-telemetry/package.yaml
+++ b/core-telemetry/package.yaml
@@ -1,5 +1,5 @@
 name: core-telemetry
-version: 0.1.8.3
+version: 0.1.8.4
 synopsis: Advanced telemetry
 description: |
   This is part of a library to help build command-line programs, both tools and
@@ -54,6 +54,7 @@ library:
    - Core.Telemetry.Console
    - Core.Telemetry.General
    - Core.Telemetry.Honeycomb
+   - Core.Telemetry.Identifiers
    - Core.Telemetry.Observability
    - Core.Telemetry.Structured
   other-modules: []

--- a/core-telemetry/package.yaml
+++ b/core-telemetry/package.yaml
@@ -40,7 +40,6 @@ library:
    - exceptions
    - http-streams
    - io-streams
-   - locators
    - mtl
    - random
    - safe-exceptions

--- a/core-telemetry/package.yaml
+++ b/core-telemetry/package.yaml
@@ -1,5 +1,5 @@
 name: core-telemetry
-version: 0.1.8.1
+version: 0.1.8.2
 synopsis: Advanced telemetry
 description: |
   This is part of a library to help build command-line programs, both tools and

--- a/core-telemetry/package.yaml
+++ b/core-telemetry/package.yaml
@@ -1,5 +1,5 @@
 name: core-telemetry
-version: 0.1.8.2
+version: 0.1.8.3
 synopsis: Advanced telemetry
 description: |
   This is part of a library to help build command-line programs, both tools and
@@ -41,12 +41,12 @@ library:
    - http-streams
    - io-streams
    - mtl
+   - network-info
    - random
    - safe-exceptions
    - scientific
    - stm
    - unix
-   - uuid
   source-dirs:
   - lib
   exposed-modules:

--- a/package.yaml
+++ b/package.yaml
@@ -81,6 +81,7 @@ tests:
      - text
      - text-short
      - unordered-containers
+     - uuid
      - wai
     ghc-options: -threaded
     source-dirs:

--- a/package.yaml
+++ b/package.yaml
@@ -75,13 +75,13 @@ tests:
      - fingertree
      - hashable
      - hspec
+     - network-info
      - prettyprinter
      - safe-exceptions
      - stm
      - text
      - text-short
      - unordered-containers
-     - uuid
      - wai
     ghc-options: -threaded
     source-dirs:

--- a/tests/CheckProgramMonad.hs
+++ b/tests/CheckProgramMonad.hs
@@ -86,5 +86,5 @@ checkProgramMonad = do
                 Safe.catch (Safe.throw Boom) (\(_ :: Boom) -> return ())
 
     describe "Package metadata" $ do
-        it "The source location is accessible" $ do
+        it "the source location is accessible" $ do
             render 80 __LOCATION__ `shouldBe` "tests/CheckProgramMonad.hs:90"

--- a/tests/CheckTelemetryMachinery.hs
+++ b/tests/CheckTelemetryMachinery.hs
@@ -16,7 +16,6 @@ import Test.Hspec hiding (context)
 
 import Core.Program
 import Core.System
-import Core.Telemetry
 import Core.Telemetry.Identifiers
 import Core.Text
 
@@ -91,8 +90,9 @@ checkTelemetryMachinery = do
             createIdentifierSpan (TimeStamp (fromIntegral (maxBound :: Int32))) 0 `shouldBe` Span "fffffff700000000"
             createIdentifierSpan (TimeStamp (fromIntegral (maxBound :: Word32))) 0 `shouldBe` Span "ffffffff00000000"
             createIdentifierSpan (TimeStamp (fromIntegral (maxBound :: Word32)) + 1) 0 `shouldBe` Span "0000000010000000"
-            createIdentifierSpan (TimeStamp 1642770757512438606) 0 `shouldBe` Span "e43ade8dc4b4cc61"
-            createIdentifierSpan (TimeStamp 1642770757512438607) 0 `shouldBe` Span "f43ade8dc4b4cc61"
+            createIdentifierSpan (TimeStamp 1642770757512438606) 0 `shouldBe` Span "e43ade8dc4b40000"
+            createIdentifierSpan (TimeStamp 1642770757512438607) 0 `shouldBe` Span "f43ade8dc4b40000"
+            createIdentifierSpan (TimeStamp 1642770757512438607) 0x1a2b `shouldBe` Span "f43ade8dc4b4b2a1"
 
         it "formats timestamp and address as trace identifier" $ do
             createIdentifierTrace (TimeStamp 0) 0 (MAC 0 0 0 0 0 0) `shouldBe` Trace "00000000000000000000000000000000"

--- a/tests/CheckTelemetryMachinery.hs
+++ b/tests/CheckTelemetryMachinery.hs
@@ -10,12 +10,15 @@ import Control.Concurrent.MVar (MVar, modifyMVar_, newMVar, readMVar)
 import Control.Concurrent.STM (atomically)
 import Control.Concurrent.STM.TQueue (newTQueueIO, writeTQueue)
 import Data.Int (Int32)
+import Data.Maybe (fromMaybe)
+import Data.UUID (fromString, fromWords, nil)
 import Data.Word (Word32)
 import Test.Hspec hiding (context)
 
 import Core.Program
 import Core.System
 import Core.Telemetry
+import Core.Text
 
 countingAction :: Int -> [Int] -> IO ()
 countingAction target ints = sum ints `shouldBe` target
@@ -63,6 +66,13 @@ checkTelemetryMachinery = do
             convertToSpan32 (TimeStamp (fromIntegral (maxBound :: Word32)) + 1) `shouldBe` "0000000010000000"
             convertToSpan32 (TimeStamp 1642770757512438606) `shouldBe` "e43ade8dc4b4cc61"
             convertToSpan32 (TimeStamp 1642770757512438607) `shouldBe` "f43ade8dc4b4cc61"
+
+        it "formats UUID as trace identifier" $ do
+            convertToTrace64 nil `shouldBe` "00000000000000000000000000000000"
+            let uuid1 = fromWords 2 0 0 1
+            convertToTrace64 uuid1 `shouldBe` "20000000000000000000000000000001"
+            let uuid2 = fromMaybe nil (fromString "3f648e86-9642-4af6-b8ff-bd2c64c6eedd")
+            convertToTrace64 uuid2 `shouldBe` packRope ("68e846f3" ++ "6fa42469" ++ "b8ff" ++ "bd2c64c6eedd")
 
     describe "Queue processing" $ do
         it "processes an item put on queue" $ do

--- a/tests/CheckTelemetryMachinery.hs
+++ b/tests/CheckTelemetryMachinery.hs
@@ -72,7 +72,16 @@ checkTelemetryMachinery = do
             let uuid1 = fromWords 2 0 0 1
             convertToTrace64 uuid1 `shouldBe` "20000000000000000000000000000001"
             let uuid2 = fromMaybe nil (fromString "3f648e86-9642-4af6-b8ff-bd2c64c6eedd")
-            convertToTrace64 uuid2 `shouldBe` packRope ("68e846f3" ++ "6fa42469" ++ "b8ff" ++ "bd2c64c6eedd")
+            convertToTrace64 uuid2
+                `shouldBe` mconcat
+                    ( fmap
+                        packRope
+                        [ reverse "3f648e86"
+                        , reverse ("9642" ++ "4af6")
+                        , "b8ff"
+                        , "bd2c64c6eedd"
+                        ]
+                    )
 
     describe "Queue processing" $ do
         it "processes an item put on queue" $ do

--- a/tests/CheckTelemetryMachinery.hs
+++ b/tests/CheckTelemetryMachinery.hs
@@ -17,6 +17,7 @@ import Test.Hspec hiding (context)
 import Core.Program
 import Core.System
 import Core.Telemetry
+import Core.Telemetry.Identifiers
 import Core.Text
 
 countingAction :: Int -> [Int] -> IO ()
@@ -86,23 +87,25 @@ checkTelemetryMachinery = do
             toHexReversed64 maxBound `shouldBe` "ffffffffffffffff"
 
         it "formats timestamp as span identifier" $ do
-            convertToSpan32 (TimeStamp 1) `shouldBe` "1000000000000000"
-            convertToSpan32 (TimeStamp (fromIntegral (maxBound :: Int32))) `shouldBe` "fffffff700000000"
-            convertToSpan32 (TimeStamp (fromIntegral (maxBound :: Word32))) `shouldBe` "ffffffff00000000"
-            convertToSpan32 (TimeStamp (fromIntegral (maxBound :: Word32)) + 1) `shouldBe` "0000000010000000"
-            convertToSpan32 (TimeStamp 1642770757512438606) `shouldBe` "e43ade8dc4b4cc61"
-            convertToSpan32 (TimeStamp 1642770757512438607) `shouldBe` "f43ade8dc4b4cc61"
+            createIdentifierSpan (TimeStamp 1) 0 `shouldBe` Span "1000000000000000"
+            createIdentifierSpan (TimeStamp (fromIntegral (maxBound :: Int32))) 0 `shouldBe` Span "fffffff700000000"
+            createIdentifierSpan (TimeStamp (fromIntegral (maxBound :: Word32))) 0 `shouldBe` Span "ffffffff00000000"
+            createIdentifierSpan (TimeStamp (fromIntegral (maxBound :: Word32)) + 1) 0 `shouldBe` Span "0000000010000000"
+            createIdentifierSpan (TimeStamp 1642770757512438606) 0 `shouldBe` Span "e43ade8dc4b4cc61"
+            createIdentifierSpan (TimeStamp 1642770757512438607) 0 `shouldBe` Span "f43ade8dc4b4cc61"
 
         it "formats timestamp and address as trace identifier" $ do
-            convertToTrace64 (TimeStamp 0) 0 (MAC 0 0 0 0 0 0) `shouldBe` "00000000000000000000000000000000"
-            convertToTrace64 (TimeStamp 0x0fedcba987654321) 0x2468 (MAC 0x1a 0x2b 0x3c 0x4d 0x5e 0x6f)
-                `shouldBe` mconcat
-                    ( fmap
-                        packRope
-                        [ reverse "0fedcba987654321"
-                        , "2468"
-                        , "1a2b3c4d5e6f"
-                        ]
+            createIdentifierTrace (TimeStamp 0) 0 (MAC 0 0 0 0 0 0) `shouldBe` Trace "00000000000000000000000000000000"
+            createIdentifierTrace (TimeStamp 0x0fedcba987654321) 0x2468 (MAC 0x1a 0x2b 0x3c 0x4d 0x5e 0x6f)
+                `shouldBe` Trace
+                    ( mconcat
+                        ( fmap
+                            packRope
+                            [ reverse "0fedcba987654321"
+                            , "2468"
+                            , "1a2b3c4d5e6f"
+                            ]
+                        )
                     )
 
     describe "Queue processing" $ do

--- a/unbeliever.cabal
+++ b/unbeliever.cabal
@@ -100,13 +100,13 @@ test-suite check
     , fingertree
     , hashable
     , hspec
+    , network-info
     , prettyprinter
     , safe-exceptions
     , stm
     , text
     , text-short
     , unordered-containers
-    , uuid
     , wai
   default-language: Haskell2010
 

--- a/unbeliever.cabal
+++ b/unbeliever.cabal
@@ -106,6 +106,7 @@ test-suite check
     , text
     , text-short
     , unordered-containers
+    , uuid
     , wai
   default-language: Haskell2010
 


### PR DESCRIPTION
Switch to generating trace and span identifiers in hexidecimal form, meeting requirements of the "traceparent" header from the W3C Trace Context Specification.

Closes #96.