### PR TITLE
Send "meta.kind" field with root spans

### DIFF
--- a/core-telemetry/core-telemetry.cabal
+++ b/core-telemetry/core-telemetry.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           core-telemetry
-version:        0.2.0.4
+version:        0.2.0.5
 synopsis:       Advanced telemetry
 description:    This is part of a library to help build command-line programs, both tools and
                 longer-running daemons.

--- a/core-telemetry/lib/Core/Telemetry/Honeycomb.hs
+++ b/core-telemetry/lib/Core/Telemetry/Honeycomb.hs
@@ -177,7 +177,7 @@ convertDatumToJson datum =
             Just value -> insertKeyValue "trace.span_id" (JsonString (unSpan value)) meta1
 
         meta3 = case parent of
-            Nothing -> meta2
+            Nothing -> insertKeyValue "meta.kind" (JsonString "root") meta2
             Just value -> insertKeyValue "trace.parent_id" (JsonString (unSpan value)) meta2
 
         meta4 = case trace of

--- a/core-telemetry/package.yaml
+++ b/core-telemetry/package.yaml
@@ -1,5 +1,5 @@
 name: core-telemetry
-version: 0.2.0.4
+version: 0.2.0.5
 synopsis: Advanced telemetry
 description: |
   This is part of a library to help build command-line programs, both tools and


### PR DESCRIPTION
The "meta.kind" field should be populated with a value to ensure the Home screen and Traces are managed to their fullest extent. https://docs.honeycomb.io/working-with-your-data/settings/definitions/#metadata-kind

In consultation with Honeycomb, we've confirmed a value of of `"root"` should be set for root spans:

> Kind is a way to annotate spans within a trace so that edges between components can be identified later. Values can be:
> - root - the start of a trace, as you say another way to mark the start in addition to a span having no parent
> - subroot - the first span from a service within a trace, used in some of Honeycombs built-ins to show you different services within a single environment
> - leaf - some of the beelines mark spans that are the last event from a service (maybe the end of a trace, maybe an end to a sub-process, or maybe the last span before an interaction with another service)
> - mid - not a root, subroot, or leaf; an interstitial event between a service's beginning of participation in a trace and the end

It's not yet clear just how much value these provide. This patch adds `"root"` for when we send a span without a parent span.