### PR TITLE
Add context to prepareRoutes for servant-auth

### DIFF
--- a/core-webserver-servant/core-webserver-servant.cabal
+++ b/core-webserver-servant/core-webserver-servant.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           core-webserver-servant
-version:        0.1.0.0
+version:        0.1.1.0
 synopsis:       Interoperability with Servant
 description:    This is part of a library to help build command-line programs, both tools and
                 longer-running daemons.

--- a/core-webserver-servant/lib/Core/Webserver/Servant.hs
+++ b/core-webserver-servant/lib/Core/Webserver/Servant.hs
@@ -31,17 +31,24 @@ module Core.Webserver.Servant (
     prepareRoutesWithContext,
 ) where
 
+import Control.Monad.Except (ExceptT (..))
 import Core.Program
 import Core.System (Exception (..))
 import Core.Telemetry.Observability (clearMetrics)
-
-import Control.Monad.Except (ExceptT (..))
 import Core.Webserver.Warp
 import Data.Proxy (Proxy)
 import GHC.Base (Type)
 import Network.Wai (Application)
-import Servant (Handler (..), ServerT)
-import Servant.Server (Context (..), HasServer, ServerContext, serveWithContextT)
+import qualified Servant as Servant (
+    Handler (..),
+    ServerT,
+ )
+import qualified Servant.Server as Servant (
+    Context (..),
+    HasServer,
+    ServerContext,
+    serveWithContextT,
+ )
 
 data ContextNotFoundInRequest = ContextNotFoundInRequest deriving (Show)
 
@@ -67,20 +74,26 @@ logging and telemetry facilities of __core-program__ and __core-telemetry__.
 -}
 prepareRoutes ::
     forall τ (api :: Type).
-    HasServer api '[] =>
+    Servant.HasServer api '[] =>
     Proxy api ->
-    ServerT api (Program τ) ->
+    Servant.ServerT api (Program τ) ->
     Program τ Application
-prepareRoutes proxy = prepareRoutesWithContext proxy EmptyContext
+prepareRoutes proxy = prepareRoutesWithContext proxy Servant.EmptyContext
 
+{- |
+Prepare routes as with 'prepareRoutes' above, but providing a __servant__
+'Servant.Server.Context' in order to give detailed control of the setup.
+
+@since 0.1.1
+-}
 prepareRoutesWithContext ::
     forall τ (api :: Type) context.
-    (HasServer api context, ServerContext context) =>
+    (Servant.HasServer api context, Servant.ServerContext context) =>
     Proxy api ->
-    Servant.Server.Context context ->
-    ServerT api (Program τ) ->
+    Servant.Context context ->
+    Servant.ServerT api (Program τ) ->
     Program τ Application
-prepareRoutesWithContext proxy sContext (routes :: ServerT api (Program τ)) =
+prepareRoutesWithContext proxy sContext (routes :: Servant.ServerT api (Program τ)) =
     pure application
   where
     application :: Application
@@ -96,7 +109,7 @@ prepareRoutesWithContext proxy sContext (routes :: ServerT api (Program τ)) =
         context <- case contextFromRequest @τ request of
             Just context' -> pure context'
             Nothing -> throw ContextNotFoundInRequest
-        serveWithContextT
+        Servant.serveWithContextT
             proxy
             sContext
             (transformProgram context)
@@ -104,11 +117,11 @@ prepareRoutesWithContext proxy sContext (routes :: ServerT api (Program τ)) =
             request
             sendResponse
 
-    transformProgram :: Core.Program.Context τ -> Program τ α -> Handler α
+    transformProgram :: Context τ -> Program τ α -> Servant.Handler α
     transformProgram context program =
         let output =
                 try $
                     subProgram context $ do
                         clearMetrics
                         program
-         in Handler (ExceptT output)
+         in Servant.Handler (ExceptT output)

--- a/core-webserver-servant/package.yaml
+++ b/core-webserver-servant/package.yaml
@@ -1,5 +1,5 @@
 name: core-webserver-servant
-version: 0.1.0.0
+version: 0.1.1.0
 synopsis: Interoperability with Servant
 description: |
   This is part of a library to help build command-line programs, both tools and

--- a/stack.yaml
+++ b/stack.yaml
@@ -8,6 +8,8 @@ packages:
  - ./core-webserver-warp
  - .
 extra-deps:
- - semialign-1.2
- - time-compat-1.9.6.1
  - hashable-1.3.5.0
+ - semialign-1.2
+ - servant-0.19
+ - servant-server-0.19.1
+ - time-compat-1.9.6.1


### PR DESCRIPTION
Implement `prepareRoutesWithContext` to align with **servant**'s `serveWithContext`. Required for **servant-auth**.