### PR TITLE
Return result of program from internal execute function 

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: unbeliever
-version: 0.11.2.0
+version: 0.11.2.1
 synopsis: Opinionated Haskell Interoperability
 description: |
   A library to help build command-line programs, both tools and
@@ -56,15 +56,13 @@ dependencies:
 executables:
   snippet:
     dependencies:
-     - core-webserver-warp
-     - http-types
-     - wai
-     - warp
+     - http-streams
+     - safe-exceptions
     ghc-options:
      - -threaded
     source-dirs:
      - tests
-    main: WarpSnippet.hs
+    main: ThreadSnippet.hs
     other-modules: []
 
 tests:

--- a/unbeliever.cabal
+++ b/unbeliever.cabal
@@ -1,11 +1,11 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.34.6.
 --
 -- see: https://github.com/sol/hpack
 
 name:           unbeliever
-version:        0.11.2.0
+version:        0.11.2.1
 synopsis:       Opinionated Haskell Interoperability
 description:    A library to help build command-line programs, both tools and
                 longer-running daemons. Its @Program@ type provides unified ouptut &
@@ -55,7 +55,7 @@ source-repository head
   location: https://github.com/aesiniath/unbeliever
 
 executable snippet
-  main-is: WarpSnippet.hs
+  main-is: ThreadSnippet.hs
   hs-source-dirs:
       tests
   ghc-options: -Wall -Wwarn -fwarn-tabs -threaded
@@ -66,10 +66,9 @@ executable snippet
     , core-telemetry >=0.1.7.3
     , core-text >=0.3.4.0
     , core-webserver-servant >=0.0.1.0
-    , core-webserver-warp
-    , http-types
-    , wai
-    , warp
+    , core-webserver-warp >=0.1.0.0
+    , http-streams
+    , safe-exceptions
   default-language: Haskell2010
 
 test-suite check


### PR DESCRIPTION
Refactor `executeActual` to be an silently exposed function returning a value. This _may_ be the missing link to support proper test machinery for the Program monad.