### PR TITLE
Only send query string value if present

### DIFF
--- a/core-telemetry/core-telemetry.cabal
+++ b/core-telemetry/core-telemetry.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           core-telemetry
-version:        0.2.2.0
+version:        0.2.3.0
 synopsis:       Advanced telemetry
 description:    This is part of a library to help build command-line programs, both tools and
                 longer-running daemons.

--- a/core-telemetry/lib/Core/Telemetry/Observability.hs
+++ b/core-telemetry/lib/Core/Telemetry/Observability.hs
@@ -267,6 +267,9 @@ instance Telemetry Rope where
 instance Telemetry String where
     metric k v = MetricValue (JsonKey k) (JsonString (intoRope v))
 
+instance Telemetry () where
+    metric k _ = MetricValue (JsonKey k) JsonNull
+
 {- |
 The usual warning about assuming the @ByteString@ is ASCII or UTF-8 applies
 here. Don't use this to send binary mush.

--- a/core-telemetry/package.yaml
+++ b/core-telemetry/package.yaml
@@ -1,5 +1,5 @@
 name: core-telemetry
-version: 0.2.2.0
+version: 0.2.3.0
 synopsis: Advanced telemetry
 description: |
   This is part of a library to help build command-line programs, both tools and

--- a/core-webserver-warp/core-webserver-warp.cabal
+++ b/core-webserver-warp/core-webserver-warp.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           core-webserver-warp
-version:        0.1.1.5
+version:        0.1.1.6
 synopsis:       Interoperability with Wai/Warp
 description:    This is part of a library to help build command-line programs, both tools and
                 longer-running daemons.
@@ -42,7 +42,7 @@ library
     , bytestring
     , core-data
     , core-program >=0.4.6
-    , core-telemetry >=0.2.0
+    , core-telemetry >=0.2.3
     , core-text
     , http-types
     , http2

--- a/core-webserver-warp/lib/Core/Webserver/Warp.hs
+++ b/core-webserver-warp/lib/Core/Webserver/Warp.hs
@@ -166,7 +166,7 @@ loggingMiddleware (context0 :: Context τ) application request sendResponse = do
                                 telemetry
                                     [ metric "request.method" method
                                     , metric "request.path" path
-                                    , metric "request.query" query
+                                    , if nullRope query then metric "request.query" () else metric "request.query" query
                                     , metric "response.status_code" code
                                     ]
 
@@ -185,7 +185,7 @@ loggingMiddleware (context0 :: Context τ) application request sendResponse = do
                                 telemetry
                                     [ metric "request.method" method
                                     , metric "request.path" path
-                                    , metric "request.query" query
+                                    , if nullRope query then metric "request.query" () else metric "request.query" query
                                     , metric "response.status_code" code
                                     , metric "error" text
                                     ]

--- a/core-webserver-warp/package.yaml
+++ b/core-webserver-warp/package.yaml
@@ -1,5 +1,5 @@
 name: core-webserver-warp
-version: 0.1.1.5
+version: 0.1.1.6
 synopsis: Interoperability with Wai/Warp
 description: |
   This is part of a library to help build command-line programs, both tools and
@@ -26,7 +26,7 @@ dependencies:
  - bytestring
  - core-data
  - core-program >= 0.4.6
- - core-telemetry >= 0.2.0
+ - core-telemetry >= 0.2.3
  - core-text
  - http-types
  - http2


### PR DESCRIPTION
@TheWizardTower as discussed, we probably shouldn't be sending `""` if there's no query string component to the URL. Testing shows that Honeycomb hides/ignores/drops fields with JSON `null` as the value, so this seems to accomplish the trick.