### PR TITLE
Use traceparent header to set parent trace and span

### DIFF
--- a/core-telemetry/core-telemetry.cabal
+++ b/core-telemetry/core-telemetry.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           core-telemetry
-version:        0.1.10.0
+version:        0.2.0.0
 synopsis:       Advanced telemetry
 description:    This is part of a library to help build command-line programs, both tools and
                 longer-running daemons.

--- a/core-telemetry/core-telemetry.cabal
+++ b/core-telemetry/core-telemetry.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           core-telemetry
-version:        0.1.9.3
+version:        0.1.10.0
 synopsis:       Advanced telemetry
 description:    This is part of a library to help build command-line programs, both tools and
                 longer-running daemons.

--- a/core-telemetry/lib/Core/Telemetry/Identifiers.hs
+++ b/core-telemetry/lib/Core/Telemetry/Identifiers.hs
@@ -228,12 +228,12 @@ createIdentifierSpan time rand =
 {- |
 Render the 'Trace' and 'Span' identifiers representing a span calling onward
 to another component in a distributed system. The W3C Trace Context
-recommendation specifies the HTTP header @traceparent@ with the 16 byte trace
-identifier and the 8 byte span identifier formatted as follows:
+recommendation specifies the HTTP header @traceparent@ with a version sequence
+(currently hard coded at @00@), the 16 byte trace identifier, the 8 byte span
+identifier, and a flag sequence (currently quite ignored), all formatted as
+follows:
 
-@
-traceparent: 00-fd533dbf96ecdc610156482ae36c24f7-1d1e9dbf96ec4649-00
-@
+@ traceparent: 00-fd533dbf96ecdc610156482ae36c24f7-1d1e9dbf96ec4649-00 @
 
 @since 0.1.9
 -}

--- a/core-telemetry/lib/Core/Telemetry/Identifiers.hs
+++ b/core-telemetry/lib/Core/Telemetry/Identifiers.hs
@@ -24,6 +24,7 @@ module Core.Telemetry.Identifiers (
     createIdentifierSpan,
     hostMachineIdentity,
     createTraceParentHeader,
+    parseTraceParentHeader,
     -- for testing
     toHexNormal64,
     toHexReversed64,
@@ -37,6 +38,7 @@ import Core.System (unsafePerformIO)
 import Core.System.Base (liftIO)
 import Core.System.External (TimeStamp (unTimeStamp))
 import Core.Text.Rope
+import Core.Text.Utilities (breakPieces)
 import Data.Bits (shiftL, shiftR, (.&.), (.|.))
 import Data.Text.Internal.Unsafe.Char (unsafeChr8)
 import GHC.Word
@@ -74,7 +76,7 @@ UUID, but we render the least significant bits of the time stamp ordered first
 so that visual distinctiveness is on the left. The MAC address in the lower 48
 bits is /not/ reversed, leaving the most distinctiveness [the actual host as
 opposed to manufacturer OIN] hanging on the right hand edge of the identifier.
-The two bytes of randomness are in the middle.
+The two bytes of supplied randomness are put in the middle.
 
 @since 0.1.9
 -}
@@ -208,7 +210,7 @@ unsafeToDigit w =
 {- |
 Generate an identifier for a span. We only have 8 bytes to work with. We use
 the nanosecond prescision timestamp with the nibbles reversed, and then
-overwrite the last two bytes with a random value.
+overwrite the last two bytes with the supplied random value.
 
 @since 0.1.9
 -}
@@ -240,6 +242,22 @@ createTraceParentHeader trace unique =
     let version = "00"
         flags = "00"
      in version <> "-" <> unTrace trace <> "-" <> unSpan unique <> "-" <> flags
+
+{- |
+Parse a @traceparent@ header into a 'Trace' and 'Span', assuming it was a
+valid pair according to the W3C Trace Context recommendation. The expectation
+is that if present in an HTTP request these values would be passed to
+'usingTrace' to allow the program to contribute spans to an existing trace
+started by another program or service.
+
+@since 0.1.10
+-}
+parseTraceParentHeader :: Rope -> Maybe (Trace, Span)
+parseTraceParentHeader header =
+    let pieces = breakPieces (== '-') header
+     in case pieces of
+            ("00" : trace : unique : _ : []) -> Just (Trace trace, Span unique)
+            _ -> Nothing
 
 {- |
 Get the identifier of the current trace, if you are ithin a trace started by

--- a/core-telemetry/lib/Core/Telemetry/Identifiers.hs
+++ b/core-telemetry/lib/Core/Telemetry/Identifiers.hs
@@ -246,9 +246,9 @@ createTraceParentHeader trace unique =
 {- |
 Parse a @traceparent@ header into a 'Trace' and 'Span', assuming it was a
 valid pair according to the W3C Trace Context recommendation. The expectation
-is that if present in an HTTP request these values would be passed to
-'usingTrace' to allow the program to contribute spans to an existing trace
-started by another program or service.
+is that, if present in an HTTP request, these values would be passed to
+'Core.Telemetry.Observability.usingTrace' to allow the program to contribute
+spans to an existing trace started by another program or service.
 
 @since 0.1.10
 -}
@@ -261,7 +261,8 @@ parseTraceParentHeader header =
 
 {- |
 Get the identifier of the current trace, if you are ithin a trace started by
-'beginTrace' or 'usingTrace'.
+'Core.Telemetry.Observability.beginTrace' or
+'Core.Telemetry.Observability.usingTrace'.
 
 @since 0.1.9
 -}
@@ -277,7 +278,7 @@ getIdentifierTrace = do
 
 {- |
 Get the identifier of the current span, if you are currently within a span
-created by 'encloseSpan'.
+created by 'Core.Telemetry.Observability.encloseSpan'.
 
 @since 0.1.9
 -}

--- a/core-telemetry/lib/Core/Telemetry/Observability.hs
+++ b/core-telemetry/lib/Core/Telemetry/Observability.hs
@@ -207,7 +207,7 @@ or program complimenting the @label@ set when calling 'encloseSpan', which by
 contrast descibes the name of the current phase, step, or even function name
 within the overall scope of the \"service\".
 
-This will end up as the @service_name@ parameter when exported.
+This will end up as the @service.name@ parameter when exported.
 -}
 
 -- This field name appears to be very Honeycomb specific, but looking around
@@ -477,15 +477,11 @@ beginTrace action = do
     encloseTrace trace Nothing action
 
 {- |
-Begin a new trace, but using a trace identifier provided externally. This is
-the most common case. Internal services that are play a part of a larger
-request will inherit a job identifier, sequence number, or other externally
-supplied unique code. Even an internet facing web service might have a
-correlation ID provided by the outside load balancers.
-
-If you are continuting an existing trace within the execution path of another,
-larger, enclosing service then you need to specify what the parent span's
-identifier is in the second argument.
+Continue an existing trace using a 'Trace' identifier and parent 'Span'
+identifier sourced externally. This is the most common case. Internal services
+that play a part of a larger request will inherit a job identifier, sequence
+number, or other externally supplied unique code. Even an internet-facing web
+service might have a correlation ID provided by the outside load balancers.
 
 @
 program :: 'Core.Program.Execute.Program' 'Core.Program.Execute.None' ()
@@ -501,6 +497,8 @@ program = do
         'encloseSpan' \"Internal processing\" $ do
             ...
 @
+
+@since 0.2.0
 -}
 usingTrace :: Trace -> Span -> Program τ α -> Program τ α
 usingTrace trace parent action = do

--- a/core-telemetry/package.yaml
+++ b/core-telemetry/package.yaml
@@ -1,5 +1,5 @@
 name: core-telemetry
-version: 0.1.10.0
+version: 0.2.0.0
 synopsis: Advanced telemetry
 description: |
   This is part of a library to help build command-line programs, both tools and

--- a/core-telemetry/package.yaml
+++ b/core-telemetry/package.yaml
@@ -1,5 +1,5 @@
 name: core-telemetry
-version: 0.1.9.3
+version: 0.1.10.0
 synopsis: Advanced telemetry
 description: |
   This is part of a library to help build command-line programs, both tools and

--- a/core-webserver-warp/core-webserver-warp.cabal
+++ b/core-webserver-warp/core-webserver-warp.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           core-webserver-warp
-version:        0.1.1.2
+version:        0.1.1.3
 synopsis:       Interoperability with Wai/Warp
 description:    This is part of a library to help build command-line programs, both tools and
                 longer-running daemons.
@@ -42,7 +42,7 @@ library
     , bytestring
     , core-data
     , core-program
-    , core-telemetry >=0.1.10
+    , core-telemetry >=0.2.0
     , core-text
     , http-types
     , http2

--- a/core-webserver-warp/core-webserver-warp.cabal
+++ b/core-webserver-warp/core-webserver-warp.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           core-webserver-warp
-version:        0.1.1.0
+version:        0.1.1.2
 synopsis:       Interoperability with Wai/Warp
 description:    This is part of a library to help build command-line programs, both tools and
                 longer-running daemons.
@@ -42,7 +42,7 @@ library
     , bytestring
     , core-data
     , core-program
-    , core-telemetry >=0.1.8
+    , core-telemetry >=0.1.10
     , core-text
     , http-types
     , http2

--- a/core-webserver-warp/lib/Core/Webserver/Warp.hs
+++ b/core-webserver-warp/lib/Core/Webserver/Warp.hs
@@ -242,12 +242,12 @@ Pull the Trace identifier and parent Span identifier out of the request
 headers, if present. Resume using those values, otherwise start a new trace.
 -}
 resumeTraceIf :: Request -> Program z a -> Program z a
-resumeTraceIf request program =
+resumeTraceIf request action =
     case extractTraceParent request of
         Nothing -> do
-            beginTrace program
+            beginTrace action
         Just (trace, unique) -> do
-            usingTrace trace (Just unique) program
+            usingTrace trace unique action
 
 --
 -- This is wildly inefficient. Surely warp must provide a better way to search

--- a/core-webserver-warp/package.yaml
+++ b/core-webserver-warp/package.yaml
@@ -1,5 +1,5 @@
 name: core-webserver-warp
-version: 0.1.1.2
+version: 0.1.1.3
 synopsis: Interoperability with Wai/Warp
 description: |
   This is part of a library to help build command-line programs, both tools and
@@ -26,7 +26,7 @@ dependencies:
  - bytestring
  - core-data
  - core-program
- - core-telemetry >= 0.1.10
+ - core-telemetry >= 0.2.0
  - core-text
  - http-types
  - http2

--- a/core-webserver-warp/package.yaml
+++ b/core-webserver-warp/package.yaml
@@ -1,5 +1,5 @@
 name: core-webserver-warp
-version: 0.1.1.0
+version: 0.1.1.2
 synopsis: Interoperability with Wai/Warp
 description: |
   This is part of a library to help build command-line programs, both tools and
@@ -26,7 +26,7 @@ dependencies:
  - bytestring
  - core-data
  - core-program
- - core-telemetry >= 0.1.8
+ - core-telemetry >= 0.1.10
  - core-text
  - http-types
  - http2


### PR DESCRIPTION
Use the `traceparent:` header to set parent Trace and Span if they are present in an incoming HTTP request.