### PR TITLE
When sending errors include HTTP status code

### DIFF
--- a/core-telemetry/package.yaml
+++ b/core-telemetry/package.yaml
@@ -1,5 +1,5 @@
 name: core-telemetry
-version: 0.2.0.3
+version: 0.2.0.4
 synopsis: Advanced telemetry
 description: |
   This is part of a library to help build command-line programs, both tools and


### PR DESCRIPTION
It turned out we weren't sending `response.status_code` to the telemetry channel when an error was encountered. We sent `error` but not the HTTP 500 or whatever.

Also, we were sending it as a string, and while Honeycomb seems to allows that, other specs want it numeric and so make both the normal path and the error path both report the metric as a number.