### PR TITLE
Limit the rate which telemetry is read from queue

### DIFF
--- a/core-program/core-program.cabal
+++ b/core-program/core-program.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           core-program
-version:        0.5.0.1
+version:        0.5.0.2
 synopsis:       Opinionated Haskell Interoperability
 description:    A library to help build command-line programs, both tools and
                 longer-running daemons.

--- a/core-program/lib/Core/Program/Execute.hs
+++ b/core-program/lib/Core/Program/Execute.hs
@@ -401,7 +401,7 @@ loopForever :: ([a] -> IO ()) -> MVar Verbosity -> TQueue (Maybe Rope) -> TQueue
 loopForever action v out queue = do
     -- block waiting for an item
     possibleItems <- atomically $ do
-        cycleOverQueue []
+        cycleOverQueue (0 :: Int) []
 
     case possibleItems of
         -- we're done!
@@ -419,34 +419,36 @@ loopForever action v out queue = do
                 )
             loopForever action v out queue
   where
-    cycleOverQueue items =
-        case items of
-            [] -> do
-                possibleItem <- readTQueue queue -- blocks
-                case possibleItem of
-                    -- we're finished! time to shutdown
-                    Nothing -> pure Nothing
-                    -- otherwise start accumulating
-                    Just item -> do
-                        cycleOverQueue (item : [])
-            _ -> do
-                pending <- tryReadTQueue queue -- doesn't block
-                case pending of
-                    -- nothing left in the queue
-                    Nothing -> pure (Just items)
-                    -- otherwise we get one of our Maybe Datum, and consider it
-                    Just possibleItem -> do
-                        case possibleItem of
-                            -- oh, time to stop! We put the Nothing back into
-                            -- the queue, then let the accumulated items get
-                            -- processed. The next loop will read the
-                            -- Nothing and shutdown.
-                            Nothing -> do
-                                unGetTQueue queue Nothing
-                                pure (Just items)
-                            -- continue accumulating!
-                            Just item -> do
-                                cycleOverQueue (item : items)
+    cycleOverQueue !count items = do
+        if count >= 1024
+            then pure (Just items)
+            else case items of
+                [] -> do
+                    possibleItem <- readTQueue queue -- blocks
+                    case possibleItem of
+                        -- we're finished! time to shutdown
+                        Nothing -> pure Nothing
+                        -- otherwise start accumulating
+                        Just item -> do
+                            cycleOverQueue 1 (item : [])
+                _ -> do
+                    pending <- tryReadTQueue queue -- doesn't block
+                    case pending of
+                        -- nothing left in the queue
+                        Nothing -> pure (Just items)
+                        -- otherwise we get one of our Maybe Datum, and consider it
+                        Just possibleItem -> do
+                            case possibleItem of
+                                -- oh, time to stop! We put the Nothing back into
+                                -- the queue, then let the accumulated items get
+                                -- processed. The next loop will read the
+                                -- Nothing and shutdown.
+                                Nothing -> do
+                                    unGetTQueue queue Nothing
+                                    pure (Just items)
+                                -- continue accumulating!
+                                Just item -> do
+                                    cycleOverQueue (count + 1) (item : items)
 
     reportStatus start num = do
         level <- readMVar v

--- a/core-program/package.yaml
+++ b/core-program/package.yaml
@@ -1,5 +1,5 @@
 name: core-program
-version: 0.5.0.1
+version: 0.5.0.2
 synopsis: Opinionated Haskell Interoperability
 description: |
   A library to help build command-line programs, both tools and

--- a/core-telemetry/core-telemetry.cabal
+++ b/core-telemetry/core-telemetry.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           core-telemetry
-version:        0.2.3.2
+version:        0.2.3.3
 synopsis:       Advanced telemetry
 description:    This is part of a library to help build command-line programs, both tools and
                 longer-running daemons.
@@ -53,7 +53,7 @@ library
     , base >=4.11 && <5
     , bytestring
     , core-data >=0.3.2.2
-    , core-program >=0.5.0
+    , core-program >=0.5.0.2
     , core-text >=0.3.6.0
     , exceptions
     , http-streams

--- a/core-telemetry/package.yaml
+++ b/core-telemetry/package.yaml
@@ -1,5 +1,5 @@
 name: core-telemetry
-version: 0.2.3.2
+version: 0.2.3.3
 synopsis: Advanced telemetry
 description: |
   This is part of a library to help build command-line programs, both tools and
@@ -35,7 +35,7 @@ library:
    - async
    - core-text >= 0.3.6.0
    - core-data >= 0.3.2.2
-   - core-program >= 0.5.0
+   - core-program >= 0.5.0.2
    - exceptions
    - http-streams
    - io-streams

--- a/core-text/core-text.cabal
+++ b/core-text/core-text.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           core-text
-version:        0.3.7.2
+version:        0.3.7.3
 synopsis:       A rope type based on a finger tree over UTF-8 fragments
 description:    A rope data type for text, built as a finger tree over UTF-8 text
                 fragments. The package also includes utiltiy functions for breaking and

--- a/core-text/lib/Core/Text/Utilities.hs
+++ b/core-text/lib/Core/Text/Utilities.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
@@ -52,13 +53,13 @@ import Core.Text.Colour
 import Core.Text.Parsing
 import Core.Text.Rope
 import Data.Bits (Bits (..))
-import qualified Data.ByteString as B (ByteString, length, splitAt, unpack)
+import Data.ByteString qualified as B (ByteString, length, splitAt, unpack)
 import Data.Char (intToDigit)
-import qualified Data.FingerTree as F (ViewL (..), viewl, (<|))
+import Data.FingerTree qualified as F (ViewL (..), viewl, (<|))
 import Data.Kind (Type)
-import qualified Data.List as List (dropWhileEnd, foldl', splitAt)
-import qualified Data.Text as T
-import qualified Data.Text.Short as S (
+import Data.List qualified as List (dropWhileEnd, foldl', splitAt)
+import Data.Text qualified as T
+import Data.Text.Short qualified as S (
     ShortText,
     replicate,
     singleton,
@@ -164,10 +165,9 @@ twoWords ds = go ds
   where
     go [] = []
     go [x] = [softline' <> x]
-    go xs =
-        let (one : two : [], remainder) = List.splitAt 2 xs
-         in group (one <> spacer <> two) : go remainder
-
+    go xs = case List.splitAt 2 xs of
+        (one : two : [], remainder) -> group (one <> spacer <> two) : go remainder
+        _ -> [] -- unreachable
     spacer = flatAlt softline' "  "
 
 byteChunk :: B.ByteString -> [B.ByteString]
@@ -316,7 +316,6 @@ Sadly if there is only one item you don't get an Oxford comma, either:
 λ> __oxford []__
 ""
 @
-
 -}
 oxford :: [Rope] -> Rope
 oxford [] = emptyRope

--- a/core-text/package.yaml
+++ b/core-text/package.yaml
@@ -1,5 +1,5 @@
 name: core-text
-version: 0.3.7.2
+version: 0.3.7.3
 synopsis: A rope type based on a finger tree over UTF-8 fragments
 description: |
   A rope data type for text, built as a finger tree over UTF-8 text

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2022-05-28
+resolver: nightly-2022-06-06
 packages:
  - ./core-data
  - ./core-text


### PR DESCRIPTION
Read no more than 1024 events at a time from the telemetry queue, which should effectively rate-limit what we're sending up to Honeycomb.