### PR TITLE
Add ability to send a span in isolation

### DIFF
--- a/core-telemetry/core-telemetry.cabal
+++ b/core-telemetry/core-telemetry.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           core-telemetry
-version:        0.2.0.4
+version:        0.2.1.0
 synopsis:       Advanced telemetry
 description:    This is part of a library to help build command-line programs, both tools and
                 longer-running daemons.

--- a/core-telemetry/lib/Core/Telemetry/Observability.hs
+++ b/core-telemetry/lib/Core/Telemetry/Observability.hs
@@ -150,6 +150,7 @@ module Core.Telemetry.Observability (
     Label,
     encloseSpan,
     setStartTime,
+    sendSpan,
 
     -- * Creating telemetry
     MetricValue,
@@ -450,6 +451,61 @@ encloseSpan label action = do
         case result of
             Left e -> Safe.throw e
             Right value -> pure value
+
+{- |
+Send a span value up by hand.
+
+Most times, you don't need this. You're much better off using
+
+@
+'beginTrace' $ do
+  'encloseSpan' "Launch Missiles" launchMissiles
+@
+
+This handles a number of convenient things for you, and takes care of a few edge
+cases.
+
+However, life is not kind, and sometimes bad things happen to good abstractions.
+Maybe you're tracing your build system, which isn't obliging enough to be all
+contained in one Haskell process, but is a half-dozen steps shotgunned across
+several different processes. In situations like this, it's useful to be able to
+generate a Trace Id and Span ID, use that as the parent across several different
+process executions, hanging children spans off of this as you go, then manually
+send up the root span at the end of it all.
+
+This gets you nice graphs and charts in your telemetry, even in somewhat hostile
+environments.
+
+Note that this function _deliberately_ does not pay attention to values in your
+Program monad. The assumption here is that you're doing something non-standard,
+so you need to break convention a bit.
+-}
+sendSpan :: Label -> Trace -> Span -> Maybe Rope -> Maybe Span -> TimeStamp -> [MetricValue] -> Program τ ()
+sendSpan label traceId spanId serviceName parentId start meta = do
+    context <- getContext
+    liftIO $ do
+        finish <- getCurrentTimeNanoseconds
+        let meta' = List.foldl' f emptyMap meta
+            tel = telemetryChannelFrom context
+            datum' =
+                emptyDatum
+                    { spanIdentifierFrom = Just spanId
+                    , spanNameFrom = label
+                    , serviceNameFrom = serviceName
+                    , spanTimeFrom = start
+                    , traceIdentifierFrom = Just traceId
+                    , parentIdentifierFrom = parentId
+                    , durationFrom = Just (unTimeStamp finish - unTimeStamp start)
+                    , attachedMetadataFrom = meta'
+                    }
+         in atomically $ do
+                writeTQueue tel (Just datum')
+  where
+    f :: Map JsonKey JsonValue -> MetricValue -> Map JsonKey JsonValue
+    f acc (MetricValue k@(JsonKey text) v) =
+        if nullRope text
+            then error "Empty metric field name not allowed"
+            else insertKeyValue k v acc
 
 {- |
 Start a new trace. A random identifier will be generated.

--- a/core-telemetry/lib/Core/Telemetry/Observability.hs
+++ b/core-telemetry/lib/Core/Telemetry/Observability.hs
@@ -459,19 +459,20 @@ Most times, you don't need this. You're much better off using
 
 @
 'beginTrace' $ do
-  'encloseSpan' "Launch Missiles" launchMissiles
+    'encloseSpan' "Launch Missiles" launchMissiles
 @
 
 This handles a number of convenient things for you, and takes care of a few edge
 cases.
 
-However, life is not kind, and sometimes bad things happen to good abstractions.
-Maybe you're tracing your build system, which isn't obliging enough to be all
-contained in one Haskell process, but is a half-dozen steps shotgunned across
-several different processes. In situations like this, it's useful to be able to
-generate a Trace Id and Span ID, use that as the parent across several different
-process executions, hanging children spans off of this as you go, then manually
-send up the root span at the end of it all.
+However, life is not kind, and sometimes bad things happen to good
+abstractions.  Maybe you're tracing your build system, which isn't obliging
+enough to be all contained in one Haskell process, but is a half-dozen steps
+shotgunned across several different processes. In situations like this, it's
+useful to be able to generate a Trace identifier and Span identifier, use that
+as the parent across several different process executions, hanging children
+spans off of this as you go, then manually send up the root span at the end of
+it all.
 
 This gets you nice graphs and charts in your telemetry, even in somewhat hostile
 environments.
@@ -479,6 +480,8 @@ environments.
 Note that this function _deliberately_ does not pay attention to values in your
 Program monad. The assumption here is that you're doing something non-standard,
 so you need to break convention a bit.
+
+@since 0.2.1
 -}
 sendSpan :: Label -> Trace -> Span -> Maybe Rope -> Maybe Span -> TimeStamp -> [MetricValue] -> Program τ ()
 sendSpan label traceId spanId serviceName parentId start meta = do

--- a/core-telemetry/package.yaml
+++ b/core-telemetry/package.yaml
@@ -1,5 +1,5 @@
 name: core-telemetry
-version: 0.2.0.4
+version: 0.2.1.0
 synopsis: Advanced telemetry
 description: |
   This is part of a library to help build command-line programs, both tools and


### PR DESCRIPTION
I added a function, so minor version bump is at hand.

I decided _not_ to fold this function in to existing code, as it's deliberately disrespecting the cascade path that Unbeliever set up.

Besides, having all the fields of `Datum` broken out like this would _add_ noise, rather than reduce it.