### PR TITLE
Expose identifiers

### DIFF
--- a/core-telemetry/core-telemetry.cabal
+++ b/core-telemetry/core-telemetry.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           core-telemetry
-version:        0.1.8.5
+version:        0.1.9.0
 synopsis:       Advanced telemetry
 description:    This is part of a library to help build command-line programs, both tools and
                 longer-running daemons.

--- a/core-telemetry/core-telemetry.cabal
+++ b/core-telemetry/core-telemetry.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           core-telemetry
-version:        0.1.9.0
+version:        0.1.9.1
 synopsis:       Advanced telemetry
 description:    This is part of a library to help build command-line programs, both tools and
                 longer-running daemons.

--- a/core-telemetry/core-telemetry.cabal
+++ b/core-telemetry/core-telemetry.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           core-telemetry
-version:        0.1.8.4
+version:        0.1.8.5
 synopsis:       Advanced telemetry
 description:    This is part of a library to help build command-line programs, both tools and
                 longer-running daemons.

--- a/core-telemetry/lib/Core/Telemetry.hs
+++ b/core-telemetry/lib/Core/Telemetry.hs
@@ -28,11 +28,18 @@ module Core.Telemetry (
     module Core.Telemetry.Console,
     module Core.Telemetry.General,
     module Core.Telemetry.Honeycomb,
-    module Core.Telemetry.Structured
+    module Core.Telemetry.Structured,
+
+    -- * Internals
+
+    -- |
+    -- Various elper functions.
+    module Core.Telemetry.Identifiers
 ) where
 
 import Core.Telemetry.Console
 import Core.Telemetry.General
 import Core.Telemetry.Honeycomb
+import Core.Telemetry.Identifiers
 import Core.Telemetry.Observability
 import Core.Telemetry.Structured

--- a/core-telemetry/lib/Core/Telemetry/Identifiers.hs
+++ b/core-telemetry/lib/Core/Telemetry/Identifiers.hs
@@ -23,7 +23,7 @@ module Core.Telemetry.Identifiers (
     createIdentifierTrace,
     createIdentifierSpan,
     hostMachineIdentity,
-    createTranceParentHeader,
+    createTraceParentHeader,
     -- for testing
     toHexNormal64,
     toHexReversed64,
@@ -235,8 +235,8 @@ traceparent: 00-fd533dbf96ecdc610156482ae36c24f7-1d1e9dbf96ec4649-00
 
 @since 0.1.9
 -}
-createTranceParentHeader :: Trace -> Span -> Rope
-createTranceParentHeader trace unique =
+createTraceParentHeader :: Trace -> Span -> Rope
+createTraceParentHeader trace unique =
     let version = "00"
         flags = "00"
      in version <> "-" <> unTrace trace <> "-" <> unSpan unique <> "-" <> flags

--- a/core-telemetry/lib/Core/Telemetry/Observability.hs
+++ b/core-telemetry/lib/Core/Telemetry/Observability.hs
@@ -513,7 +513,7 @@ usingTrace trace possibleParent action = do
         let datum2 =
                 datum
                     { traceIdentifierFrom = Just trace
-                    , parentIdentifierFrom = possibleParent
+                    , spanIdentifierFrom = possibleParent
                     }
 
         -- fork the Context

--- a/core-telemetry/package.yaml
+++ b/core-telemetry/package.yaml
@@ -1,5 +1,5 @@
 name: core-telemetry
-version: 0.1.8.4
+version: 0.1.8.5
 synopsis: Advanced telemetry
 description: |
   This is part of a library to help build command-line programs, both tools and

--- a/core-telemetry/package.yaml
+++ b/core-telemetry/package.yaml
@@ -1,5 +1,5 @@
 name: core-telemetry
-version: 0.1.9.0
+version: 0.1.9.1
 synopsis: Advanced telemetry
 description: |
   This is part of a library to help build command-line programs, both tools and

--- a/core-telemetry/package.yaml
+++ b/core-telemetry/package.yaml
@@ -1,5 +1,5 @@
 name: core-telemetry
-version: 0.1.8.5
+version: 0.1.9.0
 synopsis: Advanced telemetry
 description: |
   This is part of a library to help build command-line programs, both tools and

--- a/tests/CheckTelemetryMachinery.hs
+++ b/tests/CheckTelemetryMachinery.hs
@@ -108,6 +108,10 @@ checkTelemetryMachinery = do
                         )
                     )
 
+        it "formats trace and span as W3C Trace Context" $ do
+            createTraceContext (Trace "fd533dbf96ecdc610156482ae36c24f7") (Span "1d1e9dbf96ec4649")
+                `shouldBe` "00-fd533dbf96ecdc610156482ae36c24f7-1d1e9dbf96ec4649-00"
+
     describe "Queue processing" $ do
         it "processes an item put on queue" $ do
             v <- newMVar Debug

--- a/tests/CheckTelemetryMachinery.hs
+++ b/tests/CheckTelemetryMachinery.hs
@@ -109,7 +109,7 @@ checkTelemetryMachinery = do
                     )
 
         it "formats trace and span as W3C Trace Context" $ do
-            createTraceContext (Trace "fd533dbf96ecdc610156482ae36c24f7") (Span "1d1e9dbf96ec4649")
+            createTraceParentHeader (Trace "fd533dbf96ecdc610156482ae36c24f7") (Span "1d1e9dbf96ec4649")
                 `shouldBe` "00-fd533dbf96ecdc610156482ae36c24f7-1d1e9dbf96ec4649-00"
 
     describe "Queue processing" $ do


### PR DESCRIPTION
Add getters to enable you to get at the current Trace and Span identifier lurking in the Program monad's context.