### PR TITLE
Preserve service name when clearing trace state

### DIFF
--- a/core-telemetry/core-telemetry.cabal
+++ b/core-telemetry/core-telemetry.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           core-telemetry
-version:        0.2.5.0
+version:        0.2.5.1
 synopsis:       Advanced telemetry
 description:    This is part of a library to help build command-line programs, both tools and
                 longer-running daemons.

--- a/core-telemetry/lib/Core/Telemetry/Observability.hs
+++ b/core-telemetry/lib/Core/Telemetry/Observability.hs
@@ -756,7 +756,12 @@ clearMetrics = do
         let v = currentDatumFrom context
         modifyMVar_
             v
-            (\datum -> pure datum{attachedMetadataFrom = emptyMap})
+            ( \datum ->
+                pure
+                    datum
+                        { attachedMetadataFrom = emptyMap
+                        }
+            )
 
 {- |
 Reset the program context so that the currently executing program is no longer
@@ -764,6 +769,10 @@ within a trace or span.
 
 This is specifically for the occasion where you have forked a new thread but
 have not yet received the event which would occasion starting a new trace.
+
+The current "service name" associated with this execution thread is preserved
+(usually this is set once per process at startup or once with 'setServiceName'
+and having to reset it everytime you call this would be silly).
 
 @since 0.2.4
 -}
@@ -775,4 +784,10 @@ clearTrace = do
         let v = currentDatumFrom context
         modifyMVar_
             v
-            (\_ -> pure emptyDatum)
+            ( \datum -> do
+                let name = serviceNameFrom datum
+                pure
+                    emptyDatum
+                        { serviceNameFrom = name
+                        }
+            )

--- a/core-telemetry/package.yaml
+++ b/core-telemetry/package.yaml
@@ -1,5 +1,5 @@
 name: core-telemetry
-version: 0.2.5.0
+version: 0.2.5.1
 synopsis: Advanced telemetry
 description: |
   This is part of a library to help build command-line programs, both tools and


### PR DESCRIPTION
When resetting the trace state with `clearTrace`, don't reset the service name. As commented, the "service name" is set once per process at process startup or once with `setServiceName` and having to reset it everytime you call `clearTrace` proved annoying.