### PR TITLE
Export both the data type, and the data constructor.

### DIFF
--- a/core-telemetry/lib/Core/Telemetry/Observability.hs
+++ b/core-telemetry/lib/Core/Telemetry/Observability.hs
@@ -152,7 +152,7 @@ module Core.Telemetry.Observability (
     setStartTime,
 
     -- * Creating telemetry
-    MetricValue,
+    MetricValue (MetricValue),
     Telemetry (metric),
     telemetry,
 

--- a/core-telemetry/package.yaml
+++ b/core-telemetry/package.yaml
@@ -1,5 +1,5 @@
 name: core-telemetry
-version: 0.1.9.3
+version: 0.1.9.4
 synopsis: Advanced telemetry
 description: |
   This is part of a library to help build command-line programs, both tools and


### PR DESCRIPTION
As the title says, export the data constructor as well as the data type. Makes it easier to construct your own instances, or pattern match the key and value out of the type.