### PR TITLE
Output known environment variables  

### DIFF
--- a/core-program/core-program.cabal
+++ b/core-program/core-program.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           core-program
-version:        0.4.5.1
+version:        0.4.5.2
 synopsis:       Opinionated Haskell Interoperability
 description:    A library to help build command-line programs, both tools and
                 longer-running daemons.

--- a/core-program/package.yaml
+++ b/core-program/package.yaml
@@ -1,5 +1,5 @@
 name: core-program
-version: 0.4.5.1
+version: 0.4.5.2
 synopsis: Opinionated Haskell Interoperability
 description: |
   A library to help build command-line programs, both tools and

--- a/tests/ComplexExperiment.hs
+++ b/tests/ComplexExperiment.hs
@@ -12,12 +12,12 @@ import Core.Text
 
 program :: Program None ()
 program = do
-  event "Starting..."
+  info "Starting..."
 
   params <- getCommandLine
   debugS "params" params
 
-  event "Done."
+  info "Done."
   terminate 0
 
 main :: IO ()


### PR DESCRIPTION
If `Variable` entries are present in the Options, include their descriptions in the help output.

Closes #71.