### PR TITLE
More instances relating to identifiers

### DIFF
--- a/core-data/core-data.cabal
+++ b/core-data/core-data.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           core-data
-version:        0.3.5.0
+version:        0.3.6.0
 synopsis:       Convenience wrappers around common data structures and encodings
 description:    Wrappers around common data structures and encodings.
                 .

--- a/core-data/lib/Core/Encoding/External.hs
+++ b/core-data/lib/Core/Encoding/External.hs
@@ -54,6 +54,8 @@ import Core.Text.Rope
 import Data.ByteString.Builder qualified as Builder
 import Data.Int (Int32, Int64)
 import Data.Scientific (FPFormat (Exponent), Scientific, formatScientific)
+import Data.Time.Calendar qualified as Base (Day)
+import Data.Time.Format.ISO8601 qualified as Base (formatParseM, formatShow, iso8601Format)
 import Data.UUID qualified as Uuid (UUID, fromText, toText)
 import Text.Read (readMaybe)
 
@@ -200,6 +202,17 @@ Timestamps are formatted as per ISO 8601:
 instance Externalize Time where
     formatExternal = intoRope . show
     parseExternal = readMaybe . fromRope
+
+{- |
+Days are formatted as per ISO 8601:
+
+@
+2022-06-20
+@
+-}
+instance Externalize Base.Day where
+    formatExternal = intoRope . Base.formatShow Base.iso8601Format
+    parseExternal = Base.formatParseM Base.iso8601Format . fromRope
 
 {- |
 Numbers are converted to scientific notation:

--- a/core-data/package.yaml
+++ b/core-data/package.yaml
@@ -1,5 +1,5 @@
 name: core-data
-version: 0.3.5.0
+version: 0.3.6.0
 synopsis: Convenience wrappers around common data structures and encodings
 description: |
   Wrappers around common data structures and encodings.

--- a/core-telemetry/core-telemetry.cabal
+++ b/core-telemetry/core-telemetry.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           core-telemetry
-version:        0.2.5.1
+version:        0.2.5.2
 synopsis:       Advanced telemetry
 description:    This is part of a library to help build command-line programs, both tools and
                 longer-running daemons.
@@ -68,5 +68,6 @@ library
     , text
     , time
     , unix
+    , uuid-types
     , zlib
   default-language: Haskell2010

--- a/core-telemetry/core-telemetry.cabal
+++ b/core-telemetry/core-telemetry.cabal
@@ -52,7 +52,7 @@ library
       async
     , base >=4.11 && <5
     , bytestring
-    , core-data >=0.3.4.0
+    , core-data >=0.3.6.0
     , core-program >=0.5.0.2
     , core-text >=0.3.7.1
     , exceptions

--- a/core-telemetry/lib/Core/Telemetry/Observability.hs
+++ b/core-telemetry/lib/Core/Telemetry/Observability.hs
@@ -330,7 +330,7 @@ instance Telemetry UTCTime where
 @since 0.2.5
 -}
 instance Telemetry Day where
-    metric k v = MetricValue (JsonKey k) (JsonString (intoRope (show v)))
+    metric k v = MetricValue (JsonKey k) (JsonString (formatExternal v))
 
 {- |
 @since 0.2.5

--- a/core-telemetry/lib/Core/Telemetry/Observability.hs
+++ b/core-telemetry/lib/Core/Telemetry/Observability.hs
@@ -185,7 +185,9 @@ import Data.List qualified as List (foldl')
 import Data.Scientific (Scientific)
 import Data.Text qualified as T (Text)
 import Data.Text.Lazy qualified as U (Text)
+import Data.Time.Calendar (Day)
 import Data.Time.Clock (UTCTime)
+import Data.UUID.Types (UUID)
 import GHC.Int
 import GHC.Word
 import System.Random (randomIO)
@@ -323,6 +325,18 @@ instance Telemetry σ => Telemetry (Maybe σ) where
 -}
 instance Telemetry UTCTime where
     metric k v = MetricValue (JsonKey k) (JsonString (formatExternal (intoTime v)))
+
+{- |
+@since 0.2.5
+-}
+instance Telemetry Day where
+    metric k v = MetricValue (JsonKey k) (JsonString (intoRope (show v)))
+
+{- |
+@since 0.2.5
+-}
+instance Telemetry UUID where
+    metric k v = MetricValue (JsonKey k) (JsonString (formatExternal v))
 
 {- |
 Activate the telemetry subsystem for use within the

--- a/core-telemetry/package.yaml
+++ b/core-telemetry/package.yaml
@@ -1,5 +1,5 @@
 name: core-telemetry
-version: 0.2.5.1
+version: 0.2.5.2
 synopsis: Advanced telemetry
 description: |
   This is part of a library to help build command-line programs, both tools and
@@ -47,6 +47,7 @@ library:
    - stm
    - time
    - unix
+   - uuid-types
    - zlib
   source-dirs:
   - lib

--- a/core-telemetry/package.yaml
+++ b/core-telemetry/package.yaml
@@ -34,7 +34,7 @@ library:
   dependencies:
    - async
    - core-text >= 0.3.7.1
-   - core-data >= 0.3.4.0
+   - core-data >= 0.3.6.0
    - core-program >= 0.5.0.2
    - exceptions
    - http-streams

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2022-07-30
+resolver: nightly-2022-08-15
 compiler: ghc-9.2.2
 packages:
  - ./core-data

--- a/tests/CheckExternalizing.hs
+++ b/tests/CheckExternalizing.hs
@@ -4,10 +4,12 @@
 
 module CheckExternalizing where
 
+import Core.Data
 import Core.Encoding.External
 import Core.Text
 import Data.Int
 import Data.Scientific
+import Data.Time.Calendar (Day (ModifiedJulianDay))
 import Test.Hspec
 import Test.QuickCheck (property)
 
@@ -25,10 +27,15 @@ checkExternalizing = do
         it "behaves when QuickChecked" $ do
             property (prop_RoundTrip_External :: Int64 -> Bool)
 
+        it "Timestamps and Days" $ do
+            formatExternal (intoTime (1660802416710578538 :: Int64)) `shouldBe` packRope "2022-08-18T06:00:16.710578538Z"
+            parseExternal (packRope "2022-08-18T06:00:16.710578538Z") `shouldBe` Just (intoTime (1660802416710578538 :: Int64))
+            formatExternal (ModifiedJulianDay 59809) `shouldBe` packRope "2022-08-18"
+            parseExternal (packRope "2022-08-18") `shouldBe` Just (ModifiedJulianDay 59809)
+
         it "Scientific" $ do
             formatExternal (299792458 :: Scientific) `shouldBe` packRope "2.99792458e8"
             parseExternal (packRope "2.99792458e8") `shouldBe` Just (299792458 :: Scientific)
-
 
 prop_RoundTrip_External :: (Externalize a, Eq a) => a -> Bool
 prop_RoundTrip_External t = (parseExternal . formatExternal) t == Just t


### PR DESCRIPTION
We keep wanting to send telemetry about identifiers. While the user can convert it's supposed to be convenient, so add additional Externalize and Telemetry instances, notably UTCTime, UUID. Part of this was already done in:

- https://github.com/aesiniath/unbeliever/pull/147