### PR TITLE
Fix assignment of values to required arguments

### DIFF
--- a/core-program/core-program.cabal
+++ b/core-program/core-program.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           core-program
-version:        0.5.0.3
+version:        0.5.0.4
 synopsis:       Opinionated Haskell Interoperability
 description:    A library to help build command-line programs, both tools and
                 longer-running daemons.

--- a/core-program/lib/Core/Program/Arguments.hs
+++ b/core-program/lib/Core/Program/Arguments.hs
@@ -688,11 +688,11 @@ extractShortNames options =
 
 extractRequiredArguments :: [Options] -> [LongName]
 extractRequiredArguments arguments =
-    List.foldl' h [] arguments
+    List.foldr h [] arguments
   where
-    h :: [LongName] -> Options -> [LongName]
-    h needed (Argument longname _) = longname : needed
-    h needed _ = needed
+    h :: Options -> [LongName] -> [LongName]
+    h (Argument longname _) needed = longname : needed
+    h _ needed = needed
 
 extractGlobalOptions :: [Commands] -> [Options]
 extractGlobalOptions commands =

--- a/core-program/package.yaml
+++ b/core-program/package.yaml
@@ -1,5 +1,5 @@
 name: core-program
-version: 0.5.0.3
+version: 0.5.0.4
 synopsis: Opinionated Haskell Interoperability
 description: |
   A library to help build command-line programs, both tools and

--- a/core-text/lib/Core/Text/Rope.hs
+++ b/core-text/lib/Core/Text/Rope.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StrictData #-}
@@ -102,17 +103,17 @@ module Core.Text.Rope (
 
 import Control.DeepSeq (NFData (..))
 import Core.Text.Bytes
-import qualified Data.ByteString as B (ByteString)
-import qualified Data.ByteString.Builder as B (
+import Data.ByteString qualified as B (ByteString)
+import Data.ByteString.Builder qualified as B (
     hPutBuilder,
     toLazyByteString,
  )
-import qualified Data.ByteString.Lazy as L (
+import Data.ByteString.Lazy qualified as L (
     ByteString,
     foldrChunks,
     toStrict,
  )
-import qualified Data.FingerTree as F (
+import Data.FingerTree qualified as F (
     FingerTree,
     Measured (..),
     SearchResult (..),
@@ -129,19 +130,19 @@ import qualified Data.FingerTree as F (
 import Data.Foldable (foldl', toList)
 import Data.Hashable (Hashable, hashWithSalt)
 import Data.String (IsString (..))
-import qualified Data.Text as T (Text)
-import qualified Data.Text.Lazy as U (
+import Data.Text qualified as T (Text)
+import Data.Text.Lazy qualified as U (
     Text,
     foldrChunks,
     fromChunks,
     toStrict,
  )
-import qualified Data.Text.Lazy.Builder as U (
+import Data.Text.Lazy.Builder qualified as U (
     Builder,
     fromText,
     toLazyText,
  )
-import qualified Data.Text.Short as S (
+import Data.Text.Short qualified as S (
     ShortText,
     any,
     append,
@@ -159,7 +160,7 @@ import qualified Data.Text.Short as S (
     uncons,
     unpack,
  )
-import qualified Data.Text.Short.Unsafe as S (fromByteStringUnsafe)
+import Data.Text.Short.Unsafe qualified as S (fromByteStringUnsafe)
 import GHC.Generics (Generic)
 import Prettyprinter (Pretty (..), emptyDoc)
 import System.IO (Handle)
@@ -606,11 +607,9 @@ intermediate allocation and copying because we can go from the
 'Data.ByteString.Short.ShortByteString' to 'Data.ByteString.Builder.Builder'
 to the 'System.IO.Handle''s output buffer in one go.
 
-If you're working in the
-<https://hackage.haskell.org/package/core-program/docs/Core-Program-Execute.html#t:Program
-Program> monad, then
-<https://hackage.haskell.org/package/core-program/docs/Core-Program-Logging.html#v:write
-write> provides an efficient way to write a @Rope@ to @stdout@.
+If you're working in the __core-program__ 'Core.Program.Execute.Program' @τ@
+monad, then the 'Core.Program.Logging.write' function there provides an
+efficient way to write a 'Rope' to @stdout@.
 -}
 hWrite :: Handle -> Rope -> IO ()
 hWrite handle (Rope x) = B.hPutBuilder handle (foldr j mempty x)

--- a/tests/CheckArgumentsParsing.hs
+++ b/tests/CheckArgumentsParsing.hs
@@ -32,6 +32,14 @@ options4 =
     [ Remaining "All the rest of the files"
     ]
 
+options5 :: [Options]
+options5 =
+    [ Argument "one" "The first one"
+    , Argument "two" "The second one"
+    , Argument "three" "The third one"
+    , Remaining "All the rest"
+    ]
+
 commands1 :: [Commands]
 commands1 =
     [ Global
@@ -182,8 +190,14 @@ checkArgumentsParsing = do
 
         it "accepts trailing arguments as remainder" $
             let config = complexConfig commands4
-                actual = parseCommandLine config ["commit", "one", "two", "tree"]
-                expect = Parameters (Just "commit") emptyMap ["one", "two", "tree"] emptyMap
+                actual = parseCommandLine config ["commit", "one", "two", "three"]
+                expect = Parameters (Just "commit") emptyMap ["one", "two", "three"] emptyMap
+             in actual `shouldBe` Right expect
+
+        it "ensures required arguments as in order" $
+            let config = simpleConfig options5
+                actual = parseCommandLine config ["un", "deux", "trois", "quatre", "cinq"]
+                expect = Parameters Nothing (intoMap [("one", "un"), ("two", "deux"), ("three", "trois")]) [ "quatre", "cinq"] emptyMap
              in actual `shouldBe` Right expect
 
         -- in complex mode wasn't accpting --version as a global option.

--- a/tests/CheckArgumentsParsing.hs
+++ b/tests/CheckArgumentsParsing.hs
@@ -37,6 +37,7 @@ options5 =
     [ Argument "one" "The first one"
     , Argument "two" "The second one"
     , Argument "three" "The third one"
+    , Argument "four" "The fourth one"
     , Remaining "All the rest"
     ]
 
@@ -196,8 +197,8 @@ checkArgumentsParsing = do
 
         it "ensures required arguments as in order" $
             let config = simpleConfig options5
-                actual = parseCommandLine config ["un", "deux", "trois", "quatre", "cinq"]
-                expect = Parameters Nothing (intoMap [("one", "un"), ("two", "deux"), ("three", "trois")]) [ "quatre", "cinq"] emptyMap
+                actual = parseCommandLine config ["un", "deux", "trois", "quatre", "cinq", "six"]
+                expect = Parameters Nothing (intoMap [("one", "un"), ("two", "deux"), ("three", "trois"), ("four", "quatre")]) ["cinq", "six"] emptyMap
              in actual `shouldBe` Right expect
 
         -- in complex mode wasn't accpting --version as a global option.


### PR DESCRIPTION
It turns out we had a fairly serious bug whereby required command-line arguments were not being assigned the correct values when there was more than one required `Argument`. Turns out internally the order dependent list of needed arguments was being reversed before the correctly ordered parameters were zipped with that list. Fixed.