### PR TITLE
Fix argument order

### DIFF
--- a/core-program/core-program.cabal
+++ b/core-program/core-program.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           core-program
-version:        0.4.6.1
+version:        0.4.6.3
 synopsis:       Opinionated Haskell Interoperability
 description:    A library to help build command-line programs, both tools and
                 longer-running daemons.

--- a/core-program/lib/Core/Program/Arguments.hs
+++ b/core-program/lib/Core/Program/Arguments.hs
@@ -353,17 +353,18 @@ data Options
     | Argument LongName Description
     | Remaining Description
     | Variable LongName Description
+    deriving (Show)
 
 appendOption :: Options -> Config -> Config
 appendOption option config =
     case config of
         Blank -> Blank
-        Simple options -> Simple (List.reverse (option : options))
+        Simple options -> Simple (options ++ [option])
         Complex commands -> Complex (List.foldl' f [] commands)
   where
     f :: [Commands] -> Commands -> [Commands]
     f acc command = case command of
-        Global options -> Global (List.reverse (option : options)) : acc
+        Global options -> Global (options ++ [option]) : acc
         c@(Command _ _ _) -> c : acc
 
 {- |
@@ -709,8 +710,8 @@ extractValidModes commands =
     List.foldl' k emptyMap commands
   where
     k :: Map LongName [Options] -> Commands -> Map LongName [Options]
-    k modes (Command longname _ options)  = insertKeyValue longname options modes
-    k modes _  = modes
+    k modes (Command longname _ options) = insertKeyValue longname options modes
+    k modes _ = modes
 
 {- |
 Break the command-line apart in two steps. The first peels off the global

--- a/core-program/lib/Core/Program/Signal.hs
+++ b/core-program/lib/Core/Program/Signal.hs
@@ -54,6 +54,7 @@ logLevelHandler v = Catch $ do
             Output -> pure Debug
             Verbose -> pure Debug
             Debug -> pure Output
+            Internal -> pure Output
         )
 
 --

--- a/core-program/package.yaml
+++ b/core-program/package.yaml
@@ -1,5 +1,5 @@
 name: core-program
-version: 0.4.6.1
+version: 0.4.6.2
 synopsis: Opinionated Haskell Interoperability
 description: |
   A library to help build command-line programs, both tools and

--- a/core-program/package.yaml
+++ b/core-program/package.yaml
@@ -1,5 +1,5 @@
 name: core-program
-version: 0.4.6.2
+version: 0.4.6.3
 synopsis: Opinionated Haskell Interoperability
 description: |
   A library to help build command-line programs, both tools and


### PR DESCRIPTION
Looks like we had `appendOption` wrong which didn't matter for argument processing but was messing up the display of `--help` output. Fixed.