### PR TITLE
Create root spans allowing for override of Span identifier

### DIFF
--- a/core-telemetry/core-telemetry.cabal
+++ b/core-telemetry/core-telemetry.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           core-telemetry
-version:        0.2.1.0
+version:        0.2.1.1
 synopsis:       Advanced telemetry
 description:    This is part of a library to help build command-line programs, both tools and
                 longer-running daemons.

--- a/core-telemetry/lib/Core/Telemetry/Observability.hs
+++ b/core-telemetry/lib/Core/Telemetry/Observability.hs
@@ -144,6 +144,7 @@ module Core.Telemetry.Observability (
     Span (..),
     beginTrace,
     usingTrace,
+    usingTrace',
     setServiceName,
 
     -- * Spans
@@ -569,6 +570,24 @@ usingTrace trace parent action = do
     internal ("parent = " <> unSpan parent)
 
     encloseTrace trace (Just parent) action
+
+{- |
+Create a new trace with the specified 'Trace' identifier. Unlike 'usingTrace'
+this does /not/ set the parent 'Span' identifier, thereby marking this as a
+new trace and causing the first span enclosed within this trace to be
+considered the \"root\" span of the trace. This is unusual and should only
+expected to be used in concert with 'sendSpan' to create a root spans in
+asynchronous processes after all the child spans have already been composed
+and sent.
+
+@since 0.2.1
+-}
+usingTrace' :: Trace -> Program τ α -> Program τ α
+usingTrace' trace action = do
+    internal "Using trace"
+    internal ("trace = " <> unTrace trace)
+
+    encloseTrace trace Nothing action
 
 encloseTrace :: Trace -> Maybe Span -> Program τ α -> Program τ α
 encloseTrace trace possibleParent action = do

--- a/core-telemetry/lib/Core/Telemetry/Observability.hs
+++ b/core-telemetry/lib/Core/Telemetry/Observability.hs
@@ -151,7 +151,6 @@ module Core.Telemetry.Observability (
     Label,
     encloseSpan,
     setStartTime,
-    sendSpan,
 
     -- * Creating telemetry
     MetricValue,
@@ -456,60 +455,12 @@ encloseSpan label action = do
 {- |
 Send a span value up by hand.
 
-Most times, you don't need this. You're much better off using
-
-@
-'beginTrace' $ do
-    'encloseSpan' "Launch Missiles" launchMissiles
-@
-
 This handles a number of convenient things for you, and takes care of a few edge
 cases.
 
-However, life is not kind, and sometimes bad things happen to good
-abstractions.  Maybe you're tracing your build system, which isn't obliging
-enough to be all contained in one Haskell process, but is a half-dozen steps
-shotgunned across several different processes. In situations like this, it's
-useful to be able to generate a Trace identifier and Span identifier, use that
-as the parent across several different process executions, hanging children
-spans off of this as you go, then manually send up the root span at the end of
-it all.
-
-This gets you nice graphs and charts in your telemetry, even in somewhat hostile
-environments.
-
-Note that this function _deliberately_ does not pay attention to values in your
-Program monad. The assumption here is that you're doing something non-standard,
-so you need to break convention a bit.
 
 @since 0.2.1
 -}
-sendSpan :: Label -> Trace -> Span -> Maybe Rope -> Maybe Span -> TimeStamp -> [MetricValue] -> Program τ ()
-sendSpan label traceId spanId serviceName parentId start meta = do
-    context <- getContext
-    liftIO $ do
-        finish <- getCurrentTimeNanoseconds
-        let meta' = List.foldl' f emptyMap meta
-            tel = telemetryChannelFrom context
-            datum' =
-                emptyDatum
-                    { spanIdentifierFrom = Just spanId
-                    , spanNameFrom = label
-                    , serviceNameFrom = serviceName
-                    , spanTimeFrom = start
-                    , traceIdentifierFrom = Just traceId
-                    , parentIdentifierFrom = parentId
-                    , durationFrom = Just (unTimeStamp finish - unTimeStamp start)
-                    , attachedMetadataFrom = meta'
-                    }
-         in atomically $ do
-                writeTQueue tel (Just datum')
-  where
-    f :: Map JsonKey JsonValue -> MetricValue -> Map JsonKey JsonValue
-    f acc (MetricValue k@(JsonKey text) v) =
-        if nullRope text
-            then error "Empty metric field name not allowed"
-            else insertKeyValue k v acc
 
 {- |
 Start a new trace. A random identifier will be generated.
@@ -579,6 +530,33 @@ considered the \"root\" span of the trace. This is unusual and should only
 expected to be used in concert with the 'setIdentifierSpan' override to create
 a root spans in asynchronous processes /after/ all the child spans have
 already been composed and sent.
+
+Most times, you don't need this. You're much better off using 'beginTrace' to
+create a root span. However, life is not kind, and sometimes bad things happen
+to good abstractions. Maybe you're tracing your build system, which isn't
+obliging enough to be all contained in one Haskell process, but is a
+half-dozen steps shotgunned across several different processes. In situations
+like this, it's useful to be able to generate a 'Trace' identifier and 'Span'
+identifier, use that as the parent across several different process
+executions, hanging children spans off of this as you go, then manually send
+up the root span at the end of it all.
+
+@
+    trace <- ...
+    unique <- ...
+
+    -- many child spans in other processes have used these as trace
+    -- identifiers and parent span identifier. Now form the root span thereby
+    -- finishing the trace.
+
+    'usingTrace'' trace $ do
+        'encloseSpan' \"Launch Missiles\" $ do
+            'setStartTime' start
+            'setIdentifierSpan' unique
+            'telemetry'
+                [ 'metric' ...
+                ]
+@
 
 @since 0.2.1
 -}

--- a/core-telemetry/lib/Core/Telemetry/Observability.hs
+++ b/core-telemetry/lib/Core/Telemetry/Observability.hs
@@ -576,9 +576,9 @@ Create a new trace with the specified 'Trace' identifier. Unlike 'usingTrace'
 this does /not/ set the parent 'Span' identifier, thereby marking this as a
 new trace and causing the first span enclosed within this trace to be
 considered the \"root\" span of the trace. This is unusual and should only
-expected to be used in concert with 'sendSpan' to create a root spans in
-asynchronous processes after all the child spans have already been composed
-and sent.
+expected to be used in concert with the 'setIdentifierSpan' override to create
+a root spans in asynchronous processes /after/ all the child spans have
+already been composed and sent.
 
 @since 0.2.1
 -}

--- a/core-telemetry/package.yaml
+++ b/core-telemetry/package.yaml
@@ -1,5 +1,5 @@
 name: core-telemetry
-version: 0.2.1.0
+version: 0.2.1.1
 synopsis: Advanced telemetry
 description: |
   This is part of a library to help build command-line programs, both tools and


### PR DESCRIPTION
Presents an alternative API to that suggested by https://github.com/aesiniath/unbeliever/pull/125. The idea here is that we would create a trace but without specifying the parent, using a new `usingTrace'` function. Then we would re-use the existing `encloseSpan` function augmented by a new override `setIdentifierSpan` function, resulting in a shape like this:

```haskell
    usingTrace' trace $ do
        encloseSpan "Eat your vegetables" $ do
            setStartTime start 
            setIdentifierSpan predetermined
            telemetry
                [ metric "sugar" False
                ]

```
where `trace` and `predetermined` are the received and already created Trace and Span identifiers, respectively.

While not quite as compact as the `sendSpan` idea proposed by @TheWizardTower, I'd like to suggest that by reusing existing `encloseSpan` machinery we keep the API surface a bit more contained. `setStartTime` is already an outlier as an override, and so this usage probably makes sense.