### PR TITLE
Fix documentation to expose Telemetry class

### DIFF
--- a/core-program/lib/Core/Program/Threads.hs
+++ b/core-program/lib/Core/Program/Threads.hs
@@ -297,8 +297,9 @@ Cancel a thread.
 
 (this wraps __async__\'s 'Control.Concurrent.Async.cancel'. The underlying
 mechanism used is to throw the 'AsyncCancelled' to the other thread. That
-exception is asynchronous, so will not be trapped by a 'catch' block and will
-indeed cause the thread receiving the exception to come to an end)
+exception is asynchronous, so will not be trapped by a
+'Core.Program.Exceptions.catch' block and will indeed cause the thread
+receiving the exception to come to an end)
 
 @since 0.4.5
 -}

--- a/core-telemetry/core-telemetry.cabal
+++ b/core-telemetry/core-telemetry.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           core-telemetry
-version:        0.2.3.7
+version:        0.2.3.8
 synopsis:       Advanced telemetry
 description:    This is part of a library to help build command-line programs, both tools and
                 longer-running daemons.

--- a/core-telemetry/lib/Core/Telemetry/Observability.hs
+++ b/core-telemetry/lib/Core/Telemetry/Observability.hs
@@ -229,6 +229,14 @@ setServiceName service = do
                 pure datum'
             )
 
+{-|
+Adaptor class to take primitive values and send them as metrics. The
+underlying types are either strings, numbers, or boolean so any instance will
+need to externalize and then convert to one of these three.
+
+(this class is what allows us to act pass in what look like polymorphic lists
+of metrics to 'telemetry' and 'sendEvent')
+-}
 class Telemetry σ where
     metric :: Rope -> σ -> MetricValue
 
@@ -600,7 +608,7 @@ Add measurements to the current span.
             ]
 @
 
-The 'metric' function is a method provided by instances of the 'Telemtetry'
+The 'metric' function is a method provided by instances of the 'Telemetry'
 typeclass which is mostly a wrapper around constructing key/value pairs
 suitable to be sent as measurements up to an observability service.
 -}

--- a/core-telemetry/package.yaml
+++ b/core-telemetry/package.yaml
@@ -1,5 +1,5 @@
 name: core-telemetry
-version: 0.2.3.7
+version: 0.2.3.8
 synopsis: Advanced telemetry
 description: |
   This is part of a library to help build command-line programs, both tools and


### PR DESCRIPTION
The Haddock links for `metric` wasn't going anywhere because Telemetry wasn't showing.