### PR TITLE
Specialize exception handling functions to Program monad

### DIFF
--- a/core-program/core-program.cabal
+++ b/core-program/core-program.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           core-program
-version:        0.4.6.4
+version:        0.5.0.0
 synopsis:       Opinionated Haskell Interoperability
 description:    A library to help build command-line programs, both tools and
                 longer-running daemons.
@@ -39,6 +39,7 @@ library
       Core.Program.Arguments
       Core.Program.Context
       Core.Program.Execute
+      Core.Program.Exceptions
       Core.Program.Logging
       Core.Program.Metadata
       Core.Program.Notify

--- a/core-program/lib/Core/Program.hs
+++ b/core-program/lib/Core/Program.hs
@@ -24,6 +24,7 @@ module Core.Program
     module Core.Program.Threads,
     module Core.Program.Unlift,
     module Core.Program.Metadata,
+    module Core.Program.Exceptions,
 
     -- * Command-line argument parsing
 
@@ -48,9 +49,10 @@ module Core.Program
 where
 
 import Core.Program.Arguments
+import Core.Program.Context
+import Core.Program.Exceptions
 import Core.Program.Execute
 import Core.Program.Logging
-import Core.Program.Context
 import Core.Program.Metadata
 import Core.Program.Notify
 import Core.Program.Threads

--- a/core-program/lib/Core/Program/Context.hs
+++ b/core-program/lib/Core/Program/Context.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -40,7 +41,7 @@ module Core.Program.Context (
 import Chrono.TimeStamp (TimeStamp, getCurrentTimeNanoseconds)
 import Control.Concurrent.MVar (MVar, newEmptyMVar, newMVar, putMVar, readMVar)
 import Control.Concurrent.STM.TQueue (TQueue, newTQueueIO)
-import qualified Control.Exception.Safe as Safe (throw)
+import Control.Exception.Safe qualified as Safe (throw)
 import Control.Monad.Catch (MonadCatch, MonadMask, MonadThrow (throwM))
 import Control.Monad.Reader.Class (MonadReader (..))
 import Control.Monad.Trans.Reader (ReaderT (..))
@@ -48,18 +49,18 @@ import Core.Data.Structures
 import Core.Encoding.Json
 import Core.Program.Arguments
 import Core.Program.Metadata
-import Core.System.Base hiding (catch, throw)
+import Core.System.Base
 import Core.Text.Rope
 import Data.Foldable (foldrM)
-import System.IO (hIsTerminalDevice)
 import Data.Int (Int64)
 import Data.String (IsString)
 import Prettyprinter (LayoutOptions (..), PageWidth (..), layoutPretty)
 import Prettyprinter.Render.Text (renderIO)
-import qualified System.Console.Terminal.Size as Terminal (Window (..), size)
+import System.Console.Terminal.Size qualified as Terminal (Window (..), size)
 import System.Environment (getArgs, getProgName, lookupEnv)
 import System.Exit (ExitCode (..), exitWith)
-import qualified System.Posix.Process as Posix (exitImmediately)
+import System.IO (hIsTerminalDevice)
+import System.Posix.Process qualified as Posix (exitImmediately)
 import Prelude hiding (log)
 
 {- |
@@ -398,12 +399,10 @@ getConsoleWidth = do
             Nothing -> 80
     return columns
 
-
 getConsoleColoured :: IO Bool
 getConsoleColoured = do
     terminal <- hIsTerminalDevice stdout
     pure terminal
-
 
 {- |
 Process the command line options and arguments. If an invalid option is

--- a/core-program/lib/Core/Program/Context.hs
+++ b/core-program/lib/Core/Program/Context.hs
@@ -35,7 +35,6 @@ module Core.Program.Context (
     getContext,
     fmapContext,
     subProgram,
-    Boom (..),
 ) where
 
 import Chrono.TimeStamp (TimeStamp, getCurrentTimeNanoseconds)
@@ -529,22 +528,3 @@ handleTelemetryChoice context = do
         case target == codenameFrom exporter of
             False -> lookupExporter target exporters
             True -> Just exporter
-
-{- |
-A utility exception for those occasions when you just need to go "boom".
-
-@
-    case 'Core.Data.Structures.containsKey' \"James Bond\" agents of
-        'False' -> do
-            evilPlan
-        'True' ->  do
-            'Core.Program.Logging.write' \"No Mr Bond, I expect you to die!\"
-            'Core.System.Base.throw' 'Boom'
-@
-
-@since 0.3.2
--}
-data Boom = Boom
-    deriving (Show)
-
-instance Exception Boom

--- a/core-program/lib/Core/Program/Context.hs
+++ b/core-program/lib/Core/Program/Context.hs
@@ -163,25 +163,19 @@ application data of type @τ@ which can be retrieved with
 -- that field name as a local variable name.
 --
 data Context τ = Context
-    { -- runtime properties
-      programNameFrom :: MVar Rope
+    { programNameFrom :: MVar Rope
     , terminalWidthFrom :: Int
     , terminalColouredFrom :: Bool
     , versionFrom :: Version
-    , -- only used during initial setup
-      initialConfigFrom :: Config
+    , initialConfigFrom :: Config -- only used during initial setup
     , initialExportersFrom :: [Exporter]
-    , -- derived at startup
-      commandLineFrom :: Parameters
-    , -- operational state
-      exitSemaphoreFrom :: MVar ExitCode
+    , commandLineFrom :: Parameters -- derived at startup
+    , exitSemaphoreFrom :: MVar ExitCode
     , startTimeFrom :: MVar TimeStamp
     , verbosityLevelFrom :: MVar Verbosity
-    , -- communication channels
-      outputChannelFrom :: TQueue (Maybe Rope)
-    , telemetryChannelFrom :: TQueue (Maybe Datum)
-    , -- machinery for telemetry
-      telemetryForwarderFrom :: Maybe Forwarder
+    , outputChannelFrom :: TQueue (Maybe Rope) -- communication channels
+    , telemetryChannelFrom :: TQueue (Maybe Datum) -- machinery for telemetry
+    , telemetryForwarderFrom :: Maybe Forwarder
     , currentDatumFrom :: MVar Datum
     , applicationDataFrom :: MVar τ
     }

--- a/core-program/lib/Core/Program/Exceptions.hs
+++ b/core-program/lib/Core/Program/Exceptions.hs
@@ -1,0 +1,59 @@
+{-# LANGUAGE ImportQualifiedPost #-}
+
+module Core.Program.Exceptions where
+
+import Control.Exception qualified as Base (
+    Exception,
+ )
+import Control.Exception.Safe qualified as Safe (
+    catch,
+    throw,
+    try,
+ )
+import Core.Program.Context (
+    Program,
+ )
+
+{- |
+Catch an exception.
+
+This will /not/ catch asynchonous exceptions. If you need to that, see the
+more comprehensive exception handling facilities offered by
+__safe-exceptions__, which in turn builds on __exceptions__ and __base__).
+Note that 'Program' implements 'MonadCatch' so you can use the full power
+available there if required.
+
+@since 0.4.7
+-}
+catch :: Base.Exception ε => Program τ α -> (ε -> Program τ α) -> Program τ α
+catch = Safe.catch
+
+{- |
+Catch an exception. Instead of handling an exception in a supplied function,
+however, return from executing the sub-program with the outcome in an
+'Either', with the exception being on the 'Left' side if one is thrown. If the
+sub-program completes normally its result is in the 'Right' side.
+
+(this is a wrapper around calling __safe-exceptions__\'s
+'Control.Exceptions.Safe.try' function, which in turn wraps __exceptions__\'s
+'Control.Exceptions.try', which...)
+
+@since 0.5.0
+-}
+try :: Base.Exception ε => Program τ α -> Program τ (Either ε α)
+try = Safe.try
+
+{- |
+Throw an exception.
+
+This will be thrown as a normal synchronous exception that can be caught with
+'catch' or 'try' above.
+
+(experienced users will note that 'Program' implements 'MonadThrow' and as
+such this is just a wrapper around calling __safe-exceptions__'s
+'Control.Exceptions.Safe.throw' function)
+
+@since 0.5.0
+-}
+throw :: Base.Exception ε => ε -> Program τ α
+throw = Safe.throw

--- a/core-program/lib/Core/Program/Exceptions.hs
+++ b/core-program/lib/Core/Program/Exceptions.hs
@@ -6,7 +6,10 @@ import Control.Exception qualified as Base (
     Exception,
  )
 import Control.Exception.Safe qualified as Safe (
+    bracket,
     catch,
+    finally,
+    onException,
     throw,
     try,
  )
@@ -23,7 +26,7 @@ __safe-exceptions__, which in turn builds on __exceptions__ and __base__).
 Note that 'Program' implements 'MonadCatch' so you can use the full power
 available there if required.
 
-@since 0.4.7
+@since 0.5.0
 -}
 catch :: Base.Exception ε => Program τ α -> (ε -> Program τ α) -> Program τ α
 catch = Safe.catch
@@ -57,3 +60,45 @@ such this is just a wrapper around calling __safe-exceptions__'s
 -}
 throw :: Base.Exception ε => ε -> Program τ α
 throw = Safe.throw
+
+
+{- |
+Acquire a resource, use it, then release it back.
+
+The bracket pattern is common in Haskell for getting a resource needed for a
+computation, preforming that computation, then releasing the resource back to
+the system. Common examples are when making database connections and doing
+file or network operations, where you need to make sure you "close" the
+connection afterward before continuing the program so that scare resources
+like file handles are released.
+
+Note that this does /not/ catch the exception if one is thrown! The finalizer
+will run, but then the exception will continue to propogate its way out of
+your program's call stack.
+
+@since 0.5.0
+-}
+bracket :: Program τ ρ -> (ρ -> Program τ γ) -> (ρ -> Program τ α) -> Program τ α
+bracket = Safe.bracket
+
+{- |
+Run an action and then, run a finalizer afterwards. The second action will run
+whether or not an exception was raised by the first one. This is like
+'bracket' above, but can be used when you know you have cleanup steps to take
+after your computation which /do/ have to be run even if (especially if!) an
+exception is thrown but that that cleanup doesn't depend on the result of that
+computation or the resources used to do it.
+
+@since 0.5.0
+-}
+finally :: Program τ α -> Program τ β -> Program τ α
+finally = Safe.finally
+
+{- |
+Run an action and the, if  an exception was raised (and only if), run the
+second action.
+
+@since 0.5.0
+-}
+onException :: Program τ α -> Program τ β -> Program τ α
+onException = Safe.onException

--- a/core-program/lib/Core/Program/Exceptions.hs
+++ b/core-program/lib/Core/Program/Exceptions.hs
@@ -65,16 +65,17 @@ throw = Safe.throw
 {- |
 Acquire a resource, use it, then release it back.
 
-The bracket pattern is common in Haskell for getting a resource needed for a
-computation, preforming that computation, then releasing the resource back to
-the system. Common examples are when making database connections and doing
+The bracket pattern is common in Haskell for getting a resource @ρ@ needed for
+a computation, preforming that computation, then releasing the resource back
+to the system. Common examples are when making database connections and doing
 file or network operations, where you need to make sure you "close" the
 connection afterward before continuing the program so that scare resources
 like file handles are released.
 
 Note that this does /not/ catch the exception if one is thrown! The finalizer
 will run, but then the exception will continue to propogate its way out of
-your program's call stack.
+your program's call stack. Note also that the result of the cleanup action @γ@
+is ignored.
 
 @since 0.5.0
 -}

--- a/core-program/lib/Core/Program/Exceptions.hs
+++ b/core-program/lib/Core/Program/Exceptions.hs
@@ -68,8 +68,8 @@ Catch an exception.
 This will /not/ catch asynchonous exceptions. If you need to that, see the
 more comprehensive exception handling facilities offered by
 __safe-exceptions__, which in turn builds on __exceptions__ and __base__).
-Note that 'Program' implements 'MonadCatch' so you can use the full power
-available there if required.
+Note that 'Program' implements 'Control.Monad.Catch.MonadCatch' so you can use
+the full power available there if required.
 
 @since 0.5.0
 -}
@@ -97,9 +97,9 @@ Throw an exception.
 This will be thrown as a normal synchronous exception that can be caught with
 'catch' or 'try' above.
 
-(experienced users will note that 'Program' implements 'MonadThrow' and as
-such this is just a wrapper around calling __safe-exceptions__'s
-'Control.Exceptions.Safe.throw' function)
+(experienced users will note that 'Program' implements
+'Control.Monad.Catch.MonadThrow' and as such this is just a wrapper around
+calling __safe-exceptions__'s 'Control.Exceptions.Safe.throw' function)
 
 @since 0.5.0
 -}
@@ -135,7 +135,7 @@ it:
 Note that 'bracket' does /not/ catch the exception if one is thrown! The
 finalizer will run, but then the exception will continue to propogate its way
 out of your program's call stack. Note also that the result of the cleanup
-action @γ@ is ignored.
+action @γ@ is ignored (it can be @()@ or anythign else; it will be discarded).
 
 @since 0.5.0
 -}
@@ -148,7 +148,8 @@ whether or not an exception was raised by the first one. This is like
 'bracket' above, but can be used when you know you have cleanup steps to take
 after your computation which /do/ have to be run even if (especially if!) an
 exception is thrown but that that cleanup doesn't depend on the result of that
-computation or the resources used to do it.
+computation or the resources used to do it. The result @γ@ of the subsequent
+action is ignored.
 
 @since 0.5.0
 -}
@@ -157,7 +158,8 @@ finally = Safe.finally
 
 {- |
 Run an action and then, if an exception was raised (and only if an exception
-was raised), run the second action.
+was raised), run the second action. The result @γ@ of the subsequent action is
+is ignored.
 
 @since 0.5.0
 -}

--- a/core-program/lib/Core/Program/Execute.hs
+++ b/core-program/lib/Core/Program/Execute.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
@@ -135,7 +136,6 @@ import Control.Exception.Safe qualified as Safe (
     catch,
     catchesAsync,
     throw,
-    try,
  )
 import Control.Monad (
     void,
@@ -146,6 +146,7 @@ import Control.Monad.Reader.Class (MonadReader (ask))
 import Core.Data.Structures
 import Core.Program.Arguments
 import Core.Program.Context
+import Core.Program.Exceptions
 import Core.Program.Logging
 import Core.Program.Signal
 import Core.System.Base (
@@ -908,47 +909,3 @@ otherwise a programmer error.
 -}
 invalid :: Program τ α
 invalid = error "Invalid State"
-
-{- |
-Catch an exception.
-
-This will /not/ catch asynchonous exceptions. If you need to that, see the
-more comprehensive exception handling facilities offered by
-__safe-exceptions__, which in turn builds on __exceptions__ and __base__).
-Note that 'Program' implements 'MonadCatch' so you can use the full power
-available there if required.
-
-@since 0.4.7
--}
-catch :: Exception ε => Program τ α -> (ε -> Program τ α) -> Program τ α
-catch = Safe.catch
-
-{- |
-Catch an exception. Instead of handling an exception in a supplied function,
-however, return from executing the sub-program with the outcome in an
-'Either', with the exception being on the 'Left' side if one is thrown. If the
-sub-program completes normally its result is in the 'Right' side.
-
-(this is a wrapper around calling __safe-exceptions__\'s
-'Control.Exceptions.Safe.try' function, which in turn wraps __exceptions__\'s
-'Control.Exceptions.try', which...)
-
-@since 0.4.7
--}
-try :: Exception ε => Program τ α -> Program τ (Either ε α)
-try = Safe.try
-
-{- |
-Throw an exception.
-
-This will be thrown as a normal synchronous exception that can be caught with
-'catch' or 'try' above.
-
-(experienced users will note that 'Program' implements 'MonadThrow' and as
-such this is just a wrapper around calling __safe-exceptions__'s
-'Control.Exceptions.Safe.throw' function)
-
-@since 0.4.7
--}
-throw :: Exception ε => ε -> Program τ α
-throw = Safe.throw

--- a/core-program/lib/Core/Program/Threads.hs
+++ b/core-program/lib/Core/Program/Threads.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
@@ -43,8 +44,8 @@ module Core.Program.Threads (
     unThread,
 ) where
 
-import Control.Concurrent.Async (Async, AsyncCancelled, cancel)
-import qualified Control.Concurrent.Async as Async (
+import Control.Concurrent.Async (Async, AsyncCancelled)
+import Control.Concurrent.Async qualified as Async (
     async,
     cancel,
     concurrently,
@@ -59,7 +60,7 @@ import Control.Concurrent.MVar (
     newMVar,
     readMVar,
  )
-import qualified Control.Exception.Safe as Safe (catch, catchAsync)
+import Control.Exception.Safe qualified as Safe (catch, catchAsync, throw)
 import Control.Monad (
     void,
  )
@@ -139,7 +140,7 @@ forkThread program = do
                             subProgram context' $ do
                                 warn "Uncaught exception in thread"
                                 debug "e" text
-                            throw e
+                            Safe.throw e
                 )
 
         return (Thread a)
@@ -167,8 +168,8 @@ waitThread (Thread a) = liftIO $ do
     Safe.catchAsync
         (Async.wait a)
         ( \(e :: AsyncCancelled) -> do
-            cancel a
-            throw e
+            Async.cancel a
+            Safe.throw e
         )
 
 {- |
@@ -219,8 +220,8 @@ waitThread' (Thread a) = liftIO $ do
             pure result
         )
         ( \(e :: AsyncCancelled) -> do
-            cancel a
-            throw e
+            Async.cancel a
+            Safe.throw e
         )
 
 {- |
@@ -273,8 +274,8 @@ waitThreads' ts = liftIO $ do
             pure results
         )
         ( \(e :: AsyncCancelled) -> do
-            mapM_ cancel as
-            throw e
+            mapM_ Async.cancel as
+            Safe.throw e
         )
 
 {- |

--- a/core-program/lib/Core/System/Base.hs
+++ b/core-program/lib/Core/System/Base.hs
@@ -33,21 +33,19 @@ module Core.System.Base (
     -- | Re-exported from "Control.Exception.Safe" in the __safe-exceptions__ package:
     Exception (..),
     SomeException,
-    throw,
     impureThrow,
     bracket,
-    catch,
     finally,
 ) where
 
-import Control.Exception.Safe (
+import Control.Exception (
     Exception (..),
     SomeException,
+ )
+import Control.Exception.Safe (
     bracket,
-    catch,
     finally,
     impureThrow,
-    throw,
  )
 import Control.Monad.IO.Class (MonadIO, liftIO)
 import System.IO (Handle, IOMode (..), hFlush, stderr, stdin, stdout, withFile)

--- a/core-program/package.yaml
+++ b/core-program/package.yaml
@@ -1,5 +1,5 @@
 name: core-program
-version: 0.4.6.4
+version: 0.5.0.0
 synopsis: Opinionated Haskell Interoperability
 description: |
   A library to help build command-line programs, both tools and
@@ -56,6 +56,7 @@ library:
    - Core.Program.Arguments
    - Core.Program.Context
    - Core.Program.Execute
+   - Core.Program.Exceptions
    - Core.Program.Logging
    - Core.Program.Metadata
    - Core.Program.Notify

--- a/core-telemetry/core-telemetry.cabal
+++ b/core-telemetry/core-telemetry.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           core-telemetry
-version:        0.2.3.0
+version:        0.2.3.1
 synopsis:       Advanced telemetry
 description:    This is part of a library to help build command-line programs, both tools and
                 longer-running daemons.
@@ -54,7 +54,7 @@ library
     , bytestring
     , chronologique
     , core-data >=0.3.2.2
-    , core-program >=0.4.6.1
+    , core-program >=0.5.0
     , core-text >=0.3.6.0
     , exceptions
     , http-streams

--- a/core-telemetry/lib/Core/Telemetry/Honeycomb.hs
+++ b/core-telemetry/lib/Core/Telemetry/Honeycomb.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralisedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# OPTIONS_GHC -fno-warn-unused-imports #-}
 
@@ -34,30 +35,30 @@ module Core.Telemetry.Honeycomb (
     honeycombExporter,
 ) where
 
+import Control.Exception.Safe qualified as Safe (catch, throw, finally)
 import Core.Data.Structures (Map, fromMap, insertKeyValue, intoMap, lookupKeyValue)
 import Core.Encoding.Json
 import Core.Program.Arguments
 import Core.Program.Context
 import Core.Program.Logging
-import Core.System
-import Core.System.Base (stdout)
+import Core.System.Base (liftIO, stdout, SomeException)
 import Core.System.External (TimeStamp (unTimeStamp), getCurrentTimeNanoseconds)
 import Core.Text.Bytes
 import Core.Text.Colour
 import Core.Text.Rope
 import Core.Text.Utilities
 import Data.ByteString (ByteString)
-import qualified Data.ByteString as B (ByteString)
-import qualified Data.ByteString.Char8 as C (append, null, putStrLn)
-import qualified Data.ByteString.Lazy as L (ByteString)
+import Data.ByteString qualified as B (ByteString)
+import Data.ByteString.Char8 qualified as C (append, null, putStrLn)
+import Data.ByteString.Lazy qualified as L (ByteString)
 import Data.Fixed
 import Data.IORef (IORef, newIORef, readIORef, writeIORef)
-import qualified Data.List as List
+import Data.List qualified as List
 import Network.Http.Client
 import System.Environment (lookupEnv)
 import System.Exit (ExitCode (..))
 import System.IO.Streams (InputStream)
-import qualified System.Posix.Process as Posix (exitImmediately)
+import System.Posix.Process qualified as Posix (exitImmediately)
 
 {- |
 Indicate which \"dataset\" spans and events will be posted into
@@ -221,7 +222,7 @@ acquireConnection r = do
 
 cleanupConnection :: IORef (Maybe Connection) -> IO ()
 cleanupConnection r = do
-    finally
+    Safe.finally
         ( do
             possible <- readIORef r
             case possible of
@@ -236,7 +237,7 @@ postEventToHoneycombAPI :: IORef (Maybe Connection) -> ApiKey -> Dataset -> Json
 postEventToHoneycombAPI r apikey dataset json = attempt False
   where
     attempt retrying = do
-        catch
+        Safe.catch
             ( do
                 c <- acquireConnection r
 
@@ -252,7 +253,7 @@ postEventToHoneycombAPI r apikey dataset json = attempt False
                     False -> do
                         putStrLn "Reattempting"
                         attempt True
-                    True -> throw e
+                    True -> Safe.throw e
             )
 
     q = buildRequest1 $ do

--- a/core-telemetry/package.yaml
+++ b/core-telemetry/package.yaml
@@ -1,5 +1,5 @@
 name: core-telemetry
-version: 0.2.3.0
+version: 0.2.3.1
 synopsis: Advanced telemetry
 description: |
   This is part of a library to help build command-line programs, both tools and
@@ -35,7 +35,7 @@ library:
    - async
    - core-text >= 0.3.6.0
    - core-data >= 0.3.2.2
-   - core-program >= 0.4.6.1
+   - core-program >= 0.5.0
    - chronologique
    - exceptions
    - http-streams

--- a/core-webserver-servant/core-webserver-servant.cabal
+++ b/core-webserver-servant/core-webserver-servant.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           core-webserver-servant
-version:        0.1.1.1
+version:        0.1.1.2
 synopsis:       Interoperability with Servant
 description:    This is part of a library to help build command-line programs, both tools and
                 longer-running daemons.
@@ -38,7 +38,7 @@ library
   ghc-options: -Wall -Wwarn -fwarn-tabs
   build-depends:
       base >=4.11 && <5
-    , core-program
+    , core-program >=0.5.0
     , core-telemetry
     , core-webserver-warp
     , mtl

--- a/core-webserver-servant/lib/Core/Webserver/Servant.hs
+++ b/core-webserver-servant/lib/Core/Webserver/Servant.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -31,19 +32,19 @@ module Core.Webserver.Servant (
     prepareRoutesWithContext,
 ) where
 
+import Control.Exception.Safe qualified as Safe (try, throw)
 import Control.Monad.Except (ExceptT (..))
 import Core.Program
 import Core.System (Exception (..))
-import Core.Telemetry.Observability (clearMetrics)
 import Core.Webserver.Warp
 import Data.Proxy (Proxy)
 import GHC.Base (Type)
 import Network.Wai (Application)
-import qualified Servant as Servant (
+import Servant qualified as Servant (
     Handler (..),
     ServerT,
  )
-import qualified Servant.Server as Servant (
+import Servant.Server qualified as Servant (
     Context (..),
     HasServer,
     ServerContext,
@@ -108,7 +109,7 @@ prepareRoutesWithContext proxy sContext (routes :: Servant.ServerT api (Program 
 
         context <- case contextFromRequest @τ request of
             Just context' -> pure context'
-            Nothing -> throw ContextNotFoundInRequest
+            Nothing -> Safe.throw ContextNotFoundInRequest
         Servant.serveWithContextT
             proxy
             sContext
@@ -120,7 +121,7 @@ prepareRoutesWithContext proxy sContext (routes :: Servant.ServerT api (Program 
     transformProgram :: Context τ -> Program τ α -> Servant.Handler α
     transformProgram context program =
         let output =
-                try $
+                Safe.try $
                     subProgram context $ do
                         program
          in Servant.Handler (ExceptT output)

--- a/core-webserver-servant/package.yaml
+++ b/core-webserver-servant/package.yaml
@@ -1,5 +1,5 @@
 name: core-webserver-servant
-version: 0.1.1.1
+version: 0.1.1.2
 synopsis: Interoperability with Servant
 description: |
   This is part of a library to help build command-line programs, both tools and
@@ -22,7 +22,7 @@ github: aesiniath/unbeliever
   
 dependencies:
  - base >= 4.11 && < 5
- - core-program
+ - core-program >= 0.5.0
  - core-telemetry
  - core-webserver-warp
  - mtl

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: unbeliever
-version: 0.11.2.0
+version: 0.11.3.0
 synopsis: Opinionated Haskell Interoperability
 description: |
   A library to help build command-line programs, both tools and
@@ -28,6 +28,8 @@ description: |
   * __core-data__
   * __core-program__
   * __core-telemetry__
+  * __core-webserver-warp__
+  * __core-webservver-servant__
   
   with more forthcoming as we continue to add convenince and
   interoperability wrappers around streaming, webservers, and database
@@ -48,7 +50,7 @@ dependencies:
  - base >= 4.11 && < 5
  - core-text >= 0.3.4.0
  - core-data >= 0.3.0.2
- - core-program >= 0.4.0.0
+ - core-program >= 0.5.0.0
  - core-telemetry >= 0.1.7.3
  - core-webserver-servant >= 0.0.1.0
  - core-webserver-warp >= 0.1.0.0

--- a/unbeliever.cabal
+++ b/unbeliever.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           unbeliever
-version:        0.11.2.0
+version:        0.11.3.0
 synopsis:       Opinionated Haskell Interoperability
 description:    A library to help build command-line programs, both tools and
                 longer-running daemons. Its @Program@ type provides unified ouptut &
@@ -33,6 +33,8 @@ description:    A library to help build command-line programs, both tools and
                 * __core-data__
                 * __core-program__
                 * __core-telemetry__
+                * __core-webserver-warp__
+                * __core-webservver-servant__
                 .
                 with more forthcoming as we continue to add convenince and
                 interoperability wrappers around streaming, webservers, and database
@@ -63,7 +65,7 @@ executable experiment
       base >=4.11 && <5
     , bytestring
     , core-data >=0.3.0.2
-    , core-program >=0.4.0.0
+    , core-program >=0.5.0.0
     , core-telemetry >=0.1.7.3
     , core-text >=0.3.4.0
     , core-webserver-servant >=0.0.1.0
@@ -81,7 +83,7 @@ executable snippet
   build-depends:
       base >=4.11 && <5
     , core-data >=0.3.0.2
-    , core-program >=0.4.0.0
+    , core-program >=0.5.0.0
     , core-telemetry >=0.1.7.3
     , core-text >=0.3.4.0
     , core-webserver-servant >=0.0.1.0
@@ -112,7 +114,7 @@ test-suite check
     , base >=4.11 && <5
     , bytestring
     , core-data >=0.3.0.2
-    , core-program >=0.4.0.0
+    , core-program >=0.5.0.0
     , core-telemetry >=0.1.7.3
     , core-text >=0.3.4.0
     , core-webserver-servant >=0.0.1.0
@@ -140,7 +142,7 @@ benchmark performance
       base >=4.11 && <5
     , bytestring
     , core-data >=0.3.0.2
-    , core-program >=0.4.0.0
+    , core-program >=0.5.0.0
     , core-telemetry >=0.1.7.3
     , core-text >=0.3.4.0
     , core-webserver-servant >=0.0.1.0


### PR DESCRIPTION
The documentation for `catch`, `try`, `throw`, etc coming out of **safe-exception** is quite anemic; it just says "go read the one in **exception**, which then says "like **base** but...". None of this is helpful for an experienced developer and for a beginner it is utterly impenetrable.

This branch creates wrappers for the exception functions specialized to the Program τ monad, meaning that in most cases a user of this library would no longer need to import Core.System to get at the re-exported functions from **safe-exceptions**. As a breaking change functions by these names are no longer re-exported, and so this is a major version bump.

I'm not convinced of this wisdom of doing this, but giving us a new place in Core.Program.Exceptions to clearly document how to use exceptions properly, along with being specialized the the actual monad you're in so that we keep the MonadThrow and MonadCatch malarkey away from our developers seems like a net gain.

Oh, I've sorta gone ahead and started let _fourmolu_ do `ImportQualifiedPost` where I've made edits. I think it does look better, though I have no idea why it was applying in some modules and not others, but adding the extension up top makes it uniform.
