### PR TITLE
Fix overriding span start time

### DIFF
--- a/core-telemetry/core-telemetry.cabal
+++ b/core-telemetry/core-telemetry.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           core-telemetry
-version:        0.2.3.5
+version:        0.2.3.6
 synopsis:       Advanced telemetry
 description:    This is part of a library to help build command-line programs, both tools and
                 longer-running daemons.

--- a/core-telemetry/lib/Core/Telemetry/Observability.hs
+++ b/core-telemetry/lib/Core/Telemetry/Observability.hs
@@ -437,12 +437,14 @@ encloseSpan label action = do
             internal ("Leave " <> label)
 
         -- extract the Datum as it stands after running the action, finalize
-        -- with its duration, and send it
+        -- with its duration, and send it. Note that we don't use the original
+        -- start time as it may have been overwritten.
         finish <- getCurrentTimeNanoseconds
         datum2 <- readMVar v2
+        let start2 = spanTimeFrom datum2
         let datum2' =
                 datum2
-                    { durationFrom = Just (unTime finish - unTime start)
+                    { durationFrom = Just (unTime finish - unTime start2)
                     }
 
         let tel = telemetryChannelFrom context

--- a/core-telemetry/package.yaml
+++ b/core-telemetry/package.yaml
@@ -1,5 +1,5 @@
 name: core-telemetry
-version: 0.2.3.5
+version: 0.2.3.6
 synopsis: Advanced telemetry
 description: |
   This is part of a library to help build command-line programs, both tools and


### PR DESCRIPTION
Fix bug exposed when calling `setStartTime`: we weren't using the revised overridden start Time when exiting from `encloseSpan`.