### PR TITLE
Fix technique used to close stdin of child process

### DIFF
--- a/core-program/core-program.cabal
+++ b/core-program/core-program.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           core-program
-version:        0.5.1.0
+version:        0.5.1.1
 synopsis:       Opinionated Haskell Interoperability
 description:    A library to help build command-line programs, both tools and
                 longer-running daemons.

--- a/core-program/lib/Core/Program/Execute.hs
+++ b/core-program/lib/Core/Program/Execute.hs
@@ -172,7 +172,7 @@ import System.Directory (
  )
 import System.Exit (ExitCode (..))
 import System.Posix.Process qualified as Posix (exitImmediately)
-import System.Process.Typed (closed, proc, readProcess, setStdin)
+import System.Process.Typed (nullStream, proc, readProcess, setStdin)
 import Prelude hiding (log)
 
 --
@@ -658,7 +658,7 @@ execProcess (cmd : args) =
     let cmd' = fromRope cmd
         args' = fmap fromRope args
         task = proc cmd' args'
-        task1 = setStdin closed task
+        task1 = setStdin nullStream task
         command = mconcat (List.intersperse (singletonRope ' ') (cmd : args))
      in do
             debug "command" command

--- a/core-program/package.yaml
+++ b/core-program/package.yaml
@@ -1,5 +1,5 @@
 name: core-program
-version: 0.5.1.0
+version: 0.5.1.1
 synopsis: Opinionated Haskell Interoperability
 description: |
   A library to help build command-line programs, both tools and


### PR DESCRIPTION
A problem was uncovered when invoking _ffmpeg_ using our `execProcess` helper. For some reason bytes are getting corrupted and the result was garbage audio being output! This is possibly because ffmpeg is reading stdin as well as the supplied file? We're not sure.

The solution was to change the way we close the stdin input stream for child process by switching to `nullStream` rather than `closed`.

It turns out the documentation for **typed-process** [discourages](https://hackage.haskell.org/package/typed-process-0.2.10.1/docs/System-Process-Typed.html#v:closed) the use of `closed` 

> You usually do not want to use this, as it will leave the corresponding file descriptor unassigned and hence available for re-use in the child process. Prefer `nullStream` unless you're certain you want this behavior.

I can't say as I saw that warning at the time when this code was first written in **publish** and even more astonishingly it hasn't caused any problem for over 5 years. Go figure.

Huge credit to @jack-davies for having identified this as the potential problem and many thanks to @StephenNorris for detailed examination of corrupt audio files which helped us realize that this area might indeed be the problem.