### PR TITLE
Fix Haddock links

### DIFF
--- a/core-program/lib/Core/Program/Arguments.hs
+++ b/core-program/lib/Core/Program/Arguments.hs
@@ -109,7 +109,7 @@ instance Textual LongName where
 
 {- |
 The setup for parsing the command-line arguments of your program. You build
-a @Config@ with 'simple' or 'complex', and pass it to
+a @Config@ with 'simpleConfig' or 'complexConfig', and pass it to
 'Core.Program.Context.configure'.
 -}
 data Config
@@ -128,7 +128,7 @@ data Config
 {- |
 A completely empty configuration, without the default debugging and logging
 options. Your program won't process any command-line options or arguments,
-which would be weird in most cases. Prefer 'simple'.
+which would be weird in most cases. Prefer 'simpleConfig'.
 
 @since 0.2.9
 -}
@@ -214,7 +214,7 @@ program = ...
 
 main :: 'IO' ()
 main = do
-    context <- 'Core.Program.Execute.configure' ('Core.Program.Execute.fromPackage' version) 'mempty' ('complex'
+    context <- 'Core.Program.Execute.configure' ('Core.Program.Execute.fromPackage' version) 'mempty' ('complexConfig'
         [ 'Global'
             [ 'Option' "station-name" 'Nothing' ('Value' \"NAME\") ['quote'|
                 Specify an alternate radio station to connect to when performing
@@ -537,18 +537,19 @@ programName :: String
 programName = unsafePerformIO getProgName
 
 {- |
-Given a program configuration schema and the command-line arguments,
-process them into key/value pairs in a Parameters object.
+Given a program configuration schema and the command-line arguments, process
+them into key/value pairs in a Parameters object.
 
-This results in 'InvalidCommandLine' on the left side if one of the passed
-in options is unrecognized or if there is some other problem handling
-options or arguments (because at that point, we want to rabbit right back
-to the top and bail out; there's no recovering).
+This results in 'InvalidCommandLine' on the left side if one of the passed in
+options is unrecognized or if there is some other problem handling options or
+arguments (because at that point, we want to rabbit right back to the top and
+bail out; there's no recovering).
 
 This isn't something you'll ever need to call directly; it's exposed for
 testing convenience. This function is invoked when you call
 'Core.Program.Context.configure' or 'Core.Program.Execute.execute' (which
-calls 'configure' with a default @Config@ when initializing).
+calls 'Core.Program.Context.configure' with a default 'Config' when
+initializing).
 -}
 parseCommandLine :: Config -> [String] -> Either InvalidCommandLine Parameters
 parseCommandLine config argv = case config of
@@ -713,7 +714,7 @@ extractValidModes commands =
     k modes (Command longname _ options) = insertKeyValue longname options modes
     k modes _ = modes
 
-{- |
+{-
 Break the command-line apart in two steps. The first peels off the global
 options, the second below looks to see if there is a command (of fails) and
 if so, whether it has any parameters.

--- a/core-program/lib/Core/Program/Execute.hs
+++ b/core-program/lib/Core/Program/Execute.hs
@@ -207,9 +207,9 @@ Trap any exceptions coming out of the given Program action, and discard them.
 The one and only time you want this is inside an endless loop:
 
 @
-    forever $ do
-        trap_
-            ( bracket
+    'Conrol.Monad.forever' $ do
+        'trap_'
+            ( 'bracket'
                 obtainResource
                 releaseResource
                 useResource
@@ -534,7 +534,7 @@ getProgramName = do
 Retreive the current terminal's width, in characters.
 
 If you are outputting an object with a 'Core.Text.Untilities.Render'
-instance then you may not need this; you can instead use 'wrteR' which is
+instance then you may not need this; you can instead use 'writeR' which is
 aware of the width of your terminal and will reflow (in as much as the
 underlying type's @Render@ instance lets it).
 -}
@@ -580,11 +580,11 @@ Write the supplied @Bytes@ to the given @Handle@. Note that in contrast to
 'write' we don't output a trailing newline.
 
 @
-    'output' h b
+    'outputEntire' h b
 @
 
 Do /not/ use this to output to @stdout@ as that would bypass the mechanism
-used by the 'write'*, 'event', and 'debug'* functions to sequence output
+used by the 'write'*, 'info', and 'debug'* functions to sequence output
 correctly. If you wish to write to the terminal use:
 
 @
@@ -666,7 +666,7 @@ of the total elapsed program time, then fork a new thread for your worker and
 reset the timer there.
 
 @
-    'forkThread' $ do
+    'Core.Program.Threads.forkThread' $ do
         'resetTimer'
         ...
 @

--- a/core-program/lib/Core/Program/Logging.hs
+++ b/core-program/lib/Core/Program/Logging.hs
@@ -98,7 +98,7 @@ all output to terminal down a single thread-safe channel. Output will be
 written in the order it was executed, and (so long as you don't use the
 @stdout@ Handle directly yourself) your terminal output will be sound.
 
-Passing @--verbose@ on the command-line of your program will cause 'event' to
+Passing @--verbose@ on the command-line of your program will cause 'info' to
 write its tracing messages to the terminal. This shares the same output
 channel as the 'write'@*@ functions and will /not/ cause corruption of your
 program's normal output.
@@ -419,12 +419,12 @@ isInternal level = case level of
 
 {- |
 Output a debugging message formed from a label and a value. This is like
-'event' above but for the (rather common) case of needing to inspect or record
+'info' above but for the (rather common) case of needing to inspect or record
 the value of a variable when debugging code. This:
 
 @
-    'setProgramName' \"hello\"
-    name <- 'getProgramName'
+    'Core.Program.Execute.setProgramName' \"hello\"
+    name <- 'Core.Program.Execute.getProgramName'
     'debug' \"programName\" name
 @
 

--- a/core-program/lib/Core/Program/Metadata.hs
+++ b/core-program/lib/Core/Program/Metadata.hs
@@ -48,7 +48,7 @@ will give you a 'Version' with that value:
 
 main :: 'IO' ()
 main = do
-    context <- 'Core.Program.Execute.configure' \"1.0\" 'Core.Program.Execute.None' ('Core.Program.Arguments.simple' ...
+    context <- 'Core.Program.Execute.configure' \"1.0\" 'Core.Program.Execute.None' ('Core.Program.Arguments.simpleConfig' ...
 @
 
 For more complex usage you can populate a 'Version' object using the
@@ -90,8 +90,9 @@ your project:
 
 version :: 'Version' version = $('fromPackage')
 
-main :: 'IO' () main = do context <- 'Core.Program.Execute.configure' version
-'Core.Program.Execute.None' ('Core.Program.Arguments.simple' ...
+main :: 'IO' ()
+main = do
+    context <- 'Core.Program.Execute.configure' version 'Core.Program.Execute.None' ('Core.Program.Arguments.simpleConfig' ...
 @
 
 (Using Template Haskell slows down compilation of this file, but the upside of

--- a/core-program/lib/Core/Program/Threads.hs
+++ b/core-program/lib/Core/Program/Threads.hs
@@ -392,7 +392,7 @@ timeouts:
 
 @
     'raceThreads_'
-        ('sleepThread' 300)
+        ('Core.Program.Execute.sleepThread' 300)
         (do
             -- We expect this to complete within 5 minutes.
             performAction

--- a/core-program/lib/Core/Program/Unlift.hs
+++ b/core-program/lib/Core/Program/Unlift.hs
@@ -72,9 +72,9 @@ main = 'execute' $ do
 
         runProgram $ do
             -- now \"unlifted\" back to Program monad!
-            'event' \"Starting compile...\"
-            'event' \"Nah. Changed our minds\"
-            'event' \"Ok, fine, compile the thing\"
+            'info' \"Starting compile...\"
+            'info' \"Nah. Changed our minds\"
+            'info' \"Ok, fine, compile the thing\"
 
         -- more IO
         result <- compileSourceCode source

--- a/core-program/lib/Core/System/Pretty.hs
+++ b/core-program/lib/Core/System/Pretty.hs
@@ -1,6 +1,6 @@
 {-# OPTIONS_HADDOCK not-home #-}
 
--- | Re-exports of combinators for use when building 'Render' instances.
+-- | Re-exports of combinators for use when building 'Core.Text.Utilities.Render' instances.
 module Core.System.Pretty (
     -- * Pretty Printing
 


### PR DESCRIPTION
Realized a large number of the Haddock hyperlinks were incorrect or had atrophied through renames. Finally worked out how to read the warning output from the `stack haddock` command and do something about it.