### PR TITLE
Fix behaviour of leaking child threads when nesting

### DIFF
--- a/core-program/core-program.cabal
+++ b/core-program/core-program.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           core-program
-version:        0.4.4.0
+version:        0.4.5.0
 synopsis:       Opinionated Haskell Interoperability
 description:    A library to help build command-line programs, both tools and
                 longer-running daemons.

--- a/core-program/lib/Core/Program/Threads.hs
+++ b/core-program/lib/Core/Program/Threads.hs
@@ -207,9 +207,7 @@ around it, but as with all the other @wait*@ functions this ensures that if
 the thread waiting is cancelled the cancellation is propagated to the thread
 being watched as well.
 
-(this wraps __async__\'s 'Control.Concurrent.Async.waitCatch', ensuring that
-the child being waited on is cancelled if the thread waiting is cancelled as
-described throughout this module)
+(this wraps __async__\'s 'Control.Concurrent.Async.waitCatch')
 
 @since 0.4.5
 -}
@@ -258,7 +256,7 @@ similar control measure implemented using 'raceThreads_'. Should the thread
 that spawned all the workers and is waiting for their results be told to
 cancel because it lost the "race", the child threads need to be told in turn
 to cancel so as to avoid those threads being leaked and continuing to run as
-zombies.
+zombies. This function takes care of that.
 
 (this extends __async__\'s 'Control.Concurrent.Async.waitCatch' to work
 across a list of Threads, taking care to ensure the cancellation behaviour
@@ -296,7 +294,10 @@ linkThread (Thread a) = do
 {- |
 Cancel a thread.
 
-(this wraps __async__\'s 'Control.Concurrent.Async.cancel')
+(this wraps __async__\'s 'Control.Concurrent.Async.cancel'. The underlying
+mechanism used is to throw the 'AsyncCancelled' to the other thread. That
+exception is asynchronous, so will not be trapped by a 'catch' block and will
+indeed cause the thread receiving the exception to come to an end)
 
 @since 0.4.5
 -}

--- a/core-program/lib/Core/Program/Threads.hs
+++ b/core-program/lib/Core/Program/Threads.hs
@@ -41,15 +41,16 @@ module Core.Program.Threads (
     unThread,
 ) where
 
-import Control.Concurrent.Async (Async, cancel, AsyncCancelled)
+import Control.Concurrent.Async (Async, AsyncCancelled, cancel)
 import qualified Control.Concurrent.Async as Async (
     async,
+    cancel,
     concurrently,
     concurrently_,
     link,
     race,
     race_,
-    wait, cancel
+    wait,
  )
 import Control.Concurrent.MVar (
     newMVar,
@@ -78,7 +79,6 @@ unThread (Thread a) = a
 {- |
 Fork a thread. The child thread will run in the same @Context@ as the calling
 @Program@, including sharing the user-defined application state value.
-
 
 Threads that are launched off as children are on their own! If the code in the
 child thread throws an exception that is /not/ caught within that thread, the

--- a/core-program/package.yaml
+++ b/core-program/package.yaml
@@ -1,5 +1,5 @@
 name: core-program
-version: 0.4.4.0
+version: 0.4.5.0
 synopsis: Opinionated Haskell Interoperability
 description: |
   A library to help build command-line programs, both tools and


### PR DESCRIPTION
Closes #102.

Credit to @carlosdagos for recognizing that the problem was that the `Async.wait` was being cancelled, but that this AsyncCancelled was not being propagated to the child thread. Fixed by having `waitThreads` catch this exception and cancel the thread being waited on in turn. 

Clarify the documentation of behaviour of `forkThread` and `waitThread` in regard to what happens when exceptions are thrown.
