### PR TITLE
Add instances to telemetry for dates and optionals

### DIFF
--- a/core-telemetry/.gitignore
+++ b/core-telemetry/.gitignore
@@ -1,0 +1,1 @@
+dist-newstyle

--- a/core-telemetry/core-telemetry.cabal
+++ b/core-telemetry/core-telemetry.cabal
@@ -52,7 +52,7 @@ library
       async
     , base >=4.11 && <5
     , bytestring
-    , core-data >=0.3.3.1
+    , core-data >=0.3.4.0
     , core-program >=0.5.0.2
     , core-text >=0.3.7.1
     , exceptions
@@ -66,6 +66,7 @@ library
     , stm
     , template-haskell >=2.14 && <3
     , text
+    , time
     , unix
     , zlib
   default-language: Haskell2010

--- a/core-telemetry/lib/Core/Telemetry/Observability.hs
+++ b/core-telemetry/lib/Core/Telemetry/Observability.hs
@@ -166,11 +166,12 @@ import Control.Concurrent.MVar (modifyMVar_, newMVar, readMVar)
 import Control.Concurrent.STM (atomically)
 import Control.Concurrent.STM.TQueue (writeTQueue)
 import qualified Control.Exception.Safe as Safe
+import Core.Data.Clock
 import Core.Data.Structures (Map, emptyMap, insertKeyValue)
+import Core.Encoding.External
 import Core.Encoding.Json
 import Core.Program.Arguments
 import Core.Program.Context
-import Core.Data.Clock
 import Core.Program.Logging
 import Core.System.Base (SomeException, liftIO)
 import Core.Telemetry.Identifiers
@@ -182,6 +183,7 @@ import qualified Data.List as List (foldl')
 import Data.Scientific (Scientific)
 import qualified Data.Text as T (Text)
 import qualified Data.Text.Lazy as U (Text)
+import Data.Time.Clock (UTCTime)
 import GHC.Int
 import GHC.Word
 import System.Random (randomIO)
@@ -295,6 +297,12 @@ instance Telemetry Bool where
 
 instance Telemetry JsonValue where
     metric k v = MetricValue (JsonKey k) v
+
+instance Telemetry (Maybe a) where
+    metric k v = MetricValue (JsonKey k) (JsonString (formatExternal v))
+
+instance Telemetry UTCTime where
+    metric k v = MetricValue (JsonKey k) (JsonString (formatExternal . intoTime v))
 
 {- |
 Activate the telemetry subsystem for use within the

--- a/core-telemetry/package.yaml
+++ b/core-telemetry/package.yaml
@@ -34,7 +34,7 @@ library:
   dependencies:
    - async
    - core-text >= 0.3.7.1
-   - core-data >= 0.3.3.1
+   - core-data >= 0.3.4.0
    - core-program >= 0.5.0.2
    - exceptions
    - http-streams


### PR DESCRIPTION
Tried to add instances for `Telemetry (Maybe a)` and `Telemetry UTCTime`. Had troubles due to needing to bump version dependency of `core-data` to 0.3.4.0 or higher. @istathar said maybe he could fix these for me.