### PR TITLE
Fork forever threads

### DIFF
--- a/core-program/core-program.cabal
+++ b/core-program/core-program.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           core-program
-version:        0.5.1.1
+version:        0.5.2.0
 synopsis:       Opinionated Haskell Interoperability
 description:    A library to help build command-line programs, both tools and
                 longer-running daemons.

--- a/core-program/lib/Core/Program/Threads.hs
+++ b/core-program/lib/Core/Program/Threads.hs
@@ -26,6 +26,7 @@ Note that when you fire off a new thread the top-level application state is
 module Core.Program.Threads (
     -- * Concurrency
     forkThread,
+    forkThread_,
     waitThread,
     waitThread_,
     waitThread',
@@ -144,6 +145,17 @@ forkThread program = do
                 )
 
         return (Thread a)
+
+{-|
+Fork a thread with 'forkThread' but do not wait for a result. This is on the
+assumption that the sub program will either be a side-effect and over quickly,
+or long-running daemon thread (presumably containing a 'Control.Monad.forever'
+loop in it), never returning.
+
+@since 0.5.2
+-}
+forkThread_ :: Program τ α -> Program τ ()
+forkThread_ = void . forkThread
 
 {- |
 Wait for the completion of a thread, returning the result. This is a blocking

--- a/core-program/package.yaml
+++ b/core-program/package.yaml
@@ -1,5 +1,5 @@
 name: core-program
-version: 0.5.1.1
+version: 0.5.2.0
 synopsis: Opinionated Haskell Interoperability
 description: |
   A library to help build command-line programs, both tools and


### PR DESCRIPTION
Add a new helper `forkThread_` which discards the return value (and the return Thread wrapper, more to the point) facilitating launching daemon threads.