### PR TITLE
 Support for externalizing data

### DIFF
--- a/core-data/core-data.cabal
+++ b/core-data/core-data.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           core-data
-version:        0.3.3.1
+version:        0.3.4.0
 synopsis:       Convenience wrappers around common data structures and encodings
 description:    Wrappers around common data structures and encodings.
                 .
@@ -36,10 +36,12 @@ library
   exposed-modules:
       Core.Data
       Core.Data.Clock
-      Core.Data.Format
+      Core.Data.External
       Core.Data.Structures
       Core.Encoding
       Core.Encoding.Json
+  other-modules:
+      Core.Data.Format
   hs-source-dirs:
       lib
   ghc-options: -Wall -Wwarn -fwarn-tabs

--- a/core-data/core-data.cabal
+++ b/core-data/core-data.cabal
@@ -36,9 +36,9 @@ library
   exposed-modules:
       Core.Data
       Core.Data.Clock
-      Core.Data.External
       Core.Data.Structures
       Core.Encoding
+      Core.Encoding.External
       Core.Encoding.Json
   other-modules:
       Core.Data.Format

--- a/core-data/core-data.cabal
+++ b/core-data/core-data.cabal
@@ -58,5 +58,6 @@ library
     , text
     , time
     , unordered-containers
+    , uuid
     , vector
   default-language: Haskell2010

--- a/core-data/lib/Core/Data/Clock.hs
+++ b/core-data/lib/Core/Data/Clock.hs
@@ -79,38 +79,39 @@ import Time.System qualified as H (
 {- |
 Number of nanoseconds since the Unix epoch.
 
-The 'Show' instance displays the 'Time' as seconds with the nanosecond
-precision expressed as a decimal amount after the interger, ie:
+The 'Show' and 'Core.Encoding.External.Externalize' instances display the
+'Time' as seconds with the nanosecond precision expressed as a decimal amount
+after the interger, ie:
 
 >>> t <- getCurrentTimeNanoseconds
->>> show t
-2014-07-31T23:09:35.274387031Z
+>>> formatExternal t
+"2014-07-31T23:09:35.274387031Z"
 
 However this doesn't change the fact the underlying representation counts
 nanoseconds since epoch:
 
 >>> show $ unTime t
-1406848175274387031
+"1406848175274387031"
 
-There is a 'Read' instance that is reasonably accommodating:
+There is a 'Externalize' instance that is reasonably accommodating:
 
->>> read "2014-07-31T13:05:04.942089001Z" :: Time
-2014-07-31T13:05:04.942089001Z
+>>> parseExternal "2014-07-31T13:05:04.942089001Z" :: Maybe Time
+Just 2014-07-31T13:05:04.942089001Z
 
->>> read "1406811904.942089001" :: Time
-2014-07-31T13:05:04.942089001Z
+>>> parseExternal "1406811904.942089001" :: Maybe Time
+Just 2014-07-31T13:05:04.942089001Z
 
->>> read "1406811904" :: Time
-2014-07-31T13:05:04.000000000Z
+>>> parseExternal "1406811904" :: Maybe Time
+Just 2014-07-31T13:05:04.000000000Z
 
 In case you're wondering, the valid range of nanoseconds that fits into the
 underlying 'Int64' is:
 
->>> show $ minBound :: Time
-1677-09-21T00:12:43.145224192Z
+>>> formatExternal (minBound :: Time)
+"1677-09-21T00:12:43.145224192Z"
 
->>> show $ maxBound :: Time
-2262-04-11T23:47:16.854775807Z
+>>> formatExternal (maxBound :: Time)
+"2262-04-11T23:47:16.854775807Z"
 
 so in a quarter millenium's time, yes, you'll have the Y2262 Problem.
 Haskell code from today will, of course, still be running, so in the mid

--- a/core-data/lib/Core/Data/External.hs
+++ b/core-data/lib/Core/Data/External.hs
@@ -1,0 +1,61 @@
+{-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_HADDOCK prune #-}
+
+
+{- |
+Quite frequently you will find yourself needing to convert between a Haskell
+data type and a textual representation of that type.
+
+Note that /externalizing/ is not the same as /serializing/. If you have more
+complex (ie rich types or nested) data structures then a simple text string
+will not be sufficient to represent it accurately. Serializing is focused on
+both performance encoding and decoding, and efficiency of the representation
+when transmitted over the wire.
+
+Of course, the obvious benefits of efficiency didn't stop the entire computer
+industry from near universal adoption of JSON as an interchange format. There
+is, perhaps, no hope for us.
+-}
+module Core.Data.External (
+    -- * Conversions
+    Externalize (intoExternal, parseExternal),
+) where
+
+import Core.Text.Rope
+
+import Data.Int (Int64)
+import Text.Read (readMaybe)
+
+{- |
+Convert between different representations of a data type.
+
+
+There is a general implementatation that goes though 'Show' and 'Read' via
+'String' but if you know you have a direct way to render or parse a type into
+a sequence of characters then you can offer an instance of 'Externalize' which
+does so more efficiently.
+
+@since 0.3.4
+-}
+class Externalize a where
+    intoExternal :: a -> Rope
+    parseExternal :: Rope -> Maybe a
+
+--
+-- We use this general instance here rather than as a super class constraint
+-- for Externalize so as to allow us to have things that can be externalized
+-- without necessarily needing those two instances. Most things have Show, but
+-- not everything, an many many things haven't bothered with Read.
+--
+
+instance {-# OVERLAPPABLE #-} (Read a, Show a) => Externalize a where
+    intoExternal = intoRope . show
+    parseExternal = readMaybe . fromRope
+
+instance Externalize Int where
+    intoExternal = intoRope . show
+    parseExternal = readMaybe . fromRope
+
+instance Externalize Int64 where
+    intoExternal = intoRope . show
+    parseExternal = readMaybe . fromRope

--- a/core-data/lib/Core/Encoding.hs
+++ b/core-data/lib/Core/Encoding.hs
@@ -18,6 +18,9 @@ this package.
 -}
 module Core.Encoding (
     module Core.Encoding.Json,
+
+    module Core.Encoding.External,
 ) where
 
+import Core.Encoding.External
 import Core.Encoding.Json

--- a/core-data/lib/Core/Encoding/External.hs
+++ b/core-data/lib/Core/Encoding/External.hs
@@ -1,7 +1,7 @@
-{-# LANGUAGE FlexibleInstances#-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_HADDOCK prune #-}
-
 
 {- |
 Quite frequently you will find yourself needing to convert between a rich
@@ -36,6 +36,7 @@ module Core.Encoding.External (
 import Core.Text.Rope
 
 import Data.Int (Int64)
+import Data.UUID qualified as Uuid (UUID, fromText, toText)
 import Text.Read (readMaybe)
 
 {- |
@@ -84,3 +85,7 @@ instance Externalize Int where
 instance Externalize Int64 where
     formatExternal = intoRope . show
     parseExternal = readMaybe . fromRope
+
+instance Externalize Uuid.UUID where
+    formatExternal = intoRope . Uuid.toText
+    parseExternal = Uuid.fromText . fromRope

--- a/core-data/lib/Core/Encoding/External.hs
+++ b/core-data/lib/Core/Encoding/External.hs
@@ -146,6 +146,28 @@ instance Externalize Int64 where
     formatExternal = intoRope . Builder.toLazyByteString . Builder.int64Dec
     parseExternal = readMaybe . fromRope
 
+{- |
+IEEE 754 floating point:
+
+@
+3.1415927
+@
+-}
+instance Externalize Float where
+    formatExternal = intoRope . Builder.toLazyByteString . Builder.floatDec
+    parseExternal = readMaybe . fromRope
+
+{- |
+IEEE 754 floating point:
+
+@
+3.141592653589793
+@
+-}
+instance Externalize Double where
+    formatExternal = intoRope . Builder.toLazyByteString . Builder.doubleDec
+    parseExternal = readMaybe . fromRope
+
 --
 -- More than anything, THIS was the example that motivated creating this
 -- module.

--- a/core-data/lib/Core/Encoding/External.hs
+++ b/core-data/lib/Core/Encoding/External.hs
@@ -16,7 +16,7 @@ Of course, the obvious benefits of efficiency didn't stop the entire computer
 industry from near universal adoption of JSON as an interchange format. There
 is, perhaps, no hope for us.
 -}
-module Core.Data.External (
+module Core.Encoding.External (
     -- * Conversions
     Externalize (intoExternal, parseExternal),
 ) where

--- a/core-data/lib/Core/Encoding/External.hs
+++ b/core-data/lib/Core/Encoding/External.hs
@@ -6,7 +6,9 @@
 {- |
 Quite frequently you will find yourself needing to convert between a rich
 semantic Haskell data type and a textual representation of that type which we
-call the /external/ representation of a value.
+call the /external/ representation of a value. The external representation of
+the value is authoriative and is meant to be re-readable even in the face of
+changing implemetations on the program side.
 
 Note that /externalizing/ is not quite the same as /serializing/. If you have
 more complex (ie rich types or nested) data structures then a simple text
@@ -21,10 +23,10 @@ You can, however, regain some of your sanity by ensuring that the individual
 fields of a larger structure are safe, and that's where the externalizing
 machinery in this module comes in.
 
-If you have read this far and think we are describing 'Show' or @toString@ you
-are correct, but at the level of primative and simple types we are providing
-the ability to marshall them to a clean UTF-8 representation and to unmarshall
-them back into Haskell values again.
+If you have read this far and think we are describing something similar to
+'Show' or @toString@ you are correct, but at the level of primative and simple
+types we are providing the ability to marshall them to a clean UTF-8
+representation and to unmarshall them back into Haskell values again.
 
 The other major use case for this module is as a helper to read user input;
 see 'Core.Program.Execute.queryOptionValue'' for an example that makes use of
@@ -32,17 +34,15 @@ this.
 
 /Notes for implementators/
 
-This external representation of the value is authoriative and is meant to be
-re-readable even in the face of changing implemetations on the program side.
-
 Postel's dictum to \"be conservative in what you produce but liberal in what
 you accept\" describes the intent of this module. If you are implementing an
 instance of 'Externalize' then you might consider being flexible as possible
 when parsing with 'parseExternal', within the constraints of having to read a
 given value with exact fidelity. But when outputing a value with
-'formatExternal' you should be correcting the value in a canonical, stable
-form, even if the original input was written differently. See the discussion
-of creating 'Core.Data.Clock.Time' types from varying inputs for an example.
+'formatExternal' you should be correcting the representation of the value to a
+canonical, stable form, even if the original input was written differently.
+See the discussion of creating 'Core.Data.Clock.Time' types from varying
+inputs for an example.
 -}
 module Core.Encoding.External (
     -- * Conversions

--- a/core-data/lib/Core/Encoding/External.hs
+++ b/core-data/lib/Core/Encoding/External.hs
@@ -33,8 +33,8 @@ module Core.Encoding.External (
     Externalize (formatExternal, parseExternal),
 ) where
 
+import Core.Data.Clock
 import Core.Text.Rope
-
 import Data.Int (Int64)
 import Data.UUID qualified as Uuid (UUID, fromText, toText)
 import Text.Read (readMaybe)
@@ -89,3 +89,7 @@ instance Externalize Int64 where
 instance Externalize Uuid.UUID where
     formatExternal = intoRope . Uuid.toText
     parseExternal = Uuid.fromText . fromRope
+
+instance Externalize Time where
+    formatExternal = intoRope . show
+    parseExternal = readMaybe . fromRope

--- a/core-data/lib/Core/Encoding/External.hs
+++ b/core-data/lib/Core/Encoding/External.hs
@@ -24,9 +24,25 @@ machinery in this module comes in.
 If you have read this far and think we are describing 'Show' or @toString@ you
 are correct, but at the level of primative and simple types we are providing
 the ability to marshall them to a clean UTF-8 representation and to unmarshall
-them back into Haskell values again. This external representation of the value
-is authoriative and is meant to be re-readable even in the face of changing
-implemetations on the program side.
+them back into Haskell values again.
+
+The other major use case for this module is as a helper to read user input;
+see 'Core.Program.Execute.queryOptionValue'' for an example that makes use of
+this.
+
+/Notes for implementators/
+
+This external representation of the value is authoriative and is meant to be
+re-readable even in the face of changing implemetations on the program side.
+
+Postel's dictum to \"be conservative in what you produce but liberal in what
+you accept\" describes the intent of this module. If you are implementing an
+instance of 'Externalize' then you might consider being flexible as possible
+when parsing with 'parseExternal', within the constraints of having to read a
+given value with exact fidelity. But when outputing a value with
+'formatExternal' you should be correcting the value in a canonical, stable
+form, even if the original input was written differently. See the discussion
+of creating 'Core.Data.Clock.Time' types from varying inputs for an example.
 -}
 module Core.Encoding.External (
     -- * Conversions

--- a/core-data/lib/Core/Encoding/External.hs
+++ b/core-data/lib/Core/Encoding/External.hs
@@ -1,24 +1,36 @@
+{-# LANGUAGE FlexibleInstances#-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_HADDOCK prune #-}
 
 
 {- |
-Quite frequently you will find yourself needing to convert between a Haskell
-data type and a textual representation of that type.
+Quite frequently you will find yourself needing to convert between a rich
+semantic Haskell data type and a textual representation of that type which we
+call the /external/ representation of a value.
 
-Note that /externalizing/ is not the same as /serializing/. If you have more
-complex (ie rich types or nested) data structures then a simple text string
-will not be sufficient to represent it accurately. Serializing is focused on
-both performance encoding and decoding, and efficiency of the representation
-when transmitted over the wire.
+Note that /externalizing/ is not quite the same as /serializing/. If you have
+more complex (ie rich types or nested) data structures then a simple text
+string will probably not be sufficient to convey sufficient information to
+represent it accurately. Serializing is focused on both performance encoding
+and decoding, and efficiency of the representation when transmitted over the
+wire. Of course, the obvious benefits of efficiency didn't stop the entire
+computer industry from near universal adoption of JSON as an interchange
+format, so there is, perhaps, no hope for us.
 
-Of course, the obvious benefits of efficiency didn't stop the entire computer
-industry from near universal adoption of JSON as an interchange format. There
-is, perhaps, no hope for us.
+You can, however, regain some of your sanity by ensuring that the individual
+fields of a larger structure are safe, and that's where the externalizing
+machinery in this module comes in.
+
+If you have read this far and think we are describing 'Show' or @toString@ you
+are correct, but at the level of primative and simple types we are providing
+the ability to marshall them to a clean UTF-8 representation and to unmarshall
+them back into Haskell values again. This external representation of the value
+is authoriative and is meant to be re-readable even in the face of changing
+implemetations on the program side.
 -}
 module Core.Encoding.External (
     -- * Conversions
-    Externalize (intoExternal, parseExternal),
+    Externalize (formatExternal, parseExternal),
 ) where
 
 import Core.Text.Rope
@@ -27,8 +39,21 @@ import Data.Int (Int64)
 import Text.Read (readMaybe)
 
 {- |
-Convert between different representations of a data type.
+Convert between the internal Haskell representation of a data type and an
+external, textual form suitable for visualization, onward transmission, or
+archival storage.
 
+It is expected that a valid instance of 'Externalize' allows you to round-trip
+through it:
+
+>>> formatExternal (42 :: Int))
+"42"
+
+>>> fromJust (parseExternal "42") :: Int
+42
+
+with the usual caveat about needing to ensure you've given enough information
+to the type-checker to know which instance you're asking for.
 
 There is a general implementatation that goes though 'Show' and 'Read' via
 'String' but if you know you have a direct way to render or parse a type into
@@ -38,24 +63,24 @@ does so more efficiently.
 @since 0.3.4
 -}
 class Externalize a where
-    intoExternal :: a -> Rope
+    formatExternal :: a -> Rope
     parseExternal :: Rope -> Maybe a
 
 --
 -- We use this general instance here rather than as a super class constraint
 -- for Externalize so as to allow us to have things that can be externalized
 -- without necessarily needing those two instances. Most things have Show, but
--- not everything, an many many things haven't bothered with Read.
+-- not everything, as many many types haven't bothered with Read.
 --
 
 instance {-# OVERLAPPABLE #-} (Read a, Show a) => Externalize a where
-    intoExternal = intoRope . show
+    formatExternal = intoRope . show
     parseExternal = readMaybe . fromRope
 
 instance Externalize Int where
-    intoExternal = intoRope . show
+    formatExternal = intoRope . show
     parseExternal = readMaybe . fromRope
 
 instance Externalize Int64 where
-    intoExternal = intoRope . show
+    formatExternal = intoRope . show
     parseExternal = readMaybe . fromRope

--- a/core-data/lib/Core/Encoding/External.hs
+++ b/core-data/lib/Core/Encoding/External.hs
@@ -65,13 +65,13 @@ does so more efficiently.
 
 @since 0.3.4
 -}
-class Externalize a where
+class Externalize ξ where
     -- | Convert a value into an authoritative, stable textual representation
     -- for use externally.
-    formatExternal :: a -> Rope
+    formatExternal :: ξ -> Rope
 
     -- | Attempt to read an external textual representation into a Haskell value.
-    parseExternal :: Rope -> Maybe a
+    parseExternal :: Rope -> Maybe ξ
 
 --
 -- We use this general instance here rather than as a super class constraint

--- a/core-data/lib/Core/Encoding/External.hs
+++ b/core-data/lib/Core/Encoding/External.hs
@@ -84,19 +84,48 @@ instance {-# OVERLAPPABLE #-} (Read a, Show a) => Externalize a where
     formatExternal = intoRope . show
     parseExternal = readMaybe . fromRope
 
+instance Externalize Rope where
+    formatExternal = id
+    parseExternal = Just
+
+instance Externalize String where
+    formatExternal = packRope
+    parseExternal = Just . fromRope
+
 --
 -- These weren't really necessary, but they're worth it as an example of
 -- avoiding Show & Read
 --
 
+{- |
+Integers are represented in decimal:
+
+@
+42
+@
+-}
 instance Externalize Int where
     formatExternal = intoRope . Builder.toLazyByteString . Builder.intDec
     parseExternal = readMaybe . fromRope
 
+{- |
+Integers are represented in decimal:
+
+@
+42
+@
+-}
 instance Externalize Int32 where
     formatExternal = intoRope . Builder.toLazyByteString . Builder.int32Dec
     parseExternal = readMaybe . fromRope
 
+{- |
+Integers are represented in decimal:
+
+@
+42
+@
+-}
 instance Externalize Int64 where
     formatExternal = intoRope . Builder.toLazyByteString . Builder.int64Dec
     parseExternal = readMaybe . fromRope
@@ -107,10 +136,10 @@ instance Externalize Int64 where
 --
 
 {- |
-UUIDs are formatted as per RFC 4122:
+Unique identifiers are formatted as per RFC 4122:
 
 @
-\"6937e157-d041-4919-8690-4d6c12b7e0e3\"
+6937e157-d041-4919-8690-4d6c12b7e0e3
 @
 -}
 instance Externalize Uuid.UUID where
@@ -127,7 +156,7 @@ instance Externalize Uuid.UUID where
 Timestamps are formatted as per ISO 8601:
 
 @
-\"2022-06-20T14:51:23.544826062Z\"
+2022-06-20T14:51:23.544826062Z
 @
 -}
 instance Externalize Time where
@@ -138,7 +167,7 @@ instance Externalize Time where
 Numbers are converted to scientific notation:
 
 @
-\"2.99792458e8\"
+2.99792458e8
 @
 -}
 instance Externalize Scientific where

--- a/core-data/package.yaml
+++ b/core-data/package.yaml
@@ -34,11 +34,13 @@ dependencies:
  - text
  - time
  - unordered-containers
+ - uuid
  - vector
- - core-text >= 0.3.7
 
 library:
   source-dirs: lib
+  dependencies:
+  - core-text >= 0.3.7
   exposed-modules:
    - Core.Data
    - Core.Data.Clock

--- a/core-data/package.yaml
+++ b/core-data/package.yaml
@@ -1,5 +1,5 @@
 name: core-data
-version: 0.3.3.1
+version: 0.3.4.0
 synopsis: Convenience wrappers around common data structures and encodings
 description: |
   Wrappers around common data structures and encodings.
@@ -42,9 +42,10 @@ library:
   exposed-modules:
    - Core.Data
    - Core.Data.Clock
-   - Core.Data.Format
+   - Core.Data.External
    - Core.Data.Structures
    - Core.Encoding
    - Core.Encoding.Json
-  other-modules: []
+  other-modules:
+   - Core.Data.Format
 

--- a/core-data/package.yaml
+++ b/core-data/package.yaml
@@ -42,9 +42,9 @@ library:
   exposed-modules:
    - Core.Data
    - Core.Data.Clock
-   - Core.Data.External
    - Core.Data.Structures
    - Core.Encoding
+   - Core.Encoding.External
    - Core.Encoding.Json
   other-modules:
    - Core.Data.Format

--- a/core-program/core-program.cabal
+++ b/core-program/core-program.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           core-program
-version:        0.5.0.4
+version:        0.5.1.0
 synopsis:       Opinionated Haskell Interoperability
 description:    A library to help build command-line programs, both tools and
                 longer-running daemons.

--- a/core-program/package.yaml
+++ b/core-program/package.yaml
@@ -1,5 +1,5 @@
 name: core-program
-version: 0.5.0.4
+version: 0.5.1.0
 synopsis: Opinionated Haskell Interoperability
 description: |
   A library to help build command-line programs, both tools and

--- a/core-text/core-text.cabal
+++ b/core-text/core-text.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           core-text
-version:        0.3.7.3
+version:        0.3.8.0
 synopsis:       A rope type based on a finger tree over UTF-8 fragments
 description:    A rope data type for text, built as a finger tree over UTF-8 text
                 fragments. The package also includes utiltiy functions for breaking and

--- a/core-text/lib/Core/Text/Rope.hs
+++ b/core-text/lib/Core/Text/Rope.hs
@@ -105,6 +105,7 @@ import Control.DeepSeq (NFData (..))
 import Core.Text.Bytes
 import Data.ByteString qualified as B (ByteString)
 import Data.ByteString.Builder qualified as B (
+    Builder,
     hPutBuilder,
     toLazyByteString,
  )
@@ -551,6 +552,20 @@ instance Textual B.ByteString where
     appendRope b' (Rope x) = case S.fromByteString b' of
         Just piece -> Rope ((F.|>) x piece)
         Nothing -> (Rope x) -- bad
+
+-- | from "Data.ByteString.Builder"
+instance Textual B.Builder where
+    fromRope = foldr g mempty . unRope
+      where
+        g piece built = (<>) (S.toBuilder piece) built
+    intoRope =
+        Rope
+            . ( L.foldrChunks
+                    ( (F.<|) . S.fromByteStringUnsafe
+                    )
+                    F.empty
+              )
+            . B.toLazyByteString
 
 -- | from "Data.ByteString.Lazy"
 instance Textual L.ByteString where

--- a/core-text/package.yaml
+++ b/core-text/package.yaml
@@ -1,5 +1,5 @@
 name: core-text
-version: 0.3.7.3
+version: 0.3.8.0
 synopsis: A rope type based on a finger tree over UTF-8 fragments
 description: |
   A rope data type for text, built as a finger tree over UTF-8 text

--- a/package.yaml
+++ b/package.yaml
@@ -48,9 +48,9 @@ github: aesiniath/unbeliever
 
 dependencies:
  - base >= 4.11 && < 5
- - core-text >= 0.3.7.3
- - core-data >= 0.3.3.1
- - core-program >= 0.5.0.3
+ - core-text >= 0.3.8.0
+ - core-data >= 0.3.4.0
+ - core-program >= 0.5.1.0
  - core-telemetry >= 0.2.3.5
  - core-webserver-servant >= 0.1.1.2
  - core-webserver-warp >= 0.1.1.6

--- a/package.yaml
+++ b/package.yaml
@@ -96,6 +96,7 @@ tests:
      - prettyprinter
      - QuickCheck
      - safe-exceptions
+     - scientific
      - stm
      - text
      - text-short
@@ -110,6 +111,7 @@ tests:
      - CheckArgumentsParsing
      - CheckBytesBehaviour
      - CheckContainerBehaviour
+     - CheckExternalizing
      - CheckJsonWrapper
      - CheckProgramMonad
      - CheckRopeBehaviour

--- a/tests/CheckExternalizing.hs
+++ b/tests/CheckExternalizing.hs
@@ -9,6 +9,7 @@ import Core.Text
 import Data.Int
 import Data.Scientific
 import Test.Hspec
+import Test.QuickCheck (property)
 
 checkExternalizing :: Spec
 checkExternalizing = do
@@ -21,6 +22,13 @@ checkExternalizing = do
             formatExternal (9223372036854775807 :: Int64) `shouldBe` packRope "9223372036854775807"
             parseExternal (packRope "9223372036854775807") `shouldBe` Just (9223372036854775807 :: Int64)
 
+        it "behaves when QuickChecked" $ do
+            property (prop_RoundTrip_External :: Int64 -> Bool)
+
         it "Scientific" $ do
             formatExternal (299792458 :: Scientific) `shouldBe` packRope "2.99792458e8"
             parseExternal (packRope "2.99792458e8") `shouldBe` Just (299792458 :: Scientific)
+
+
+prop_RoundTrip_External :: (Externalize a, Eq a) => a -> Bool
+prop_RoundTrip_External t = (parseExternal . formatExternal) t == Just t

--- a/tests/CheckExternalizing.hs
+++ b/tests/CheckExternalizing.hs
@@ -1,0 +1,26 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# OPTIONS_GHC -fno-warn-missing-signatures #-}
+
+module CheckExternalizing where
+
+import Core.Encoding.External
+import Core.Text
+import Data.Int
+import Data.Scientific
+import Test.Hspec
+
+checkExternalizing :: Spec
+checkExternalizing = do
+    describe "Values can be externalized" $ do
+        it "Int, Int32, Int64" $ do
+            formatExternal (42 :: Int) `shouldBe` packRope "42"
+            parseExternal (packRope "42") `shouldBe` Just (42 :: Int)
+            formatExternal (299792458 :: Int32) `shouldBe` packRope "299792458"
+            parseExternal (packRope "299792458") `shouldBe` Just (299792458 :: Int32)
+            formatExternal (9223372036854775807 :: Int64) `shouldBe` packRope "9223372036854775807"
+            parseExternal (packRope "9223372036854775807") `shouldBe` Just (9223372036854775807 :: Int64)
+
+        it "Scientific" $ do
+            formatExternal (299792458 :: Scientific) `shouldBe` packRope "2.99792458e8"
+            parseExternal (packRope "2.99792458e8") `shouldBe` Just (299792458 :: Scientific)

--- a/tests/TestSuite.hs
+++ b/tests/TestSuite.hs
@@ -3,6 +3,7 @@
 import CheckArgumentsParsing (checkArgumentsParsing)
 import CheckBytesBehaviour
 import CheckContainerBehaviour
+import CheckExternalizing (checkExternalizing)
 import CheckJsonWrapper
 import CheckProgramMonad
 import CheckRopeBehaviour (checkRopeBehaviour)
@@ -21,6 +22,7 @@ suite = do
     checkBytesBehaviour
     checkContainerBehaviour
     checkTimeStamp
+    checkExternalizing
     checkJsonWrapper
     checkArgumentsParsing
     checkProgramMonad

--- a/unbeliever.cabal
+++ b/unbeliever.cabal
@@ -64,10 +64,10 @@ executable experiment
   build-depends:
       base >=4.11 && <5
     , bytestring
-    , core-data >=0.3.3.1
-    , core-program >=0.5.0.3
+    , core-data >=0.3.4.0
+    , core-program >=0.5.1.0
     , core-telemetry >=0.2.3.5
-    , core-text >=0.3.7.3
+    , core-text >=0.3.8.0
     , core-webserver-servant >=0.1.1.2
     , core-webserver-warp >=0.1.1.6
     , prettyprinter
@@ -82,10 +82,10 @@ executable snippet
   ghc-options: -Wall -Wwarn -fwarn-tabs -threaded
   build-depends:
       base >=4.11 && <5
-    , core-data >=0.3.3.1
-    , core-program >=0.5.0.3
+    , core-data >=0.3.4.0
+    , core-program >=0.5.1.0
     , core-telemetry >=0.2.3.5
-    , core-text >=0.3.7.3
+    , core-text >=0.3.8.0
     , core-webserver-servant >=0.1.1.2
     , core-webserver-warp
     , http-types
@@ -117,10 +117,10 @@ test-suite check
     , async
     , base >=4.11 && <5
     , bytestring
-    , core-data >=0.3.3.1
-    , core-program >=0.5.0.3
+    , core-data >=0.3.4.0
+    , core-program >=0.5.1.0
     , core-telemetry >=0.2.3.5
-    , core-text >=0.3.7.3
+    , core-text >=0.3.8.0
     , core-webserver-servant >=0.1.1.2
     , core-webserver-warp >=0.1.1.6
     , fingertree
@@ -147,10 +147,10 @@ benchmark performance
   build-depends:
       base >=4.11 && <5
     , bytestring
-    , core-data >=0.3.3.1
-    , core-program >=0.5.0.3
+    , core-data >=0.3.4.0
+    , core-program >=0.5.1.0
     , core-telemetry >=0.2.3.5
-    , core-text >=0.3.7.3
+    , core-text >=0.3.8.0
     , core-webserver-servant >=0.1.1.2
     , core-webserver-warp >=0.1.1.6
     , gauge

--- a/unbeliever.cabal
+++ b/unbeliever.cabal
@@ -101,6 +101,7 @@ test-suite check
       CheckArgumentsParsing
       CheckBytesBehaviour
       CheckContainerBehaviour
+      CheckExternalizing
       CheckJsonWrapper
       CheckProgramMonad
       CheckRopeBehaviour
@@ -128,6 +129,7 @@ test-suite check
     , network-info
     , prettyprinter
     , safe-exceptions
+    , scientific
     , stm
     , text
     , text-short


### PR DESCRIPTION
Introduce module Core.Encoding.External with a helper class Externalizing for converting data to a stable external format and parsing externally sourced data back into Haskell values.

Closes #82.