### PR TITLE
Refine HTTP request fields in telemetry

### DIFF
--- a/core-webserver-warp/core-webserver-warp.cabal
+++ b/core-webserver-warp/core-webserver-warp.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           core-webserver-warp
-version:        0.1.1.4
+version:        0.1.1.5
 synopsis:       Interoperability with Wai/Warp
 description:    This is part of a library to help build command-line programs, both tools and
                 longer-running daemons.

--- a/core-webserver-warp/lib/Core/Webserver/Warp.hs
+++ b/core-webserver-warp/lib/Core/Webserver/Warp.hs
@@ -137,19 +137,18 @@ contextFromRequest request = Vault.lookup requestContextKey (vault request)
 loggingMiddleware :: Context τ -> Application -> Application
 loggingMiddleware (context0 :: Context τ) application request sendResponse = do
     let path = intoRope (rawPathInfo request)
+        query = intoRope (rawQueryString request)
+        method = intoRope (requestMethod request)
 
     subProgram context0 $ do
         resumeTraceIf request $ do
             encloseSpan path $ do
                 context1 <- getContext
 
-                -- we could call `telemetry` here with these values, but since
-                -- we call into nested actions which could clear the state
-                -- without starting a new span, we duplicate adding them below
-                -- to ensure they get passed through.
-
-                let query = intoRope (rawQueryString request)
-                    method = intoRope (requestMethod request)
+                -- we could call `telemetry` here with the request values, but
+                -- since we call into nested actions which could clear the
+                -- state without starting a new span, we duplicate adding them
+                -- below to ensure they get passed through.
 
                 liftIO $ do
                     -- The below wires the context in the request's `vault`. As the type of

--- a/core-webserver-warp/lib/Core/Webserver/Warp.hs
+++ b/core-webserver-warp/lib/Core/Webserver/Warp.hs
@@ -149,7 +149,6 @@ loggingMiddleware (context0 :: Context τ) application request sendResponse = do
                 -- to ensure they get passed through.
 
                 let query = intoRope (rawQueryString request)
-                    path' = path <> query
                     method = intoRope (requestMethod request)
 
                 liftIO $ do
@@ -167,7 +166,8 @@ loggingMiddleware (context0 :: Context τ) application request sendResponse = do
                             subProgram context1 $ do
                                 telemetry
                                     [ metric "request.method" method
-                                    , metric "request.path" path'
+                                    , metric "request.path" path
+                                    , metric "request.query" query
                                     , metric "response.status_code" code
                                     ]
 
@@ -185,7 +185,8 @@ loggingMiddleware (context0 :: Context τ) application request sendResponse = do
                                 debug "e" text
                                 telemetry
                                     [ metric "request.method" method
-                                    , metric "request.path" path'
+                                    , metric "request.path" path
+                                    , metric "request.query" query
                                     , metric "response.status_code" code
                                     , metric "error" text
                                     ]
@@ -243,8 +244,8 @@ resumeTraceIf request action =
     case extractTraceParent request of
         Nothing -> do
             beginTrace action
-        Just (trace, unique) -> do
-            usingTrace trace unique action
+        Just (trace, parent) -> do
+            usingTrace trace parent action
 
 --
 -- This is wildly inefficient. Surely warp must provide a better way to search

--- a/core-webserver-warp/package.yaml
+++ b/core-webserver-warp/package.yaml
@@ -1,5 +1,5 @@
 name: core-webserver-warp
-version: 0.1.1.4
+version: 0.1.1.5
 synopsis: Interoperability with Wai/Warp
 description: |
   This is part of a library to help build command-line programs, both tools and


### PR DESCRIPTION
Including the query string in the "`request.path`" telemetry field was a mistake. We need to separate them out as "`request.query`" if present. This results in the span "`name`" and `"request.path`" being the same value, but that's fine. Allows proper use of the Route field on the Honeycomb home screen.