### PR TITLE
Fix reading metadata from .cabal files

### DIFF
--- a/core-program/core-program.cabal
+++ b/core-program/core-program.cabal
@@ -58,8 +58,8 @@ library
     , base >=4.11 && <5
     , bytestring
     , chronologique
-    , core-data >=0.2.1.11
-    , core-text >=0.3.4.0
+    , core-data >=0.3.2.2
+    , core-text >=0.3.7.0
     , directory
     , exceptions
     , filepath

--- a/core-program/core-program.cabal
+++ b/core-program/core-program.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           core-program
-version:        0.4.5.2
+version:        0.4.5.3
 synopsis:       Opinionated Haskell Interoperability
 description:    A library to help build command-line programs, both tools and
                 longer-running daemons.

--- a/core-program/package.yaml
+++ b/core-program/package.yaml
@@ -36,8 +36,8 @@ dependencies:
 library:
   dependencies:
    - async
-   - core-text >= 0.3.4.0
-   - core-data >= 0.2.1.11
+   - core-text >= 0.3.7.0
+   - core-data >= 0.3.2.2
    - chronologique
    - directory
    - exceptions

--- a/core-program/package.yaml
+++ b/core-program/package.yaml
@@ -1,5 +1,5 @@
 name: core-program
-version: 0.4.5.2
+version: 0.4.5.3
 synopsis: Opinionated Haskell Interoperability
 description: |
   A library to help build command-line programs, both tools and

--- a/core-telemetry/core-telemetry.cabal
+++ b/core-telemetry/core-telemetry.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           core-telemetry
-version:        0.1.9.3
+version:        0.1.9.4
 synopsis:       Advanced telemetry
 description:    This is part of a library to help build command-line programs, both tools and
                 longer-running daemons.
@@ -53,9 +53,9 @@ library
     , base >=4.11 && <5
     , bytestring
     , chronologique
-    , core-data >=0.2.1.11
-    , core-program >=0.4.4
-    , core-text >=0.3.5
+    , core-data >=0.3.2.2
+    , core-program >=0.4.5.3
+    , core-text >=0.3.6.0
     , exceptions
     , http-streams
     , io-streams

--- a/core-telemetry/package.yaml
+++ b/core-telemetry/package.yaml
@@ -1,5 +1,5 @@
 name: core-telemetry
-version: 0.1.9.3
+version: 0.1.9.4
 synopsis: Advanced telemetry
 description: |
   This is part of a library to help build command-line programs, both tools and
@@ -33,9 +33,9 @@ dependencies:
 library:
   dependencies:
    - async
-   - core-text >= 0.3.5
-   - core-data >= 0.2.1.11
-   - core-program >= 0.4.4
+   - core-text >= 0.3.6.0
+   - core-data >= 0.3.2.2
+   - core-program >= 0.4.5.3
    - chronologique
    - exceptions
    - http-streams

--- a/core-text/core-text.cabal
+++ b/core-text/core-text.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           core-text
-version:        0.3.7.0
+version:        0.3.7.1
 synopsis:       A rope type based on a finger tree over UTF-8 fragments
 description:    A rope data type for text, built as a finger tree over UTF-8 text
                 fragments. The package also includes utiltiy functions for breaking and

--- a/core-text/lib/Core/Text/Rope.hs
+++ b/core-text/lib/Core/Text/Rope.hs
@@ -124,7 +124,7 @@ import qualified Data.FingerTree as F (
     (><),
     (|>),
  )
-import Data.Foldable (foldl', foldr', toList)
+import Data.Foldable (foldl', toList)
 import Data.Hashable (Hashable, hashWithSalt)
 import Data.String (IsString (..))
 import qualified Data.Text as T (Text)
@@ -148,14 +148,14 @@ import qualified Data.Text.Short as S (
     fromByteString,
     fromText,
     length,
-    null,
     pack,
     replicate,
     singleton,
     splitAt,
     toBuilder,
     toText,
-    unpack, uncons
+    uncons,
+    unpack,
  )
 import qualified Data.Text.Short.Unsafe as S (fromByteStringUnsafe)
 import GHC.Generics (Generic)
@@ -324,14 +324,13 @@ replicateChar count = Rope . F.singleton . S.replicate count . S.singleton
 Get the length of this text, in characters.
 -}
 widthRope :: Rope -> Int
-widthRope = foldr' f 0 . unRope
-  where
-    f piece count = S.length piece + count
+widthRope text =
+    let x = unRope text
+        (Width w) = F.measure x
+     in w
 
 nullRope :: Rope -> Bool
-nullRope (Rope x) = case F.viewl x of
-    F.EmptyL -> True
-    (F.:<) piece _ -> S.null piece
+nullRope text = widthRope text == 0
 
 {- |
 Read the first character from a 'Rope', assuming it's length 1 or greater,
@@ -349,7 +348,6 @@ unconsRope text =
                 case S.uncons piece of
                     Nothing -> Nothing
                     Just (c, piece') -> Just (c, Rope ((F.<|) piece' x'))
-
 
 {- |
 Break the text into two pieces at the specified offset.

--- a/core-text/package.yaml
+++ b/core-text/package.yaml
@@ -1,5 +1,5 @@
 name: core-text
-version: 0.3.7.0
+version: 0.3.7.1
 synopsis: A rope type based on a finger tree over UTF-8 fragments
 description: |
   A rope data type for text, built as a finger tree over UTF-8 text


### PR DESCRIPTION
Adapt **core-program** to fix reading .cabal files to use new `breakRope`.

Bump dependencies on **core-data** in order to pick up the fix to JSON string encoding.