### PR TITLE
Change from async to ki

### DIFF
--- a/core-program/core-program.cabal
+++ b/core-program/core-program.cabal
@@ -66,7 +66,7 @@ library
     , fsnotify
     , hashable >=1.2
     , hourglass
-    , ki
+    , ki >=1.0.0
     , mtl
     , prettyprinter >=1.6.2
     , safe-exceptions

--- a/core-program/core-program.cabal
+++ b/core-program/core-program.cabal
@@ -55,8 +55,7 @@ library
       lib
   ghc-options: -Wall -Wwarn -fwarn-tabs
   build-depends:
-      async
-    , base >=4.11 && <5
+      base >=4.11 && <5
     , bytestring
     , core-data >=0.3.4
     , core-text >=0.3.8

--- a/core-program/core-program.cabal
+++ b/core-program/core-program.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           core-program
-version:        0.5.2.0
+version:        0.6.0.0
 synopsis:       Opinionated Haskell Interoperability
 description:    A library to help build command-line programs, both tools and
                 longer-running daemons.
@@ -66,6 +66,7 @@ library
     , fsnotify
     , hashable >=1.2
     , hourglass
+    , ki
     , mtl
     , prettyprinter >=1.6.2
     , safe-exceptions

--- a/core-program/lib/Core/Program/Context.hs
+++ b/core-program/lib/Core/Program/Context.hs
@@ -49,6 +49,7 @@ import Core.Encoding.Json
 import Core.Program.Arguments
 import Core.Program.Metadata
 import Core.System.Base
+import Ki qualified as Ki (Scope)
 import Core.Text.Rope
 import Data.Foldable (foldrM)
 import Data.Int (Int64)
@@ -175,6 +176,7 @@ data Context τ = Context
     , outputChannelFrom :: TQueue (Maybe Rope) -- communication channels
     , telemetryChannelFrom :: TQueue (Maybe Datum) -- machinery for telemetry
     , telemetryForwarderFrom :: Maybe Forwarder
+    , currentScopeFrom :: Maybe Ki.Scope
     , currentDatumFrom :: MVar Datum
     , applicationDataFrom :: MVar τ
     }
@@ -374,6 +376,7 @@ configure version t config = do
             , outputChannelFrom = out
             , telemetryChannelFrom = tel
             , telemetryForwarderFrom = Nothing
+            , currentScopeFrom = Nothing
             , currentDatumFrom = v
             , applicationDataFrom = u
             }

--- a/core-program/lib/Core/Program/Context.hs
+++ b/core-program/lib/Core/Program/Context.hs
@@ -49,11 +49,11 @@ import Core.Encoding.Json
 import Core.Program.Arguments
 import Core.Program.Metadata
 import Core.System.Base
-import Ki qualified as Ki (Scope)
 import Core.Text.Rope
 import Data.Foldable (foldrM)
 import Data.Int (Int64)
 import Data.String (IsString)
+import Ki qualified as Ki (Scope)
 import Prettyprinter (LayoutOptions (..), PageWidth (..), layoutPretty)
 import Prettyprinter.Render.Text (renderIO)
 import System.Console.Terminal.Size qualified as Terminal (Window (..), size)

--- a/core-program/lib/Core/Program/Execute.hs
+++ b/core-program/lib/Core/Program/Execute.hs
@@ -279,11 +279,8 @@ executeActual context0 program = do
 
     -- wait for indication to terminate
     code <- readMVar quit
-    putStr "CODE " >> print code
 
     killThread t1
-
-    putStrLn "HERE"
 
     -- instruct handlers to finish, and wait for the message queues to
     -- drain. Allow 10 seconds, then timeout, in case something has gone
@@ -303,8 +300,6 @@ executeActual context0 program = do
         writeTQueue out Nothing
 
     readMVar vo
-
-    putStrLn "DONE"
 
     hFlush stdout
 

--- a/core-program/lib/Core/Program/Execute.hs
+++ b/core-program/lib/Core/Program/Execute.hs
@@ -105,24 +105,14 @@ module Core.Program.Execute (
 ) where
 
 import Control.Concurrent (threadDelay)
-import Control.Concurrent.Async (
-    ExceptionInLinkedThread (..),
- )
-import Control.Concurrent.Async qualified as Async (
-    async,
-    cancel,
-    race_,
-    wait,
- )
 import Control.Concurrent.MVar (
     MVar,
     modifyMVar_,
     putMVar,
     readMVar,
+    tryPutMVar,
  )
-import Control.Concurrent.STM (
-    atomically,
- )
+import Control.Concurrent.STM (atomically)
 import Control.Concurrent.STM.TQueue (
     TQueue,
     readTQueue,
@@ -133,7 +123,6 @@ import Control.Concurrent.STM.TQueue (
 import Control.Exception qualified as Base (throwIO)
 import Control.Exception.Safe qualified as Safe (
     catch,
-    catchesAsync,
     throw,
  )
 import Control.Monad (
@@ -166,55 +155,13 @@ import Data.ByteString.Char8 qualified as C (singleton)
 import Data.List qualified as List (intersperse)
 import GHC.Conc (getNumProcessors, numCapabilities, setNumCapabilities)
 import GHC.IO.Encoding (setLocaleEncoding, utf8)
-import Ki qualified as Ki (await, fork, forkTry, fork_, scoped)
+import Ki qualified as Ki (await, fork, fork_, scoped)
 import System.Directory (
     findExecutable,
  )
 import System.Exit (ExitCode (..))
-import System.Posix.Process qualified as Posix (exitImmediately)
 import System.Process.Typed (nullStream, proc, readProcess, setStdin)
 import Prelude hiding (log)
-
---
--- If an exception escapes, we'll catch it here. The displayException value
--- for some exceptions is really quit unhelpful, so we pattern match the
--- wrapping gumpf away for cases as we encounter them. The final entry is the
--- catch-all.
---
--- Note this is called via Safe.catchesAsync because we want to be able to
--- strip out ExceptionInLinkedThread (which is asynchronous and otherwise
--- reasonably special) from the final output message.
---
-escapeHandlers :: Context c -> [Handler IO ExitCode]
-escapeHandlers context =
-    [ Handler (\(code :: ExitCode) -> pure code)
-    , Handler (\(ExceptionInLinkedThread _ e) -> bail e)
-    , Handler (\(e :: SomeException) -> bail e)
-    ]
-  where
-    bail :: Exception e => e -> IO ExitCode
-    bail e =
-        let text = intoRope (displayException e)
-         in do
-                subProgram context $ do
-                    setVerbosityLevel Debug
-                    critical text
-                pure (ExitFailure 127)
-
---
--- If an exception occurs in one of the output handlers, its failure causes
--- a subsequent race condition when the program tries to clean up and drain
--- the queues. So we use `exitImmediately` (which we normally avoid, as it
--- unhelpfully destroys the parent process if you're in ghci) because we
--- really need the process to go down and we're in an inconsistent state
--- where debug or console output is no longer possible.
---
-collapseHandler :: String -> SomeException -> IO ()
-collapseHandler problem e = do
-    putStr "error: "
-    putStrLn problem
-    print e
-    Posix.exitImmediately (ExitFailure 99)
 
 {- |
 Trap any exceptions coming out of the given Program action, and discard them.
@@ -287,67 +234,77 @@ executeActual context0 program = do
         tel = telemetryChannelFrom context
         forwarder = telemetryForwarderFrom context
 
-    -- set up signal handlers
-    _ <-
-        Async.async $ do
+    code <- Ki.scoped $ \outer -> do
+        -- set up signal handlers
+        _ <- Ki.fork outer $ do
             setupSignalHandlers quit level
 
-    -- set up standard output
-    o <-
-        Async.async $ do
-            processStandardOutput out
+        -- set up standard output
+        o <-
+            Ki.fork outer $ do
+                processStandardOutput out
 
-    -- set up debug logger
-    l <-
-        Async.async $ do
-            processTelemetryMessages forwarder level out tel
+        -- set up debug logger
+        l <-
+            Ki.fork outer $ do
+                processTelemetryMessages forwarder level out tel
 
-    -- run actual program, ensuring to grab any otherwise uncaught exceptions.
-    code <-
-        Safe.catchesAsync
-            ( do
-                result <-
-                    Ki.scoped $ \scope -> do
-                        t <- Ki.forkTry scope $ do
-                            Ki.fork_ scope $ do
-                                code <- readMVar quit
-                                Safe.throw code
+        -- run actual program, ensuring to grab any otherwise uncaught exceptions.
+        _ <- Ki.fork outer $ do
+            Safe.catch
+                ( do
+                    --
+                    -- execute actual "main". Note that we're not passing the
+                    -- Scope into the program's Context; it stays the default
+                    -- Nothing because the outer Scope is none of the
+                    -- program's business and we absolutely don't want an
+                    -- awaitAll to sit there and block on our machinery
+                    -- threads.
+                    --
+                    -- We use tryPutMVar here (rather than putMVar) because we
+                    -- might already be on the way out and need to not block.
+                    --
+                    _ <- subProgram context program
+                    tryPutMVar quit ExitSuccess
+                )
+                ( \(e :: SomeException) -> do
+                    let text = intoRope (displayException e)
+                    subProgram context $ do
+                        setVerbosityLevel Debug
+                        critical text
+                    tryPutMVar quit (ExitFailure 127)
+                )
 
-                            -- execute actual "main"
-                            _ <- subProgram context program
-                            pure ()
+        -- wait for indication to terminate, and start doing
+        code <- readMVar quit
+        putStr "CODE " >> print code
 
-                        atomically $ do
-                                Ki.await t
+        putStrLn "HERE"
 
-                case (result :: Either ExitCode ()) of
-                    Left code' -> pure code'
-                    Right () -> pure ExitSuccess
-            )
-            (escapeHandlers context)
+        -- instruct handlers to finish, and wait for the message queues to
+        -- drain. Allow 10 seconds, then timeout, in case something has gone
+        -- wrong and queues don't empty.
 
-    -- instruct handlers to finish, and wait for the message queues to drain.
-    -- Allow 10 seconds, then timeout, in case something has gone wrong and
-    -- queues don't empty.
-    Async.race_
-        ( do
-            atomically $ do
-                writeTQueue tel Nothing
-
-            Async.wait l
-
-            atomically $ do
-                writeTQueue out Nothing
-
-            Async.wait o
-        )
-        ( do
+        Ki.fork_ outer $ do
             threadDelay 10000000
-
-            Async.cancel l
-            Async.cancel o
             putStrLn "error: Timeout"
-        )
+            Safe.throw (ExitFailure 99)
+
+        atomically $ do
+            writeTQueue tel Nothing
+
+        atomically $ do
+            Ki.await l
+
+        atomically $ do
+            writeTQueue out Nothing
+
+        atomically $ do
+            Ki.await o
+
+        putStrLn "DONE"
+
+        pure code
 
     hFlush stdout
 
@@ -358,9 +315,7 @@ executeActual context0 program = do
 
 processStandardOutput :: TQueue (Maybe Rope) -> IO ()
 processStandardOutput out =
-    Safe.catch
-        (loop)
-        (collapseHandler "output processing collapsed")
+    loop
   where
     loop :: IO ()
     loop = do
@@ -395,9 +350,7 @@ processTelemetryMessages Nothing _ _ tel = do
             Just _ -> do
                 ignoreForever queue
 processTelemetryMessages (Just processor) v out tel = do
-    Safe.catch
-        (loopForever action v out tel)
-        (collapseHandler "telemetry processing collapsed")
+    loopForever action v out tel
   where
     action = telemetryHandlerFrom processor
 

--- a/core-program/lib/Core/Program/Threads.hs
+++ b/core-program/lib/Core/Program/Threads.hs
@@ -153,14 +153,15 @@ forkThread program = do
 
         a <- Ki.fork scope $ do
             Safe.catch
-                (subProgram context' program)
-                ( \(e :: SomeException) ->
+                ( do
+                    subProgram context' program
+                )
+                ( \(e :: SomeException) -> do
                     let text = intoRope (displayException e)
-                     in do
-                            subProgram context' $ do
-                                warn "Uncaught exception in thread"
-                                debug "e" text
-                            Safe.throw e
+                    subProgram context' $ do
+                        internal "Uncaught exception ending thread"
+                        internal ("e = " <> text)
+                    Safe.throw e
                 )
 
         return (Thread a)

--- a/core-program/lib/Core/Program/Threads.hs
+++ b/core-program/lib/Core/Program/Threads.hs
@@ -64,7 +64,10 @@ import Ki qualified as Ki (Scope, Thread, await, awaitAll, fork, scoped)
 {- |
 A thread for concurrent computation.
 
-(this wraps __async__'s 'Async')
+(this wraps __ki__'s 'Thread' which in turn wraps __base__'s
+'Control.Concurrent.ThreadId')
+
+@since 0.6.0
 -}
 newtype Thread α = Thread (Ki.Thread α)
 

--- a/core-program/lib/Core/Program/Threads.hs
+++ b/core-program/lib/Core/Program/Threads.hs
@@ -31,7 +31,6 @@ module Core.Program.Threads (
     waitThread_,
     waitThread',
     waitThreads',
-    linkThread,
     cancelThread,
 
     -- * Helper functions
@@ -43,6 +42,7 @@ module Core.Program.Threads (
     -- * Internals
     Thread,
     unThread,
+    getScope,
 ) where
 
 import Control.Concurrent.Async (Async, AsyncCancelled)
@@ -61,6 +61,7 @@ import Control.Concurrent.MVar (
     newMVar,
     readMVar,
  )
+import Control.Concurrent.STM (atomically, orElse)
 import Control.Exception.Safe qualified as Safe (catch, catchAsync, throw)
 import Control.Monad (
     void,
@@ -70,16 +71,24 @@ import Core.Program.Context
 import Core.Program.Logging
 import Core.System.Base
 import Core.Text.Rope
+import Ki qualified as Ki (Scope, Thread, await, awaitAll, fork, scoped)
 
 {- |
 A thread for concurrent computation.
 
 (this wraps __async__'s 'Async')
 -}
-newtype Thread α = Thread (Async α)
+newtype Thread α = Thread (Ki.Thread α)
 
-unThread :: Thread α -> Async α
+unThread :: Thread α -> Ki.Thread α
 unThread (Thread a) = a
+
+getScope :: Context τ -> Ki.Scope
+getScope context =
+    let possibleScope = currentScopeFrom context
+     in case possibleScope of
+            Nothing -> error "Attempt to use a Context that is not within an executing Program monad"
+            Just scope -> scope
 
 {- |
 Fork a thread. The child thread will run in the same @Context@ as the calling
@@ -107,7 +116,7 @@ forkThread program = do
     context <- ask
     let i = startTimeFrom context
     let v = currentDatumFrom context
-
+    let scope = getScope context
     liftIO $ do
         -- if someone calls resetTimer in the thread it should just be that
         -- thread's local duration that is affected, not the parent. We simply
@@ -132,7 +141,7 @@ forkThread program = do
 
         -- fork, and run nested program
 
-        a <- Async.async $ do
+        a <- Ki.fork scope $ do
             Safe.catch
                 (subProgram context' program)
                 ( \(e :: SomeException) ->
@@ -146,7 +155,7 @@ forkThread program = do
 
         return (Thread a)
 
-{-|
+{- |
 Fork a thread with 'forkThread' but do not wait for a result. This is on the
 assumption that the sub program will either be a side-effect and over quickly,
 or long-running daemon thread (presumably containing a 'Control.Monad.forever'
@@ -177,12 +186,8 @@ ensure the behaviour described above)
 -}
 waitThread :: Thread α -> Program τ α
 waitThread (Thread a) = liftIO $ do
-    Safe.catchAsync
-        (Async.wait a)
-        ( \(e :: AsyncCancelled) -> do
-            Async.cancel a
-            Safe.throw e
-        )
+    atomically $ do
+        Ki.await a
 
 {- |
 Wait for the completion of a thread, discarding its result. This is
@@ -209,7 +214,7 @@ value.
 @since 0.2.7
 -}
 waitThread_ :: Thread α -> Program τ ()
-waitThread_ = void . waitThread
+waitThread_ t = void (waitThread t)
 
 {- |
 Wait for a thread to complete, returning the result if the computation was
@@ -226,14 +231,14 @@ being watched as well.
 -}
 waitThread' :: Thread α -> Program τ (Either SomeException α)
 waitThread' (Thread a) = liftIO $ do
-    Safe.catchAsync
+    Safe.catch
         ( do
-            result <- Async.waitCatch a
-            pure result
+            result <- atomically $ do
+                Ki.await a
+            pure (Right result)
         )
-        ( \(e :: AsyncCancelled) -> do
-            Async.cancel a
-            Safe.throw e
+        ( \(e :: SomeException) -> do
+            pure (Left e)
         )
 
 {- |
@@ -278,47 +283,63 @@ described throughout this module)
 @since 0.4.5
 -}
 waitThreads' :: [Thread α] -> Program τ [Either SomeException α]
-waitThreads' ts = liftIO $ do
+waitThreads' ts = liftIO $ undefined
+
+{-
     let as = fmap unThread ts
     Safe.catchAsync
         ( do
-            results <- mapM Async.waitCatch as
+            results <- atomically $ do
+                mapM Ki.await as
             pure results
         )
         ( \(e :: AsyncCancelled) -> do
             mapM_ Async.cancel as
             Safe.throw e
         )
-
-{- |
-Ordinarily if an exception is thrown in a forked thread that exception is
-silently swollowed. If you instead need the exception to propegate back to the
-parent thread, you can \"link\" the two together using this function.
-
-(this wraps __async__\'s 'Control.Concurrent.Async.link')
-
-@since 0.4.2
 -}
-linkThread :: Thread α -> Program τ ()
-linkThread (Thread a) = do
-    liftIO $ do
-        Async.link a
 
 {- |
-Cancel a thread.
+Wait for many threads to complete. This function is intended for the scenario
+where you fire off a number of worker threads with `forkThread` but rather
+than leaving them to run independantly, you need to wait for them all to
+complete.
 
-(this wraps __async__\'s 'Control.Concurrent.Async.cancel'. The underlying
-mechanism used is to throw the 'AsyncCancelled' to the other thread. That
-exception is asynchronous, so will not be trapped by a
-'Core.Program.Exceptions.catch' block and will indeed cause the thread
-receiving the exception to come to an end)
+(this extends __ki__\'s 'Ki.awaitAll' to work across a list of Threads)
 
+@since 0.6.0
+-}
+waitThreads :: [Thread α] -> Program τ ()
+waitThreads ts = liftIO $ do
+    atomically $ do
+        mapM_ (Ki.await . unThread) ts
+
+{- |
+Wait for all child threads in the current scope to complete.
+
+(this wraps __ki__\'s 'Ki.awaitAll' )
+
+@since 0.6.0
+-}
+waitThreadsAll :: Program τ ()
+waitThreadsAll = do
+    context <- ask
+    let possibleScope = currentScopeFrom context
+    scope <- case possibleScope of
+        Nothing -> error "Invalid use of waitThreadsAll without an enclosing scope"
+        Just value -> pure value
+
+    liftIO $ do
+        atomically $ do
+            Ki.awaitAll scope
+
+{- |
 @since 0.4.5
 -}
 cancelThread :: Thread α -> Program τ ()
 cancelThread (Thread a) = do
-    liftIO $ do
-        Async.cancel a
+    error "No longer"
+{-# DEPRECATED cancelThread "No longer implemented" #-}
 
 {- |
 Fork two threads and wait for both to finish. The return value is the pair of
@@ -345,9 +366,18 @@ concurrentThreads :: Program τ α -> Program τ β -> Program τ (α, β)
 concurrentThreads one two = do
     context <- ask
     liftIO $ do
-        Async.concurrently
-            (subProgram context one)
-            (subProgram context two)
+        Ki.scoped $ \scope -> do
+            a1 <- Ki.fork scope $ do
+                subProgram context one
+
+            a2 <- Ki.fork scope $ do
+                subProgram context two
+
+            atomically $ do
+                result1 <- Ki.await a1
+                result2 <- Ki.await a2
+
+                pure (result1, result2)
 
 {- |
 Fork two threads and wait for both to finish.
@@ -361,12 +391,7 @@ running will be cancelled and the original exception is then re-thrown.
 @since 0.4.0
 -}
 concurrentThreads_ :: Program τ α -> Program τ β -> Program τ ()
-concurrentThreads_ one two = do
-    context <- ask
-    liftIO $ do
-        Async.concurrently_
-            (subProgram context one)
-            (subProgram context two)
+concurrentThreads_ one two = void (concurrentThreads one two)
 
 {- |
 Fork two threads and race them against each other. This blocks until one or
@@ -395,9 +420,21 @@ raceThreads :: Program τ α -> Program τ β -> Program τ (Either α β)
 raceThreads one two = do
     context <- ask
     liftIO $ do
-        Async.race
-            (subProgram context one)
-            (subProgram context two)
+        Ki.scoped $ \scope -> do
+            t1 <- Ki.fork scope $ do
+                result1 <- subProgram context{currentScopeFrom = Just scope} one
+                pure (Left result1)
+
+            t2 <- Ki.fork scope $ do
+                result2 <- subProgram context{currentScopeFrom = Just scope} two
+                pure (Right result2)
+
+            result <- atomically $ do
+                orElse
+                    (Ki.await t1)
+                    (Ki.await t2)
+
+            pure result
 
 {- |
 Fork two threads and race them against each other. When one action completes
@@ -418,9 +455,4 @@ timeouts:
 @since 0.4.0
 -}
 raceThreads_ :: Program τ α -> Program τ β -> Program τ ()
-raceThreads_ one two = do
-    context <- ask
-    liftIO $ do
-        Async.race_
-            (subProgram context one)
-            (subProgram context two)
+raceThreads_ one two = void (raceThreads one two)

--- a/core-program/lib/Core/Program/Threads.hs
+++ b/core-program/lib/Core/Program/Threads.hs
@@ -74,12 +74,10 @@ newtype Thread α = Thread (Ki.Thread α)
 unThread :: Thread α -> Ki.Thread α
 unThread (Thread a) = a
 
-getScope :: Context τ -> Ki.Scope
-getScope context =
-    let possibleScope = currentScopeFrom context
-     in case possibleScope of
-            Nothing -> error "Attempt to fork a thread outside of an enclosing scope"
-            Just scope -> scope
+getScope :: Program τ (Maybe Ki.Scope)
+getScope = do
+    context <- ask
+    pure (currentScopeFrom context)
 
 {- |
 Create a scope to enclose any subsequently spawned threads.
@@ -126,7 +124,10 @@ forkThread program = do
     context <- ask
     let i = startTimeFrom context
     let v = currentDatumFrom context
-    let scope = getScope context
+    let scope = case currentScopeFrom context of
+            Nothing -> error "Attempt to fork a thread outside of an enclosing scope"
+            Just scope' -> scope'
+
     liftIO $ do
         -- if someone calls resetTimer in the thread it should just be that
         -- thread's local duration that is affected, not the parent. We simply

--- a/core-program/lib/Core/Program/Threads.hs
+++ b/core-program/lib/Core/Program/Threads.hs
@@ -187,12 +187,11 @@ If the thread you are waiting on throws an exception it will be rethrown by
 
 If the current thread making this call is cancelled (as a result of being on
 the losing side of 'concurrentThreads' or 'raceThreads' for example, or due to
-an explicit call to 'cancelThread'), then the thread you are waiting on will
-be cancelled. This is necessary to ensure that child threads are not leaked if
+the current Scope exiting), then the thread you are waiting on will be
+cancelled. This is necessary to ensure that child threads are not leaked if
 you nest `forkThread`s.
 
-(this wraps __async__\'s 'Control.Concurrent.Async.wait', taking care to
-ensure the behaviour described above)
+(this wraps __ki__\'s 'Ki.await')
 
 @since 0.2.7
 -}
@@ -236,8 +235,6 @@ This basically is convenience for calling `waitThread` and putting `catch`
 around it, but as with all the other @wait*@ functions this ensures that if
 the thread waiting is killed the cancellation is propagated to the thread
 being watched as well.
-
-(this wraps __async__\'s 'Control.Concurrent.Async.waitCatch')
 
 @since 0.4.5
 -}
@@ -300,8 +297,6 @@ running will be cancelled and the original exception is then re-thrown.
 For a variant that ingores the return values and just waits for both see
 'concurrentThreads_' below.
 
-(this wraps __async__\'s 'Control.Concurrent.Async.concurrently')
-
 @since 0.4.0
 -}
 concurrentThreads :: Program τ α -> Program τ β -> Program τ (α, β)
@@ -328,8 +323,6 @@ This is the same as calling 'forkThread' and 'waitThread_' twice, except that
 if either sub-program fails with an exception the other program which is still
 running will be cancelled and the original exception is then re-thrown.
 
-(this wraps __async__\'s 'Control.Concurrent.Async.concurrently_')
-
 @since 0.4.0
 -}
 concurrentThreads_ :: Program τ α -> Program τ β -> Program τ ()
@@ -353,8 +346,6 @@ will be cancelled with an exception.
 
 For a variant that ingores the return value and just races the threads see
 'raceThreads_' below.
-
-(this wraps __async__\'s 'Control.Concurrent.Async.race')
 
 @since 0.4.0
 -}
@@ -391,8 +382,6 @@ timeouts:
             performAction
         )
 @
-
-(this wraps __async__\'s 'Control.Concurrent.Async.race_')
 
 @since 0.4.0
 -}

--- a/core-program/package.yaml
+++ b/core-program/package.yaml
@@ -43,7 +43,7 @@ library:
    - filepath
    - fsnotify
    - hourglass
-   - ki
+   - ki >= 1.0.0
    - mtl
    - safe-exceptions
    - stm

--- a/core-program/package.yaml
+++ b/core-program/package.yaml
@@ -35,7 +35,6 @@ dependencies:
 
 library:
   dependencies:
-   - async
    - core-text >= 0.3.8
    - core-data >= 0.3.4
    - directory

--- a/core-program/package.yaml
+++ b/core-program/package.yaml
@@ -1,5 +1,5 @@
 name: core-program
-version: 0.5.2.0
+version: 0.6.0.0
 synopsis: Opinionated Haskell Interoperability
 description: |
   A library to help build command-line programs, both tools and
@@ -43,6 +43,7 @@ library:
    - filepath
    - fsnotify
    - hourglass
+   - ki
    - mtl
    - safe-exceptions
    - stm

--- a/core-telemetry/core-telemetry.cabal
+++ b/core-telemetry/core-telemetry.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           core-telemetry
-version:        0.2.6.0
+version:        0.2.6.1
 synopsis:       Advanced telemetry
 description:    This is part of a library to help build command-line programs, both tools and
                 longer-running daemons.
@@ -49,15 +49,15 @@ library
       lib
   ghc-options: -Wall -Wwarn -fwarn-tabs
   build-depends:
-      async
-    , base >=4.11 && <5
+      base >=4.11 && <5
     , bytestring
     , core-data >=0.3.6.0
-    , core-program >=0.5.0.2
+    , core-program >=0.6.0.0
     , core-text >=0.3.7.1
     , exceptions
     , http-streams
     , io-streams
+    , ki
     , mtl
     , network-info
     , random

--- a/core-telemetry/package.yaml
+++ b/core-telemetry/package.yaml
@@ -1,5 +1,5 @@
 name: core-telemetry
-version: 0.2.6.0
+version: 0.2.6.1
 synopsis: Advanced telemetry
 description: |
   This is part of a library to help build command-line programs, both tools and
@@ -32,13 +32,13 @@ dependencies:
 
 library:
   dependencies:
-   - async
    - core-text >= 0.3.7.1
    - core-data >= 0.3.6.0
-   - core-program >= 0.5.0.2
+   - core-program >= 0.6.0.0
    - exceptions
    - http-streams
    - io-streams
+   - ki
    - mtl
    - network-info
    - random

--- a/package.yaml
+++ b/package.yaml
@@ -57,6 +57,7 @@ dependencies:
 
 executables:
   snippet:
+    buildable: false
     dependencies:
     - bytestring
     ghc-options:

--- a/package.yaml
+++ b/package.yaml
@@ -48,16 +48,12 @@ github: aesiniath/unbeliever
 
 dependencies:
  - base >= 4.11 && < 5
- - core-text >= 0.3.8.0
- - core-data >= 0.3.4.0
- - core-program >= 0.5.1.0
- - core-telemetry >= 0.2.3.5
- - core-webserver-servant >= 0.1.1.2
- - core-webserver-warp >= 0.1.1.6
+ - core-text
+ - core-data
+ - core-program
 
 executables:
   snippet:
-    buildable: false
     dependencies:
     - bytestring
     ghc-options:
@@ -83,23 +79,30 @@ executables:
 tests:
   check:
     dependencies:
-     - aeson
-     - bytestring
-     - fingertree
-     - hashable
-     - hspec
-     - ki >= 1.0.0
-     - network-info
-     - prettyprinter
-     - QuickCheck
-     - safe-exceptions
-     - scientific
-     - stm
-     - text
-     - text-short
-     - time
-     - unordered-containers
-     - wai
+    - aeson
+    - bytestring
+    - fingertree
+    - hashable
+    - hspec
+    - ki >= 1.0.0
+    - network-info
+    - prettyprinter
+    - QuickCheck
+    - safe-exceptions
+    - scientific
+    - stm
+    - text
+    - text-short
+    - time
+    - unordered-containers
+    - wai
+    - core-text
+    - core-data
+    - core-program
+    - core-telemetry
+    - core-webserver-servant
+    - core-webserver-warp
+
     ghc-options: -threaded
     source-dirs:
      - tests

--- a/package.yaml
+++ b/package.yaml
@@ -57,17 +57,13 @@ dependencies:
 
 executables:
   snippet:
-    buildable: false
     dependencies:
-     - core-webserver-warp
-     - http-types
-     - wai
-     - warp
+    - bytestring
     ghc-options:
      - -threaded
     source-dirs:
      - tests
-    main: WarpSnippet.hs
+    main: Snippet.hs
     other-modules: []
 
   experiment:

--- a/package.yaml
+++ b/package.yaml
@@ -84,11 +84,11 @@ tests:
   check:
     dependencies:
      - aeson
-     - async
      - bytestring
      - fingertree
      - hashable
      - hspec
+     - ki >= 1.0.0
      - network-info
      - prettyprinter
      - QuickCheck

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2022-08-15
+resolver: nightly-2022-09-11
 compiler: ghc-9.2.2
 packages:
  - ./core-data

--- a/tests/SimpleExperiment.hs
+++ b/tests/SimpleExperiment.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
@@ -16,8 +17,8 @@ import Core.Encoding
 import Core.Program
 import Core.System
 import Core.Text
-import qualified Data.ByteString.Char8 as S
-import qualified Data.HashMap.Strict as HashMap
+import Data.ByteString.Char8 qualified as S
+import Data.HashMap.Strict qualified as HashMap
 import Prettyprinter (Pretty (..), defaultLayoutOptions, layoutPretty)
 import Prettyprinter.Render.Text (renderStrict)
 

--- a/tests/SimpleExperiment.hs
+++ b/tests/SimpleExperiment.hs
@@ -9,7 +9,6 @@
 {-# OPTIONS_GHC -fno-warn-unused-imports #-}
 {-# OPTIONS_GHC -fno-warn-unused-top-binds #-}
 
---import Data.Text (Text)
 import Control.Concurrent (threadDelay)
 import Control.Monad (replicateM_)
 import Core.Data
@@ -70,28 +69,33 @@ program = do
     let x = encodeToUTF8 j
     writeS x
 
-    let (Just y) = decodeFromUTF8 b
-    writeS y
-    writeS (encodeToUTF8 y)
-    writeR (encodeToUTF8 y)
-    writeS (encodeToUTF8 r)
+    let possibleY = decodeFromUTF8 b
+    case possibleY of 
+        Nothing -> invalid
+        Just y -> do
+            writeS y
+            writeS (encodeToUTF8 y)
+            writeR (encodeToUTF8 y)
+            writeS (encodeToUTF8 r)
 
     debugR "packet" j
 
     info "Clock..."
 
-    t <- forkThread $ do
+    createScope $ do
+        t1 <- forkThread $ do
             sleepThread 1.5
             warn "Wakey wakey"
             throw Boom
-    linkThread t
 
-    replicateM_ 5 $ do
-        sleepThread 0.5
-        info "tick"
+        forkThread $ do
+            replicateM_ 500 $ do
+                sleepThread 0.1
+                info "tick"
+
+        waitThread t1
 
     info "Brr! It's cold"
-    terminate 0
 
 version :: Version
 version = $(fromPackage)

--- a/tests/SimpleExperiment.hs
+++ b/tests/SimpleExperiment.hs
@@ -70,7 +70,7 @@ program = do
     writeS x
 
     let possibleY = decodeFromUTF8 b
-    case possibleY of 
+    case possibleY of
         Nothing -> invalid
         Just y -> do
             writeS y

--- a/tests/Snippet.hs
+++ b/tests/Snippet.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# OPTIONS_GHC -fno-warn-missing-signatures #-}
 {-# OPTIONS_GHC -fno-warn-unused-do-bind #-}
 {-# OPTIONS_GHC -fno-warn-unused-imports #-}

--- a/tests/Snippet.hs
+++ b/tests/Snippet.hs
@@ -21,6 +21,7 @@ main = execute $ do
 
     write $ case x of
         Nothing -> "Nothing!"
+        Just _ -> "Something!"
 
     sleepThread 0.2
 

--- a/unbeliever.cabal
+++ b/unbeliever.cabal
@@ -112,7 +112,6 @@ test-suite check
   build-depends:
       QuickCheck
     , aeson
-    , async
     , base >=4.11 && <5
     , bytestring
     , core-data >=0.3.4.0
@@ -124,6 +123,7 @@ test-suite check
     , fingertree
     , hashable
     , hspec
+    , ki >=1.0.0
     , network-info
     , prettyprinter
     , safe-exceptions

--- a/unbeliever.cabal
+++ b/unbeliever.cabal
@@ -76,22 +76,19 @@ executable experiment
   default-language: Haskell2010
 
 executable snippet
-  main-is: WarpSnippet.hs
+  main-is: Snippet.hs
   hs-source-dirs:
       tests
   ghc-options: -Wall -Wwarn -fwarn-tabs -threaded
   build-depends:
       base >=4.11 && <5
+    , bytestring
     , core-data >=0.3.4.0
     , core-program >=0.5.1.0
     , core-telemetry >=0.2.3.5
     , core-text >=0.3.8.0
     , core-webserver-servant >=0.1.1.2
-    , core-webserver-warp
-    , http-types
-    , wai
-    , warp
-  buildable: False
+    , core-webserver-warp >=0.1.1.6
   default-language: Haskell2010
 
 test-suite check

--- a/unbeliever.cabal
+++ b/unbeliever.cabal
@@ -89,6 +89,7 @@ executable snippet
     , core-text >=0.3.8.0
     , core-webserver-servant >=0.1.1.2
     , core-webserver-warp >=0.1.1.6
+  buildable: False
   default-language: Haskell2010
 
 test-suite check

--- a/unbeliever.cabal
+++ b/unbeliever.cabal
@@ -64,12 +64,9 @@ executable experiment
   build-depends:
       base >=4.11 && <5
     , bytestring
-    , core-data >=0.3.4.0
-    , core-program >=0.5.1.0
-    , core-telemetry >=0.2.3.5
-    , core-text >=0.3.8.0
-    , core-webserver-servant >=0.1.1.2
-    , core-webserver-warp >=0.1.1.6
+    , core-data
+    , core-program
+    , core-text
     , prettyprinter
     , unordered-containers
   buildable: False
@@ -83,13 +80,9 @@ executable snippet
   build-depends:
       base >=4.11 && <5
     , bytestring
-    , core-data >=0.3.4.0
-    , core-program >=0.5.1.0
-    , core-telemetry >=0.2.3.5
-    , core-text >=0.3.8.0
-    , core-webserver-servant >=0.1.1.2
-    , core-webserver-warp >=0.1.1.6
-  buildable: False
+    , core-data
+    , core-program
+    , core-text
   default-language: Haskell2010
 
 test-suite check
@@ -114,12 +107,12 @@ test-suite check
     , aeson
     , base >=4.11 && <5
     , bytestring
-    , core-data >=0.3.4.0
-    , core-program >=0.5.1.0
-    , core-telemetry >=0.2.3.5
-    , core-text >=0.3.8.0
-    , core-webserver-servant >=0.1.1.2
-    , core-webserver-warp >=0.1.1.6
+    , core-data
+    , core-program
+    , core-telemetry
+    , core-text
+    , core-webserver-servant
+    , core-webserver-warp
     , fingertree
     , hashable
     , hspec
@@ -145,12 +138,9 @@ benchmark performance
   build-depends:
       base >=4.11 && <5
     , bytestring
-    , core-data >=0.3.4.0
-    , core-program >=0.5.1.0
-    , core-telemetry >=0.2.3.5
-    , core-text >=0.3.8.0
-    , core-webserver-servant >=0.1.1.2
-    , core-webserver-warp >=0.1.1.6
+    , core-data
+    , core-program
+    , core-text
     , gauge
     , text
   default-language: Haskell2010


### PR DESCRIPTION
Change the underlying concurrency library from **async** to **ki**.

We have run into considerable problems in the design of `waitThread*` in the face of exceptions; we really want _bi-directional_ exceptions, whereby death of a child or parent thread results in the conclusion of both. It appears **ki** provides this.

This is a major API bump due to the change in the return type of `unThread` and the removal of `cancelThread` and other wrappers around **async** specific usages.