### PR TITLE
Escape backslashes in addition to quotes

### DIFF
--- a/core-data/core-data.cabal
+++ b/core-data/core-data.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           core-data
-version:        0.3.2.0
+version:        0.3.2.1
 synopsis:       Convenience wrappers around common data structures and encodings
 description:    Wrappers around common data structures and encodings.
                 .

--- a/core-data/lib/Core/Encoding/Json.hs
+++ b/core-data/lib/Core/Encoding/Json.hs
@@ -178,13 +178,26 @@ encodeToRope value = case value of
     closebracket = singletonRope ']'
 
 {- |
--- Escape any quotes in a JsonString.
+Escape any quotes or backslashes in a JsonString.
 -}
 escapeString :: Rope -> Rope
 escapeString text =
+    let text1 = escapeBackslashes text
+        text2 = escapeQuotes text1
+      in text2
+{-# INLINEABLE escapeString #-}
+
+escapeBackslashes :: Rope -> Rope
+escapeBackslashes text =
+     let pieces = breakPieces (== '\\') text
+     in mconcat (List.intersperse "\\\\" pieces)
+{-# INLINEABLE escapeBackslashes #-}
+
+escapeQuotes :: Rope -> Rope
+escapeQuotes text =
     let pieces = breakPieces (== '"') text
      in mconcat (List.intersperse "\\\"" pieces)
-{-# INLINEABLE escapeString #-}
+{-# INLINEABLE escapeQuotes #-}
 
 {- |
 Given an array of bytes, attempt to decode it as a JSON value.

--- a/core-data/package.yaml
+++ b/core-data/package.yaml
@@ -1,5 +1,5 @@
 name: core-data
-version: 0.3.2.0
+version: 0.3.2.1
 synopsis: Convenience wrappers around common data structures and encodings
 description: |
   Wrappers around common data structures and encodings.

--- a/tests/CheckJsonWrapper.hs
+++ b/tests/CheckJsonWrapper.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
 {-# OPTIONS_GHC -fno-warn-missing-signatures #-}
 
 module CheckJsonWrapper where
@@ -11,6 +12,10 @@ import Test.Hspec
 k = JsonKey "intro"
 
 v = JsonString "Hello"
+
+v2 =
+    JsonString
+        [quote|Joy to the "world", they sang\nIn the \"matrix\" softly|]
 
 j = JsonObject (intoMap [(k, v)])
 
@@ -38,25 +43,31 @@ r = JsonArray [JsonBool False, JsonNull, JsonNumber 42]
 
 checkJsonWrapper :: Spec
 checkJsonWrapper = do
-    describe "JsonValue encoding" $
-        do
-            it "JSON String should be wrapped in quotes" $ do
-                encodeToUTF8 v `shouldBe` packBytes "\"Hello\""
+    describe "JsonValue encoding" $ do
+        it "JSON String should be wrapped in quotes" $ do
+            encodeToUTF8 v `shouldBe` packBytes "\"Hello\""
 
-            it "JSON Numbers differentiate between integers and floats" $ do
-                encodeToUTF8 (JsonNumber 42) `shouldBe` packBytes "42"
-                encodeToUTF8 (JsonNumber 3.141592) `shouldBe` packBytes "3.141592"
-                encodeToUTF8 (JsonNumber 2.99792458e8) `shouldBe` packBytes "299792458"
-                encodeToUTF8 (JsonNumber 6.62607015e-34) `shouldBe` packBytes "6.62607015e-34"
+        it "JSON Strings are escaped properly" $ do
+            encodeToUTF8 v2
+                `shouldBe` packBytes
+                    [quote|"Joy to the \"world\", they sang\\nIn the \\\"matrix\\\" softly"|]
 
-            it "JSON Array renders correctly" $ do
-                encodeToUTF8 r `shouldBe` packBytes "[false,null,42]"
+        it "JSON Numbers differentiate between integers and floats" $ do
+            encodeToUTF8 (JsonNumber 42) `shouldBe` packBytes "42"
+            encodeToUTF8 (JsonNumber 3.141592) `shouldBe` packBytes "3.141592"
+            encodeToUTF8 (JsonNumber 2.99792458e8) `shouldBe` packBytes "299792458"
+            encodeToUTF8 (JsonNumber 6.62607015e-34) `shouldBe` packBytes "6.62607015e-34"
 
-            it "JSON Object renders correctly" $ do
-                encodeToUTF8 j `shouldBe` packBytes "{\"intro\":\"Hello\"}"
+        it "JSON Array renders correctly" $ do
+            encodeToUTF8 r `shouldBe` packBytes "[false,null,42]"
 
-            it "decoding an Object parses" $ do
-                decodeFromUTF8 b `shouldBe` Just (JsonObject (intoMap [(JsonKey "cost", JsonNumber 4500)]))
+        it "JSON Object renders correctly" $ do
+            encodeToUTF8 j `shouldBe` packBytes "{\"intro\":\"Hello\"}"
 
-            it "complex JSON Object round trips" $ do
-                decodeFromUTF8 (encodeToUTF8 j2) `shouldBe` Just j2
+        it "decoding an Object parses" $ do
+            decodeFromUTF8 b
+                `shouldBe` Just
+                    (JsonObject (intoMap [(JsonKey "cost", JsonNumber 4500)]))
+
+        it "complex JSON Object round trips" $ do
+            decodeFromUTF8 (encodeToUTF8 j2) `shouldBe` Just j2


### PR DESCRIPTION
When preparing strings to be sent as JSON, escape `\` characters in addition to `"` characters, doing backslashes first.

Fixes #111. 