### PR TITLE
Ensure a span is sent if an exception is thrown

### DIFF
--- a/core-telemetry/core-telemetry.cabal
+++ b/core-telemetry/core-telemetry.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           core-telemetry
-version:        0.1.9.2
+version:        0.1.9.3
 synopsis:       Advanced telemetry
 description:    This is part of a library to help build command-line programs, both tools and
                 longer-running daemons.

--- a/core-telemetry/package.yaml
+++ b/core-telemetry/package.yaml
@@ -1,5 +1,5 @@
 name: core-telemetry
-version: 0.1.9.2
+version: 0.1.9.3
 synopsis: Advanced telemetry
 description: |
   This is part of a library to help build command-line programs, both tools and


### PR DESCRIPTION
When executing a sub Program nested in `encloseSpan` we need to ensure that telemetry is still sent even if an exception is thrown.