### PR TITLE
Compress events before sending to Honeycomb

### DIFF
--- a/core-telemetry/core-telemetry.cabal
+++ b/core-telemetry/core-telemetry.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           core-telemetry
-version:        0.2.3.3
+version:        0.2.3.4
 synopsis:       Advanced telemetry
 description:    This is part of a library to help build command-line programs, both tools and
                 longer-running daemons.
@@ -67,4 +67,5 @@ library
     , template-haskell >=2.14 && <3
     , text
     , unix
+    , zlib
   default-language: Haskell2010

--- a/core-telemetry/lib/Core/Telemetry/Honeycomb.hs
+++ b/core-telemetry/lib/Core/Telemetry/Honeycomb.hs
@@ -262,9 +262,11 @@ postEventToHoneycombAPI r apikey dataset json = attempt False
                 cleanupConnection r
                 case retrying of
                     False -> do
-                        putStrLn "Reattempting"
+                        putStrLn "internal: Reconnecting to Honeycomb"
                         attempt True
-                    True -> Safe.throw e
+                    True -> do
+                        putStrLn "internal: Failed to re-establish connection to Honeycomb"
+                        Safe.throw e
             )
 
     q = buildRequest1 $ do
@@ -297,7 +299,7 @@ postEventToHoneycombAPI r apikey dataset json = attempt False
                                     pure ()
                                 _ -> do
                                     -- some other status!
-                                    putStrLn "Unexpected status returned;"
+                                    putStrLn "internal: Unexpected status returned;"
                                     C.putStrLn body
                             _ -> putStrLn "internal: wtf?"
                     _ -> do

--- a/core-telemetry/package.yaml
+++ b/core-telemetry/package.yaml
@@ -1,5 +1,5 @@
 name: core-telemetry
-version: 0.2.3.3
+version: 0.2.3.4
 synopsis: Advanced telemetry
 description: |
   This is part of a library to help build command-line programs, both tools and
@@ -46,6 +46,7 @@ library:
    - scientific
    - stm
    - unix
+   - zlib
   source-dirs:
   - lib
   exposed-modules:


### PR DESCRIPTION
The _batch_ endpoint offered by Honeycomb is allows for compressing payloads before sending. Tests using gzip to show a drop in transmitted size of around 90% for large packets of 1024 events. That's worth the CPU time :)

(they also support zstd, but gzip seems fine)