### PR TITLE
Fix global help

### DIFF
--- a/core-program/core-program.cabal
+++ b/core-program/core-program.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           core-program
-version:        0.5.0.2
+version:        0.5.0.3
 synopsis:       Opinionated Haskell Interoperability
 description:    A library to help build command-line programs, both tools and
                 longer-running daemons.

--- a/core-program/lib/Core/Program/Arguments.hs
+++ b/core-program/lib/Core/Program/Arguments.hs
@@ -49,7 +49,7 @@ module Core.Program.Arguments (
 ) where
 
 import Data.Hashable (Hashable)
-import qualified Data.List as List
+import Data.List qualified as List
 import Data.Maybe (fromMaybe)
 import Data.String (IsString (..))
 import Prettyprinter (
@@ -360,12 +360,8 @@ appendOption option config =
     case config of
         Blank -> Blank
         Simple options -> Simple (options ++ [option])
-        Complex commands -> Complex (List.foldl' f [] commands)
-  where
-    f :: [Commands] -> Commands -> [Commands]
-    f acc command = case command of
-        Global options -> acc ++ [Global (options ++ [option])]
-        c@(Command _ _ _) -> acc ++ [c]
+        Complex commands -> Complex (commands ++ [Global [option]])
+
 {- |
 Individual parameters read in off the command-line can either have a value
 (in the case of arguments and options taking a value) or be empty (in the

--- a/core-program/lib/Core/Program/Arguments.hs
+++ b/core-program/lib/Core/Program/Arguments.hs
@@ -364,9 +364,8 @@ appendOption option config =
   where
     f :: [Commands] -> Commands -> [Commands]
     f acc command = case command of
-        Global options -> Global (options ++ [option]) : acc
-        c@(Command _ _ _) -> c : acc
-
+        Global options -> acc ++ [Global (options ++ [option])]
+        c@(Command _ _ _) -> acc ++ [c]
 {- |
 Individual parameters read in off the command-line can either have a value
 (in the case of arguments and options taking a value) or be empty (in the

--- a/core-program/lib/Core/Program/Arguments.hs
+++ b/core-program/lib/Core/Program/Arguments.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE StrictData #-}

--- a/core-program/package.yaml
+++ b/core-program/package.yaml
@@ -1,5 +1,5 @@
 name: core-program
-version: 0.5.0.2
+version: 0.5.0.3
 synopsis: Opinionated Haskell Interoperability
 description: |
   A library to help build command-line programs, both tools and

--- a/core-telemetry/core-telemetry.cabal
+++ b/core-telemetry/core-telemetry.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           core-telemetry
-version:        0.2.3.4
+version:        0.2.3.5
 synopsis:       Advanced telemetry
 description:    This is part of a library to help build command-line programs, both tools and
                 longer-running daemons.

--- a/core-telemetry/lib/Core/Telemetry/Observability.hs
+++ b/core-telemetry/lib/Core/Telemetry/Observability.hs
@@ -456,16 +456,6 @@ encloseSpan label action = do
             Right value -> pure value
 
 {- |
-Send a span value up by hand.
-
-This handles a number of convenient things for you, and takes care of a few edge
-cases.
-
-
-@since 0.2.1
--}
-
-{- |
 Start a new trace. A random identifier will be generated.
 
 You /must/ have a single \"root span\" immediately below starting a new trace.

--- a/core-telemetry/package.yaml
+++ b/core-telemetry/package.yaml
@@ -1,5 +1,5 @@
 name: core-telemetry
-version: 0.2.3.4
+version: 0.2.3.5
 synopsis: Advanced telemetry
 description: |
   This is part of a library to help build command-line programs, both tools and

--- a/package.yaml
+++ b/package.yaml
@@ -48,12 +48,12 @@ github: aesiniath/unbeliever
 
 dependencies:
  - base >= 4.11 && < 5
- - core-text >= 0.3.4.0
- - core-data >= 0.3.3.0
- - core-program >= 0.5.0.0
- - core-telemetry >= 0.1.7.3
- - core-webserver-servant >= 0.0.1.0
- - core-webserver-warp >= 0.1.0.0
+ - core-text >= 0.3.7.3
+ - core-data >= 0.3.3.1
+ - core-program >= 0.5.0.3
+ - core-telemetry >= 0.2.3.5
+ - core-webserver-servant >= 0.1.1.2
+ - core-webserver-warp >= 0.1.1.6
 
 executables:
   snippet:

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2022-06-06
+resolver: nightly-2022-06-12
 packages:
  - ./core-data
  - ./core-text

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2022-06-12
+resolver: nightly-2022-06-06
 packages:
  - ./core-data
  - ./core-text

--- a/unbeliever.cabal
+++ b/unbeliever.cabal
@@ -64,12 +64,12 @@ executable experiment
   build-depends:
       base >=4.11 && <5
     , bytestring
-    , core-data >=0.3.3.0
-    , core-program >=0.5.0.0
-    , core-telemetry >=0.1.7.3
-    , core-text >=0.3.4.0
-    , core-webserver-servant >=0.0.1.0
-    , core-webserver-warp >=0.1.0.0
+    , core-data >=0.3.3.1
+    , core-program >=0.5.0.3
+    , core-telemetry >=0.2.3.5
+    , core-text >=0.3.7.3
+    , core-webserver-servant >=0.1.1.2
+    , core-webserver-warp >=0.1.1.6
     , prettyprinter
     , unordered-containers
   buildable: False
@@ -82,11 +82,11 @@ executable snippet
   ghc-options: -Wall -Wwarn -fwarn-tabs -threaded
   build-depends:
       base >=4.11 && <5
-    , core-data >=0.3.3.0
-    , core-program >=0.5.0.0
-    , core-telemetry >=0.1.7.3
-    , core-text >=0.3.4.0
-    , core-webserver-servant >=0.0.1.0
+    , core-data >=0.3.3.1
+    , core-program >=0.5.0.3
+    , core-telemetry >=0.2.3.5
+    , core-text >=0.3.7.3
+    , core-webserver-servant >=0.1.1.2
     , core-webserver-warp
     , http-types
     , wai
@@ -116,12 +116,12 @@ test-suite check
     , async
     , base >=4.11 && <5
     , bytestring
-    , core-data >=0.3.3.0
-    , core-program >=0.5.0.0
-    , core-telemetry >=0.1.7.3
-    , core-text >=0.3.4.0
-    , core-webserver-servant >=0.0.1.0
-    , core-webserver-warp >=0.1.0.0
+    , core-data >=0.3.3.1
+    , core-program >=0.5.0.3
+    , core-telemetry >=0.2.3.5
+    , core-text >=0.3.7.3
+    , core-webserver-servant >=0.1.1.2
+    , core-webserver-warp >=0.1.1.6
     , fingertree
     , hashable
     , hspec
@@ -145,12 +145,12 @@ benchmark performance
   build-depends:
       base >=4.11 && <5
     , bytestring
-    , core-data >=0.3.3.0
-    , core-program >=0.5.0.0
-    , core-telemetry >=0.1.7.3
-    , core-text >=0.3.4.0
-    , core-webserver-servant >=0.0.1.0
-    , core-webserver-warp >=0.1.0.0
+    , core-data >=0.3.3.1
+    , core-program >=0.5.0.3
+    , core-telemetry >=0.2.3.5
+    , core-text >=0.3.7.3
+    , core-webserver-servant >=0.1.1.2
+    , core-webserver-warp >=0.1.1.6
     , gauge
     , text
   default-language: Haskell2010


### PR DESCRIPTION
When using `complexConfig` the global options (notably the default options such as `--verbose` and `--debug` and those added by `initializeTelemetry`) were being duplicated in the generated help output. That was embarrassing.

Fixed.