### PR TITLE
Adjust logging of telemetry

### DIFF
--- a/core-program/core-program.cabal
+++ b/core-program/core-program.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           core-program
-version:        0.4.5.3
+version:        0.4.6.1
 synopsis:       Opinionated Haskell Interoperability
 description:    A library to help build command-line programs, both tools and
                 longer-running daemons.

--- a/core-program/lib/Core/Program/Context.hs
+++ b/core-program/lib/Core/Program/Context.hs
@@ -233,6 +233,8 @@ data Verbosity
     | -- | @since 0.2.12
       Verbose
     | Debug
+    | -- | @since 0.4.6
+      Internal
     deriving (Show)
 
 {- |
@@ -491,6 +493,7 @@ queryVerbosityLevel params =
      in case debug of
             Just value -> case value of
                 Empty -> Right Debug
+                Value "internal" -> Right Internal
                 Value _ -> Left (ExitFailure 2)
             Nothing -> case verbose of
                 Just value -> case value of

--- a/core-program/lib/Core/Program/Execute.hs
+++ b/core-program/lib/Core/Program/Execute.hs
@@ -438,7 +438,7 @@ loopForever action v out queue = do
 
     reportStatus start num = do
         level <- readMVar v
-        when (isDebug level) $ do
+        when (isInternal level) $ do
             now <- getCurrentTimeNanoseconds
             let desc = case num of
                     1 -> "1 event"
@@ -449,7 +449,7 @@ loopForever action v out queue = do
                         now
                         True
                         SeverityInternal
-                        ("telemetry: sent " <> desc)
+                        ("Sent " <> desc)
             atomically $ do
                 writeTQueue out (Just message)
 
@@ -463,7 +463,7 @@ loopForever action v out queue = do
                         now
                         True
                         SeverityWarn
-                        ("sending telemetry failed (Exception: " <> intoRope (show e) <> "); Restarting exporter.")
+                        ("Sending telemetry failed (Exception: " <> intoRope (show e) <> "); Restarting exporter.")
             atomically $ do
                 writeTQueue out (Just message)
 

--- a/core-program/package.yaml
+++ b/core-program/package.yaml
@@ -1,5 +1,5 @@
 name: core-program
-version: 0.4.5.3
+version: 0.4.6.1
 synopsis: Opinionated Haskell Interoperability
 description: |
   A library to help build command-line programs, both tools and

--- a/core-telemetry/core-telemetry.cabal
+++ b/core-telemetry/core-telemetry.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           core-telemetry
-version:        0.2.0.0
+version:        0.2.0.1
 synopsis:       Advanced telemetry
 description:    This is part of a library to help build command-line programs, both tools and
                 longer-running daemons.

--- a/core-telemetry/package.yaml
+++ b/core-telemetry/package.yaml
@@ -1,5 +1,5 @@
 name: core-telemetry
-version: 0.2.0.0
+version: 0.2.0.1
 synopsis: Advanced telemetry
 description: |
   This is part of a library to help build command-line programs, both tools and

--- a/package.yaml
+++ b/package.yaml
@@ -69,6 +69,7 @@ executables:
     other-modules: []
 
   experiment:
+    buildable: false
     dependencies:
      - bytestring
      - prettyprinter

--- a/tests/WarpSnippet.hs
+++ b/tests/WarpSnippet.hs
@@ -44,10 +44,14 @@ exampleApplication request sendResponse =
      in do
             sendResponse (responseLBS status200 [] path')
 
+port :: Port
+port = 48080
+
 main :: IO ()
 main = do
     context <- configure "1" None (simpleConfig [])
     context' <- initializeTelemetry [consoleExporter, structuredExporter, honeycombExporter] context
     executeWith context' $ do
         info "Starting..."
-        launchWebserver 48080 exampleApplication
+        debugS "port" port
+        launchWebserver port exampleApplication

--- a/unbeliever.cabal
+++ b/unbeliever.cabal
@@ -70,6 +70,7 @@ executable experiment
     , core-webserver-warp >=0.1.0.0
     , prettyprinter
     , unordered-containers
+  buildable: False
   default-language: Haskell2010
 
 executable snippet


### PR DESCRIPTION
Create new level `Internal` level for Verbosity and undocumented feature `--debug=internal` to get at it. The messages about traces and spans were already using an `isInternal` helper; now they have an explicit level to go with it.

Emit an "Enter" and "Leave" around spans, and likewise note "Begin" or "Using" when starting a trace.