### PR TITLE
Add FromJSON instance

### DIFF
--- a/core-data/core-data.cabal
+++ b/core-data/core-data.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           core-data
-version:        0.3.1.1
+version:        0.3.2.0
 synopsis:       Convenience wrappers around common data structures and encodings
 description:    Wrappers around common data structures and encodings.
                 .

--- a/core-data/lib/Core/Encoding/Json.hs
+++ b/core-data/lib/Core/Encoding/Json.hs
@@ -99,6 +99,8 @@ import qualified Data.Aeson.KeyMap as Aeson
 #else
 import qualified Data.HashMap.Strict as HashMap
 #endif
+
+import Data.Aeson (FromJSON, Value (String))
 import Data.Coerce
 import Data.Hashable (Hashable)
 import qualified Data.List as List
@@ -413,3 +415,12 @@ escapeText text =
         ds = fmap pretty ts
      in hcat (punctuate (annotate EscapeToken "\\\"") ds)
 {-# INLINEABLE escapeText #-}
+
+--
+-- Orphan instance; ideally we wouldn't need this anywhere but people are
+-- asking for it and the relevant symbols are imported here.
+--
+
+instance FromJSON Rope where
+    parseJSON (String text) = pure (intoRope text)
+    parseJSON _ = fail "Can't parse this non-textual field as a Rope"

--- a/core-data/package.yaml
+++ b/core-data/package.yaml
@@ -1,5 +1,5 @@
 name: core-data
-version: 0.3.1.1
+version: 0.3.2.0
 synopsis: Convenience wrappers around common data structures and encodings
 description: |
   Wrappers around common data structures and encodings.


### PR DESCRIPTION
Ideally we wouldn't need this anywhere but people do keep asking for it and we have the relevant symbols imported in Core.Encoding.Json. So, fine. Add a FromJSON instance for Rope.