### PR TITLE
Don't clear metrics before running handler

### DIFF
--- a/core-webserver-servant/core-webserver-servant.cabal
+++ b/core-webserver-servant/core-webserver-servant.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           core-webserver-servant
-version:        0.1.1.0
+version:        0.1.1.1
 synopsis:       Interoperability with Servant
 description:    This is part of a library to help build command-line programs, both tools and
                 longer-running daemons.

--- a/core-webserver-servant/lib/Core/Webserver/Servant.hs
+++ b/core-webserver-servant/lib/Core/Webserver/Servant.hs
@@ -122,6 +122,5 @@ prepareRoutesWithContext proxy sContext (routes :: Servant.ServerT api (Program 
         let output =
                 try $
                     subProgram context $ do
-                        clearMetrics
                         program
          in Servant.Handler (ExceptT output)

--- a/core-webserver-servant/package.yaml
+++ b/core-webserver-servant/package.yaml
@@ -1,5 +1,5 @@
 name: core-webserver-servant
-version: 0.1.1.0
+version: 0.1.1.1
 synopsis: Interoperability with Servant
 description: |
   This is part of a library to help build command-line programs, both tools and


### PR DESCRIPTION
For some reason we thought we needed to clear the telemetry metrics before running the supplied handler function. This turned out to be unnecessary, because we are of course starting a new trace when we run a handler and that by definition starts with a clean slate. Calling `clearMetrics` was, however, resulting in us throwing away metrics being added by (for example) authorization machinery before the handler function was invoked. Fixed by removing the call.