### PR TITLE
Only colour log output if attached to a terminal

### DIFF
--- a/core-program/core-program.cabal
+++ b/core-program/core-program.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           core-program
-version:        0.4.5.0
+version:        0.4.5.1
 synopsis:       Opinionated Haskell Interoperability
 description:    A library to help build command-line programs, both tools and
                 longer-running daemons.

--- a/core-program/lib/Core/Program/Context.hs
+++ b/core-program/lib/Core/Program/Context.hs
@@ -51,6 +51,7 @@ import Core.Program.Metadata
 import Core.System.Base hiding (catch, throw)
 import Core.Text.Rope
 import Data.Foldable (foldrM)
+import System.IO (hIsTerminalDevice)
 import Data.Int (Int64)
 import Data.String (IsString)
 import Prettyprinter (LayoutOptions (..), PageWidth (..), layoutPretty)
@@ -164,6 +165,7 @@ data Context τ = Context
     { -- runtime properties
       programNameFrom :: MVar Rope
     , terminalWidthFrom :: Int
+    , terminalColouredFrom :: Bool
     , versionFrom :: Version
     , -- only used during initial setup
       initialConfigFrom :: Config
@@ -353,6 +355,7 @@ configure version t config = do
     q <- newEmptyMVar
     i <- newMVar start
     columns <- getConsoleWidth
+    coloured <- getConsoleColoured
     level <- newEmptyMVar
     out <- newTQueueIO
     tel <- newTQueueIO
@@ -364,6 +367,7 @@ configure version t config = do
         $! Context
             { programNameFrom = n
             , terminalWidthFrom = columns
+            , terminalColouredFrom = coloured
             , versionFrom = version
             , initialConfigFrom = config
             , initialExportersFrom = []
@@ -392,7 +396,12 @@ getConsoleWidth = do
             Nothing -> 80
     return columns
 
---
+
+getConsoleColoured :: IO Bool
+getConsoleColoured = do
+    terminal <- hIsTerminalDevice stdout
+    pure terminal
+
 
 {- |
 Process the command line options and arguments. If an invalid option is

--- a/core-program/lib/Core/Program/Execute.hs
+++ b/core-program/lib/Core/Program/Execute.hs
@@ -447,6 +447,7 @@ loopForever action v out queue = do
                     formatLogMessage
                         start
                         now
+                        True
                         SeverityInternal
                         ("telemetry: sent " <> desc)
             atomically $ do
@@ -460,6 +461,7 @@ loopForever action v out queue = do
                     formatLogMessage
                         start
                         now
+                        True
                         SeverityWarn
                         ("sending telemetry failed (Exception: " <> intoRope (show e) <> "); Restarting exporter.")
             atomically $ do

--- a/core-program/package.yaml
+++ b/core-program/package.yaml
@@ -1,5 +1,5 @@
 name: core-program
-version: 0.4.5.0
+version: 0.4.5.1
 synopsis: Opinionated Haskell Interoperability
 description: |
   A library to help build command-line programs, both tools and

--- a/core-telemetry/lib/Core/Telemetry/Console.hs
+++ b/core-telemetry/lib/Core/Telemetry/Console.hs
@@ -81,6 +81,7 @@ processConsoleOutput out datums = do
                 formatLogMessage
                     start
                     now
+                    True
                     SeverityInternal
                     text
         atomically $ do

--- a/package.yaml
+++ b/package.yaml
@@ -55,6 +55,7 @@ dependencies:
 
 executables:
   snippet:
+    buildable: false
     dependencies:
      - core-webserver-warp
      - http-types
@@ -65,6 +66,18 @@ executables:
     source-dirs:
      - tests
     main: WarpSnippet.hs
+    other-modules: []
+
+  experiment:
+    dependencies:
+     - bytestring
+     - prettyprinter
+     - unordered-containers
+    ghc-options:
+     - -threaded
+    source-dirs:
+     - tests
+    main: SimpleExperiment.hs
     other-modules: []
 
 tests:

--- a/unbeliever.cabal
+++ b/unbeliever.cabal
@@ -54,6 +54,24 @@ source-repository head
   type: git
   location: https://github.com/aesiniath/unbeliever
 
+executable experiment
+  main-is: SimpleExperiment.hs
+  hs-source-dirs:
+      tests
+  ghc-options: -Wall -Wwarn -fwarn-tabs -threaded
+  build-depends:
+      base >=4.11 && <5
+    , bytestring
+    , core-data >=0.3.0.2
+    , core-program >=0.4.0.0
+    , core-telemetry >=0.1.7.3
+    , core-text >=0.3.4.0
+    , core-webserver-servant >=0.0.1.0
+    , core-webserver-warp >=0.1.0.0
+    , prettyprinter
+    , unordered-containers
+  default-language: Haskell2010
+
 executable snippet
   main-is: WarpSnippet.hs
   hs-source-dirs:
@@ -70,6 +88,7 @@ executable snippet
     , http-types
     , wai
     , warp
+  buildable: False
   default-language: Haskell2010
 
 test-suite check


### PR DESCRIPTION
We ran into a problem that some log aggregating services don't deal with (ie, don't strip) ANSI escape sequences resulting in quite an amount of gibberish obscuring the output. This was particularly a problem with AWS CloudWatch, so much so that (somewhat reluctantly) we'll add the usual trick of detecting whether the sddout handle is a terminal and deciding whether to colour or not based on that.