### PR TITLE
Structured concurrency re-implementation

### DIFF
--- a/core-data/core-data.cabal
+++ b/core-data/core-data.cabal
@@ -1,11 +1,11 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.35.0.
 --
 -- see: https://github.com/sol/hpack
 
 name:           core-data
-version:        0.3.6.0
+version:        0.3.7.0
 synopsis:       Convenience wrappers around common data structures and encodings
 description:    Wrappers around common data structures and encodings.
                 .

--- a/core-data/core-data.cabal
+++ b/core-data/core-data.cabal
@@ -26,7 +26,7 @@ license:        MIT
 license-file:   LICENSE
 build-type:     Simple
 tested-with:
-    GHC == 8.10.7, GHC == 9.2.2
+    GHC == 8.10.7, GHC == 9.2.4
 
 source-repository head
   type: git

--- a/core-data/core-data.cabal
+++ b/core-data/core-data.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           core-data
-version:        0.3.7.0
+version:        0.3.8.0
 synopsis:       Convenience wrappers around common data structures and encodings
 description:    Wrappers around common data structures and encodings.
                 .

--- a/core-data/lib/Core/Data/Structures.hs
+++ b/core-data/lib/Core/Data/Structures.hs
@@ -16,6 +16,7 @@ module Core.Data.Structures (
     insertKeyValue,
     containsKey,
     lookupKeyValue,
+    removeKeyValue,
 
     -- * Conversions
     Dictionary (K, V, fromMap, intoMap),
@@ -26,6 +27,7 @@ module Core.Data.Structures (
     singletonSet,
     insertElement,
     containsElement,
+    removeElement,
 
     -- * Conversions
     Collection (E, fromSet, intoSet),
@@ -145,6 +147,14 @@ Does the dictionary contain the specified key?
 -}
 containsKey :: Key κ => κ -> Map κ ν -> Bool
 containsKey k (Map u) = HashMap.member k u
+
+{- |
+Remove a key/value pair if present in the dictionary.
+
+@since 0.3.7
+-}
+removeKeyValue :: Key κ => κ -> Map κ ν -> Map κ ν
+removeKeyValue k (Map u) = Map (HashMap.delete k u)
 
 -- |
 instance Key κ => Semigroup (Map κ ν) where
@@ -288,6 +298,15 @@ Does the collection contain the specified element?
 -}
 containsElement :: Key ε => ε -> Set ε -> Bool
 containsElement e (Set u) = HashSet.member e u
+
+{- |
+Remove an element from the collection if present.
+
+@since 0.3.7
+-}
+removeElement :: Key ε => ε -> Set ε -> Set ε
+removeElement e (Set u) = Set (HashSet.delete e u)
+
 
 {- |
 Types that represent collections of elements that can be converted to

--- a/core-data/lib/Core/Data/Structures.hs
+++ b/core-data/lib/Core/Data/Structures.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralisedNewtypeDeriving #-}
+{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# OPTIONS_GHC -fno-warn-orphans -Wno-redundant-constraints #-}
 
@@ -38,19 +39,20 @@ module Core.Data.Structures (
     unSet,
 ) where
 
+import Control.Concurrent qualified as Base (ThreadId)
 import Core.Text.Bytes (Bytes)
 import Core.Text.Rope (Rope)
 import Data.Bifoldable (Bifoldable)
-import qualified Data.ByteString as B (ByteString)
-import qualified Data.HashMap.Strict as HashMap
-import qualified Data.HashSet as HashSet
+import Data.ByteString qualified as B (ByteString)
+import Data.HashMap.Strict qualified as HashMap
+import Data.HashSet qualified as HashSet
 import Data.Hashable (Hashable)
 import Data.Kind (Type)
-import qualified Data.Map.Strict as OrdMap
-import qualified Data.Set as OrdSet
-import qualified Data.Text as T (Text)
-import qualified Data.Text.Lazy as U (Text)
-import qualified GHC.Exts as Exts (IsList (..))
+import Data.Map.Strict qualified as OrdMap
+import Data.Set qualified as OrdSet
+import Data.Text qualified as T (Text)
+import Data.Text.Lazy qualified as U (Text)
+import GHC.Exts qualified as Exts (IsList (..))
 
 -- Naming convention used throughout this file is (Thing u) where u is the
 -- underlying structure [from unordered-containers] wrapped in the Thing
@@ -110,6 +112,8 @@ instance Key Int
 
 instance Key B.ByteString
 
+instance Key Base.ThreadId
+
 instance Foldable (Map κ) where
     foldr f start (Map u) = HashMap.foldr f start u
     null (Map u) = HashMap.null u
@@ -156,7 +160,6 @@ Remove a key/value pair if present in the dictionary.
 removeKeyValue :: Key κ => κ -> Map κ ν -> Map κ ν
 removeKeyValue k (Map u) = Map (HashMap.delete k u)
 
--- |
 instance Key κ => Semigroup (Map κ ν) where
     (<>) (Map u1) (Map u2) = Map (HashMap.union u1 u2)
 
@@ -306,7 +309,6 @@ Remove an element from the collection if present.
 -}
 removeElement :: Key ε => ε -> Set ε -> Set ε
 removeElement e (Set u) = Set (HashSet.delete e u)
-
 
 {- |
 Types that represent collections of elements that can be converted to

--- a/core-data/package.yaml
+++ b/core-data/package.yaml
@@ -17,7 +17,7 @@ license-file: LICENSE
 author: Andrew Cowie <istathar@gmail.com>
 maintainer: Andrew Cowie <istathar@gmail.com>
 copyright: © 2018-2022 Athae Eredh Siniath and Others
-tested-with: GHC == 8.10.7, GHC == 9.2.2
+tested-with: GHC == 8.10.7, GHC == 9.2.4
 category: System
 ghc-options: -Wall -Wwarn -fwarn-tabs
 github: aesiniath/unbeliever

--- a/core-data/package.yaml
+++ b/core-data/package.yaml
@@ -1,5 +1,5 @@
 name: core-data
-version: 0.3.7.0
+version: 0.3.8.0
 synopsis: Convenience wrappers around common data structures and encodings
 description: |
   Wrappers around common data structures and encodings.

--- a/core-data/package.yaml
+++ b/core-data/package.yaml
@@ -1,5 +1,5 @@
 name: core-data
-version: 0.3.6.0
+version: 0.3.7.0
 synopsis: Convenience wrappers around common data structures and encodings
 description: |
   Wrappers around common data structures and encodings.

--- a/core-program/core-program.cabal
+++ b/core-program/core-program.cabal
@@ -27,7 +27,7 @@ license:        MIT
 license-file:   LICENSE
 build-type:     Simple
 tested-with:
-    GHC == 8.10.7, GHC == 9.2.2
+    GHC == 8.10.7, GHC == 9.2.4
 
 source-repository head
   type: git
@@ -65,7 +65,6 @@ library
     , fsnotify
     , hashable >=1.2
     , hourglass
-    , ki >=1.0.0
     , mtl
     , prettyprinter >=1.6.2
     , safe-exceptions

--- a/core-program/core-program.cabal
+++ b/core-program/core-program.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.35.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -57,7 +57,7 @@ library
   build-depends:
       base >=4.11 && <5
     , bytestring
-    , core-data >=0.3.4
+    , core-data >=0.3.8
     , core-text >=0.3.8
     , directory
     , exceptions

--- a/core-program/core-program.cabal
+++ b/core-program/core-program.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           core-program
-version:        0.6.0.0
+version:        0.6.0.1
 synopsis:       Opinionated Haskell Interoperability
 description:    A library to help build command-line programs, both tools and
                 longer-running daemons.

--- a/core-program/core-program.cabal
+++ b/core-program/core-program.cabal
@@ -55,8 +55,7 @@ library
       lib
   ghc-options: -Wall -Wwarn -fwarn-tabs
   build-depends:
-      async
-    , base >=4.11 && <5
+      base >=4.11 && <5
     , bytestring
     , core-data >=0.3.4
     , core-text >=0.3.8
@@ -66,7 +65,7 @@ library
     , fsnotify
     , hashable >=1.2
     , hourglass
-    , ki
+    , ki >=1.0.0
     , mtl
     , prettyprinter >=1.6.2
     , safe-exceptions

--- a/core-program/core-program.cabal
+++ b/core-program/core-program.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           core-program
-version:        0.5.2.0
+version:        0.6.0.0
 synopsis:       Opinionated Haskell Interoperability
 description:    A library to help build command-line programs, both tools and
                 longer-running daemons.
@@ -66,6 +66,7 @@ library
     , fsnotify
     , hashable >=1.2
     , hourglass
+    , ki
     , mtl
     , prettyprinter >=1.6.2
     , safe-exceptions

--- a/core-program/lib/Core/Program/Context.hs
+++ b/core-program/lib/Core/Program/Context.hs
@@ -49,6 +49,7 @@ import Core.Encoding.Json
 import Core.Program.Arguments
 import Core.Program.Metadata
 import Core.System.Base
+import Ki qualified as Ki (Scope)
 import Core.Text.Rope
 import Data.Foldable (foldrM)
 import Data.Int (Int64)
@@ -175,6 +176,7 @@ data Context τ = Context
     , outputChannelFrom :: TQueue (Maybe Rope) -- communication channels
     , telemetryChannelFrom :: TQueue (Maybe Datum) -- machinery for telemetry
     , telemetryForwarderFrom :: Maybe Forwarder
+    , currentScopeFrom :: Maybe Ki.Scope
     , currentDatumFrom :: MVar Datum
     , applicationDataFrom :: MVar τ
     }
@@ -374,6 +376,7 @@ configure version t config = do
             , outputChannelFrom = out
             , telemetryChannelFrom = tel
             , telemetryForwarderFrom = Nothing
+            , currentScopeFrom = Nothing
             , currentDatumFrom = v
             , applicationDataFrom = u
             }

--- a/core-program/lib/Core/Program/Context.hs
+++ b/core-program/lib/Core/Program/Context.hs
@@ -49,11 +49,11 @@ import Core.Encoding.Json
 import Core.Program.Arguments
 import Core.Program.Metadata
 import Core.System.Base
-import Ki qualified as Ki (Scope)
 import Core.Text.Rope
 import Data.Foldable (foldrM)
 import Data.Int (Int64)
 import Data.String (IsString)
+import Ki qualified as Ki (Scope)
 import Prettyprinter (LayoutOptions (..), PageWidth (..), layoutPretty)
 import Prettyprinter.Render.Text (renderIO)
 import System.Console.Terminal.Size qualified as Terminal (Window (..), size)

--- a/core-program/lib/Core/Program/Execute.hs
+++ b/core-program/lib/Core/Program/Execute.hs
@@ -279,11 +279,8 @@ executeActual context0 program = do
 
     -- wait for indication to terminate
     code <- readMVar quit
-    putStr "CODE " >> print code
 
     killThread t1
-
-    putStrLn "HERE"
 
     -- instruct handlers to finish, and wait for the message queues to
     -- drain. Allow 10 seconds, then timeout, in case something has gone
@@ -303,8 +300,6 @@ executeActual context0 program = do
         writeTQueue out Nothing
 
     readMVar vo
-
-    putStrLn "DONE"
 
     hFlush stdout
 

--- a/core-program/lib/Core/Program/Execute.hs
+++ b/core-program/lib/Core/Program/Execute.hs
@@ -286,6 +286,7 @@ executeActual context0 program = do
     -- wait for indication to terminate
     code <- readMVar quit
 
+    -- kill main thread
     killThread t1
 
     -- instruct handlers to finish, and wait for the message queues to

--- a/core-program/lib/Core/Program/Threads.hs
+++ b/core-program/lib/Core/Program/Threads.hs
@@ -44,13 +44,11 @@ module Core.Program.Threads (
     unThread,
 ) where
 
-import Control.Applicative ((<|>))
-import Control.Concurrent (ThreadId, forkIO, killThread, myThreadId, throwTo)
+import Control.Concurrent (ThreadId, forkIO, killThread)
 import Control.Concurrent.MVar (MVar, newEmptyMVar, newMVar, putMVar, readMVar)
-import Control.Concurrent.STM (atomically, orElse)
-import Control.Concurrent.STM.TVar (modifyTVar', newTVarIO, readTVar, readTVarIO)
-import Control.Exception.Base qualified as Base (AsyncException)
-import Control.Exception.Safe qualified as Safe (catch, catchAsync, finally, onException, throw)
+import Control.Concurrent.STM (atomically)
+import Control.Concurrent.STM.TVar (modifyTVar', newTVarIO, readTVarIO)
+import Control.Exception.Safe qualified as Safe (catch, finally, onException, throw)
 import Control.Monad (
     forM_,
     void,

--- a/core-program/lib/Core/Program/Threads.hs
+++ b/core-program/lib/Core/Program/Threads.hs
@@ -274,26 +274,50 @@ waitThread' thread = do
                 killThread (threadPointerOf thread)
             )
 
+
 {- |
-Wait for all child threads in the current scope to complete.
+Wait for many threads to complete. This function is intended for the scenario
+where you fire off a number of worker threads with `forkThread` but rather
+than leaving them to run independantly, you need to wait for them all to
+complete.
 
-This function is intended for the scenario where you fire off a number of
-worker threads with `forkThread` but rather than leaving them to run
-independantly, you need to wait for them all to complete.
+The results of the threads that complete successfully will be returned as
+'Right' values. Should any of the threads being waited upon throw an
+exception, those exceptions will be returned as 'Left' values.
 
-If the thread calling 'waitThreads_' is killed, then all the threads being
-waited upon will also be killed. This often occurs within a timeout or similar
-control measure implemented using 'raceThreads_'. Should the thread that
-spawned all the workers and is waiting for their results be told to cancel
-because it lost the "race", the child threads need to be told in turn to
-cancel so as to avoid those threads being leaked and continuing to run as
-zombies. The machinery underlying this function takes care of that.
+If you don't need to analyse the failures individually, then you can just
+collect the successes using "Data.Either"'s 'Data.Either.rights':
 
+@
+    responses <- 'waitThreads''
 
-@since 0.6.0
+    'info' "Aggregating results..."
+    combineResults ('Data.Either.rights' responses)
+@
+
+Likewise, if you /do/ want to do something with all the failures, you might
+find 'Data.Either.lefts' useful:
+
+@
+    'mapM_' ('warn' . 'intoRope' . 'displayException') ('Data.Either.lefts' responses)
+@
+
+If the thread calling 'waitThreads'' is cancelled, then all the threads being
+waited upon will also be cancelled. This often occurs within a timeout or
+similar control measure implemented using 'raceThreads_'. Should the thread
+that spawned all the workers and is waiting for their results be told to
+cancel because it lost the "race", the child threads need to be told in turn
+to cancel so as to avoid those threads being leaked and continuing to run as
+zombies. This function takes care of that.
+
+(this extends 'waitThread'' to work across a list of Threads, taking care to
+ensure the cancellation behaviour described throughout this module)
+
+@since 0.4.5
 -}
-waitThreads_ :: Program τ ()
-waitThreads_ = undefined
+waitThreads' :: [Thread α] -> Program τ [Either SomeException α]
+waitThreads' threads = do
+    forM_ threads waitThread'
 
 {- |
 Fork two threads and wait for both to finish. The return value is the pair of

--- a/core-program/lib/Core/Program/Threads.hs
+++ b/core-program/lib/Core/Program/Threads.hs
@@ -64,7 +64,10 @@ import Ki qualified as Ki (Scope, Thread, await, awaitAll, fork, scoped)
 {- |
 A thread for concurrent computation.
 
-(this wraps __async__'s 'Async')
+(this wraps __ki__'s 'Thread' which in turn wraps __base__'s
+'Control.Concurrent.ThreadId')
+
+@since 0.6.0
 -}
 newtype Thread α = Thread (Ki.Thread α)
 

--- a/core-program/lib/Core/Program/Threads.hs
+++ b/core-program/lib/Core/Program/Threads.hs
@@ -187,12 +187,11 @@ If the thread you are waiting on throws an exception it will be rethrown by
 
 If the current thread making this call is cancelled (as a result of being on
 the losing side of 'concurrentThreads' or 'raceThreads' for example, or due to
-an explicit call to 'cancelThread'), then the thread you are waiting on will
-be cancelled. This is necessary to ensure that child threads are not leaked if
+the current Scope exiting), then the thread you are waiting on will be
+cancelled. This is necessary to ensure that child threads are not leaked if
 you nest `forkThread`s.
 
-(this wraps __async__\'s 'Control.Concurrent.Async.wait', taking care to
-ensure the behaviour described above)
+(this wraps __ki__\'s 'Ki.await')
 
 @since 0.2.7
 -}
@@ -236,8 +235,6 @@ This basically is convenience for calling `waitThread` and putting `catch`
 around it, but as with all the other @wait*@ functions this ensures that if
 the thread waiting is killed the cancellation is propagated to the thread
 being watched as well.
-
-(this wraps __async__\'s 'Control.Concurrent.Async.waitCatch')
 
 @since 0.4.5
 -}
@@ -300,8 +297,6 @@ running will be cancelled and the original exception is then re-thrown.
 For a variant that ingores the return values and just waits for both see
 'concurrentThreads_' below.
 
-(this wraps __async__\'s 'Control.Concurrent.Async.concurrently')
-
 @since 0.4.0
 -}
 concurrentThreads :: Program τ α -> Program τ β -> Program τ (α, β)
@@ -328,8 +323,6 @@ This is the same as calling 'forkThread' and 'waitThread_' twice, except that
 if either sub-program fails with an exception the other program which is still
 running will be cancelled and the original exception is then re-thrown.
 
-(this wraps __async__\'s 'Control.Concurrent.Async.concurrently_')
-
 @since 0.4.0
 -}
 concurrentThreads_ :: Program τ α -> Program τ β -> Program τ ()
@@ -353,8 +346,6 @@ will be cancelled with an exception.
 
 For a variant that ingores the return value and just races the threads see
 'raceThreads_' below.
-
-(this wraps __async__\'s 'Control.Concurrent.Async.race')
 
 @since 0.4.0
 -}
@@ -391,8 +382,6 @@ timeouts:
             performAction
         )
 @
-
-(this wraps __async__\'s 'Control.Concurrent.Async.race_')
 
 @since 0.4.0
 -}

--- a/core-program/package.yaml
+++ b/core-program/package.yaml
@@ -36,7 +36,7 @@ dependencies:
 library:
   dependencies:
    - core-text >= 0.3.8
-   - core-data >= 0.3.4
+   - core-data >= 0.3.8
    - directory
    - exceptions
    - filepath

--- a/core-program/package.yaml
+++ b/core-program/package.yaml
@@ -18,7 +18,7 @@ license-file: LICENSE
 author: Andrew Cowie <istathar@gmail.com>
 maintainer: Andrew Cowie <istathar@gmail.com>
 copyright: © 2018-2022 Athae Eredh Siniath and Others
-tested-with: GHC == 8.10.7, GHC == 9.2.2
+tested-with: GHC == 8.10.7, GHC == 9.2.4
 category: System
 ghc-options: -Wall -Wwarn -fwarn-tabs
 github: aesiniath/unbeliever
@@ -42,7 +42,6 @@ library:
    - filepath
    - fsnotify
    - hourglass
-   - ki >= 1.0.0
    - mtl
    - safe-exceptions
    - stm

--- a/core-program/package.yaml
+++ b/core-program/package.yaml
@@ -35,7 +35,6 @@ dependencies:
 
 library:
   dependencies:
-   - async
    - core-text >= 0.3.8
    - core-data >= 0.3.4
    - directory
@@ -43,7 +42,7 @@ library:
    - filepath
    - fsnotify
    - hourglass
-   - ki
+   - ki >= 1.0.0
    - mtl
    - safe-exceptions
    - stm

--- a/core-program/package.yaml
+++ b/core-program/package.yaml
@@ -1,5 +1,5 @@
 name: core-program
-version: 0.6.0.0
+version: 0.6.0.1
 synopsis: Opinionated Haskell Interoperability
 description: |
   A library to help build command-line programs, both tools and

--- a/core-program/package.yaml
+++ b/core-program/package.yaml
@@ -1,5 +1,5 @@
 name: core-program
-version: 0.5.2.0
+version: 0.6.0.0
 synopsis: Opinionated Haskell Interoperability
 description: |
   A library to help build command-line programs, both tools and
@@ -43,6 +43,7 @@ library:
    - filepath
    - fsnotify
    - hourglass
+   - ki
    - mtl
    - safe-exceptions
    - stm

--- a/core-telemetry/core-telemetry.cabal
+++ b/core-telemetry/core-telemetry.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           core-telemetry
-version:        0.2.6.0
+version:        0.2.6.1
 synopsis:       Advanced telemetry
 description:    This is part of a library to help build command-line programs, both tools and
                 longer-running daemons.
@@ -49,15 +49,15 @@ library
       lib
   ghc-options: -Wall -Wwarn -fwarn-tabs
   build-depends:
-      async
-    , base >=4.11 && <5
+      base >=4.11 && <5
     , bytestring
     , core-data >=0.3.6.0
-    , core-program >=0.5.0.2
+    , core-program >=0.6.0.0
     , core-text >=0.3.7.1
     , exceptions
     , http-streams
     , io-streams
+    , ki
     , mtl
     , network-info
     , random

--- a/core-telemetry/core-telemetry.cabal
+++ b/core-telemetry/core-telemetry.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.18
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.35.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -51,13 +51,12 @@ library
   build-depends:
       base >=4.11 && <5
     , bytestring
-    , core-data >=0.3.6.0
+    , core-data >=0.3.8.0
     , core-program >=0.6.0.0
     , core-text >=0.3.7.1
     , exceptions
     , http-streams
     , io-streams
-    , ki
     , mtl
     , network-info
     , random

--- a/core-telemetry/package.yaml
+++ b/core-telemetry/package.yaml
@@ -33,12 +33,11 @@ dependencies:
 library:
   dependencies:
    - core-text >= 0.3.7.1
-   - core-data >= 0.3.6.0
+   - core-data >= 0.3.8.0
    - core-program >= 0.6.0.0
    - exceptions
    - http-streams
    - io-streams
-   - ki
    - mtl
    - network-info
    - random

--- a/core-telemetry/package.yaml
+++ b/core-telemetry/package.yaml
@@ -1,5 +1,5 @@
 name: core-telemetry
-version: 0.2.6.0
+version: 0.2.6.1
 synopsis: Advanced telemetry
 description: |
   This is part of a library to help build command-line programs, both tools and
@@ -32,13 +32,13 @@ dependencies:
 
 library:
   dependencies:
-   - async
    - core-text >= 0.3.7.1
    - core-data >= 0.3.6.0
-   - core-program >= 0.5.0.2
+   - core-program >= 0.6.0.0
    - exceptions
    - http-streams
    - io-streams
+   - ki
    - mtl
    - network-info
    - random

--- a/core-text/core-text.cabal
+++ b/core-text/core-text.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.18
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.35.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -32,7 +32,7 @@ license:        MIT
 license-file:   LICENSE
 build-type:     Simple
 tested-with:
-    GHC == 8.10.7
+    GHC == 8.10.7, GHC == 9.2.4
 extra-doc-files:
     AnsiColours.png
 

--- a/core-text/package.yaml
+++ b/core-text/package.yaml
@@ -23,7 +23,7 @@ license-file: LICENSE
 author: Andrew Cowie <istathar@gmail.com>
 maintainer: Andrew Cowie <istathar@gmail.com>
 copyright: © 2018-2022 Athae Eredh Siniath and Others
-tested-with: GHC == 8.10.7
+tested-with: GHC == 8.10.7, GHC == 9.2.4
 category: System
 ghc-options: -Wall -Wwarn -fwarn-tabs
 github: aesiniath/unbeliever

--- a/core-webserver-servant/core-webserver-servant.cabal
+++ b/core-webserver-servant/core-webserver-servant.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.35.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -24,7 +24,7 @@ license:        MIT
 license-file:   LICENSE
 build-type:     Simple
 tested-with:
-    GHC == 8.10.7
+    GHC == 8.10.7, GHC == 9.2.4
 
 source-repository head
   type: git

--- a/core-webserver-servant/package.yaml
+++ b/core-webserver-servant/package.yaml
@@ -15,7 +15,7 @@ license-file: LICENSE
 author: Carlos D'Agostino <carlos.dagostino@gmail.com>
 maintainer: Andrew Cowie <istathar@gmail.com>
 copyright: © 2021-2022 Athae Eredh Siniath and Others
-tested-with: GHC == 8.10.7
+tested-with: GHC == 8.10.7, GHC == 9.2.4
 category: System
 ghc-options: -Wall -Wwarn -fwarn-tabs
 github: aesiniath/unbeliever

--- a/core-webserver-warp/core-webserver-warp.cabal
+++ b/core-webserver-warp/core-webserver-warp.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.35.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -24,7 +24,7 @@ license:        MIT
 license-file:   LICENSE
 build-type:     Simple
 tested-with:
-    GHC == 8.10.7
+    GHC == 8.10.7, GHC == 9.2.4
 
 source-repository head
   type: git

--- a/core-webserver-warp/package.yaml
+++ b/core-webserver-warp/package.yaml
@@ -15,7 +15,7 @@ license-file: LICENSE
 author: Andrew Cowie <istathar@gmail.com>
 maintainer: Andrew Cowie <istathar@gmail.com>
 copyright: © 2021-2022 Athae Eredh Siniath and Others
-tested-with: GHC == 8.10.7
+tested-with: GHC == 8.10.7, GHC == 9.2.4
 category: System
 ghc-options: -Wall -Wwarn -fwarn-tabs
 github: aesiniath/unbeliever

--- a/package.yaml
+++ b/package.yaml
@@ -57,6 +57,7 @@ dependencies:
 
 executables:
   snippet:
+    buildable: false
     dependencies:
     - bytestring
     ghc-options:

--- a/package.yaml
+++ b/package.yaml
@@ -84,7 +84,6 @@ tests:
     - fingertree
     - hashable
     - hspec
-    - ki >= 1.0.0
     - network-info
     - prettyprinter
     - QuickCheck

--- a/package.yaml
+++ b/package.yaml
@@ -48,16 +48,12 @@ github: aesiniath/unbeliever
 
 dependencies:
  - base >= 4.11 && < 5
- - core-text >= 0.3.8.0
- - core-data >= 0.3.4.0
- - core-program >= 0.5.1.0
- - core-telemetry >= 0.2.3.5
- - core-webserver-servant >= 0.1.1.2
- - core-webserver-warp >= 0.1.1.6
+ - core-text
+ - core-data
+ - core-program
 
 executables:
   snippet:
-    buildable: false
     dependencies:
     - bytestring
     ghc-options:
@@ -83,23 +79,30 @@ executables:
 tests:
   check:
     dependencies:
-     - aeson
-     - bytestring
-     - fingertree
-     - hashable
-     - hspec
-     - ki >= 1.0.0
-     - network-info
-     - prettyprinter
-     - QuickCheck
-     - safe-exceptions
-     - scientific
-     - stm
-     - text
-     - text-short
-     - time
-     - unordered-containers
-     - wai
+    - aeson
+    - bytestring
+    - fingertree
+    - hashable
+    - hspec
+    - ki >= 1.0.0
+    - network-info
+    - prettyprinter
+    - QuickCheck
+    - safe-exceptions
+    - scientific
+    - stm
+    - text
+    - text-short
+    - time
+    - unordered-containers
+    - wai
+    - core-text
+    - core-data
+    - core-program
+    - core-telemetry
+    - core-webserver-servant
+    - core-webserver-warp
+
     ghc-options: -threaded
     source-dirs:
      - tests

--- a/package.yaml
+++ b/package.yaml
@@ -57,17 +57,13 @@ dependencies:
 
 executables:
   snippet:
-    buildable: false
     dependencies:
-     - core-webserver-warp
-     - http-types
-     - wai
-     - warp
+    - bytestring
     ghc-options:
      - -threaded
     source-dirs:
      - tests
-    main: WarpSnippet.hs
+    main: Snippet.hs
     other-modules: []
 
   experiment:

--- a/package.yaml
+++ b/package.yaml
@@ -41,7 +41,7 @@ license-file: LICENSE
 author: Andrew Cowie <istathar@gmail.com>
 maintainer: Andrew Cowie <istathar@gmail.com>
 copyright: © 2018-2022 Athae Eredh Siniath and Others
-tested-with: GHC == 8.10.7
+tested-with: GHC == 9.2.4
 category: System
 ghc-options: -Wall -Wwarn -fwarn-tabs
 github: aesiniath/unbeliever
@@ -54,6 +54,7 @@ dependencies:
 
 executables:
   snippet:
+    buildable: false
     dependencies:
     - bytestring
     ghc-options:

--- a/package.yaml
+++ b/package.yaml
@@ -84,11 +84,11 @@ tests:
   check:
     dependencies:
      - aeson
-     - async
      - bytestring
      - fingertree
      - hashable
      - hspec
+     - ki >= 1.0.0
      - network-info
      - prettyprinter
      - QuickCheck

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2022-09-23
+resolver: nightly-2022-09-28
 packages:
  - ./core-data
  - ./core-text

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2022-08-15
+resolver: nightly-2022-09-11
 compiler: ghc-9.2.2
 packages:
  - ./core-data

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,4 @@
-resolver: nightly-2022-09-11
-compiler: ghc-9.2.2
+resolver: nightly-2022-09-23
 packages:
  - ./core-data
  - ./core-text

--- a/tests/CheckTelemetryMachinery.hs
+++ b/tests/CheckTelemetryMachinery.hs
@@ -5,7 +5,7 @@
 
 module CheckTelemetryMachinery where
 
-import Control.Concurrent (threadDelay)
+import Control.Concurrent (threadDelay, forkIO)
 import Control.Concurrent.MVar (MVar, modifyMVar_, newMVar, readMVar)
 import Control.Concurrent.STM (atomically)
 import Control.Concurrent.STM.TQueue (newTQueueIO, writeTQueue)
@@ -13,13 +13,14 @@ import Data.Int (Int32, Int64)
 import Data.Word (Word32)
 import Network.Info (MAC (..))
 import Test.Hspec hiding (context)
-import Ki qualified as Ki (scoped, fork, await)
 
 import Core.Data.Clock
 import Core.Program
 import Core.System
 import Core.Telemetry.Identifiers
 import Core.Text
+import Control.Concurrent.MVar (newEmptyMVar)
+import Control.Concurrent.MVar (putMVar)
 
 countingAction :: Int -> [Int] -> IO ()
 countingAction target ints = sum ints `shouldBe` target
@@ -153,33 +154,34 @@ checkTelemetryMachinery = do
             v <- newMVar Debug
             out <- newTQueueIO
             queue <- newTQueueIO
+            done <- newEmptyMVar
 
-            Ki.scoped $ \scope -> do
-                a <- Ki.fork scope (loopForever storingAction v out queue)
+            _ <- forkIO $ do
+                loopForever storingAction v out queue
+                putMVar done ()
 
-                mapM_
-                    ( \i -> atomically $ do
-                        writeTQueue queue (Just i)
-                    )
-                    ([1 .. 100] :: [Int])
-                threadDelay 100000
-                mapM_
-                    ( \i -> atomically $ do
-                        writeTQueue queue (Just i)
-                    )
-                    ([101 .. 200] :: [Int])
-                threadDelay 100000
-                mapM_
-                    ( \i -> atomically $ do
-                        writeTQueue queue (Just i)
-                    )
-                    ([201 .. 300] :: [Int])
+            mapM_
+                ( \i -> atomically $ do
+                    writeTQueue queue (Just i)
+                )
+                ([1 .. 100] :: [Int])
+            threadDelay 100000
+            mapM_
+                ( \i -> atomically $ do
+                    writeTQueue queue (Just i)
+                )
+                ([101 .. 200] :: [Int])
+            threadDelay 100000
+            mapM_
+                ( \i -> atomically $ do
+                    writeTQueue queue (Just i)
+                )
+                ([201 .. 300] :: [Int])
 
-                atomically $ do
-                    writeTQueue queue Nothing
+            atomically $ do
+                writeTQueue queue Nothing
 
-                atomically $ do
-                    Ki.await a
+            readMVar done
 
-                value <- readMVar store
-                value `shouldBe` ([1 .. 300] :: [Int])
+            value <- readMVar store
+            value `shouldBe` ([1 .. 300] :: [Int])

--- a/tests/SimpleExperiment.hs
+++ b/tests/SimpleExperiment.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
@@ -16,8 +17,8 @@ import Core.Encoding
 import Core.Program
 import Core.System
 import Core.Text
-import qualified Data.ByteString.Char8 as S
-import qualified Data.HashMap.Strict as HashMap
+import Data.ByteString.Char8 qualified as S
+import Data.HashMap.Strict qualified as HashMap
 import Prettyprinter (Pretty (..), defaultLayoutOptions, layoutPretty)
 import Prettyprinter.Render.Text (renderStrict)
 

--- a/tests/SimpleExperiment.hs
+++ b/tests/SimpleExperiment.hs
@@ -9,7 +9,6 @@
 {-# OPTIONS_GHC -fno-warn-unused-imports #-}
 {-# OPTIONS_GHC -fno-warn-unused-top-binds #-}
 
---import Data.Text (Text)
 import Control.Concurrent (threadDelay)
 import Control.Monad (replicateM_)
 import Core.Data
@@ -70,28 +69,33 @@ program = do
     let x = encodeToUTF8 j
     writeS x
 
-    let (Just y) = decodeFromUTF8 b
-    writeS y
-    writeS (encodeToUTF8 y)
-    writeR (encodeToUTF8 y)
-    writeS (encodeToUTF8 r)
+    let possibleY = decodeFromUTF8 b
+    case possibleY of 
+        Nothing -> invalid
+        Just y -> do
+            writeS y
+            writeS (encodeToUTF8 y)
+            writeR (encodeToUTF8 y)
+            writeS (encodeToUTF8 r)
 
     debugR "packet" j
 
     info "Clock..."
 
-    t <- forkThread $ do
+    createScope $ do
+        t1 <- forkThread $ do
             sleepThread 1.5
             warn "Wakey wakey"
             throw Boom
-    linkThread t
 
-    replicateM_ 5 $ do
-        sleepThread 0.5
-        info "tick"
+        forkThread $ do
+            replicateM_ 500 $ do
+                sleepThread 0.1
+                info "tick"
+
+        waitThread t1
 
     info "Brr! It's cold"
-    terminate 0
 
 version :: Version
 version = $(fromPackage)

--- a/tests/SimpleExperiment.hs
+++ b/tests/SimpleExperiment.hs
@@ -70,7 +70,7 @@ program = do
     writeS x
 
     let possibleY = decodeFromUTF8 b
-    case possibleY of 
+    case possibleY of
         Nothing -> invalid
         Just y -> do
             writeS y

--- a/tests/Snippet.hs
+++ b/tests/Snippet.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# OPTIONS_GHC -fno-warn-missing-signatures #-}
 {-# OPTIONS_GHC -fno-warn-unused-do-bind #-}
 {-# OPTIONS_GHC -fno-warn-unused-imports #-}

--- a/tests/Snippet.hs
+++ b/tests/Snippet.hs
@@ -1,6 +1,6 @@
+{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
-{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# OPTIONS_GHC -fno-warn-missing-signatures #-}
 {-# OPTIONS_GHC -fno-warn-unused-do-bind #-}
@@ -10,7 +10,7 @@
 import Core.Program
 import Core.System
 import Core.Text
-import qualified Data.ByteString.Char8 as C
+import Data.ByteString.Char8 qualified as C
 
 b = intoBytes (C.pack "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789")
 

--- a/tests/Snippet.hs
+++ b/tests/Snippet.hs
@@ -21,6 +21,7 @@ main = execute $ do
 
     write $ case x of
         Nothing -> "Nothing!"
+        Just _ -> "Something!"
 
     sleepThread 0.2
 

--- a/unbeliever.cabal
+++ b/unbeliever.cabal
@@ -50,7 +50,7 @@ license:        MIT
 license-file:   LICENSE
 build-type:     Simple
 tested-with:
-    GHC == 8.10.7
+    GHC == 9.2.4
 
 source-repository head
   type: git
@@ -83,6 +83,7 @@ executable snippet
     , core-data
     , core-program
     , core-text
+  buildable: False
   default-language: Haskell2010
 
 test-suite check

--- a/unbeliever.cabal
+++ b/unbeliever.cabal
@@ -112,7 +112,6 @@ test-suite check
   build-depends:
       QuickCheck
     , aeson
-    , async
     , base >=4.11 && <5
     , bytestring
     , core-data >=0.3.4.0
@@ -124,6 +123,7 @@ test-suite check
     , fingertree
     , hashable
     , hspec
+    , ki >=1.0.0
     , network-info
     , prettyprinter
     , safe-exceptions

--- a/unbeliever.cabal
+++ b/unbeliever.cabal
@@ -76,22 +76,19 @@ executable experiment
   default-language: Haskell2010
 
 executable snippet
-  main-is: WarpSnippet.hs
+  main-is: Snippet.hs
   hs-source-dirs:
       tests
   ghc-options: -Wall -Wwarn -fwarn-tabs -threaded
   build-depends:
       base >=4.11 && <5
+    , bytestring
     , core-data >=0.3.4.0
     , core-program >=0.5.1.0
     , core-telemetry >=0.2.3.5
     , core-text >=0.3.8.0
     , core-webserver-servant >=0.1.1.2
-    , core-webserver-warp
-    , http-types
-    , wai
-    , warp
-  buildable: False
+    , core-webserver-warp >=0.1.1.6
   default-language: Haskell2010
 
 test-suite check

--- a/unbeliever.cabal
+++ b/unbeliever.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.35.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -116,7 +116,6 @@ test-suite check
     , fingertree
     , hashable
     , hspec
-    , ki >=1.0.0
     , network-info
     , prettyprinter
     , safe-exceptions

--- a/unbeliever.cabal
+++ b/unbeliever.cabal
@@ -89,6 +89,7 @@ executable snippet
     , core-text >=0.3.8.0
     , core-webserver-servant >=0.1.1.2
     , core-webserver-warp >=0.1.1.6
+  buildable: False
   default-language: Haskell2010
 
 test-suite check

--- a/unbeliever.cabal
+++ b/unbeliever.cabal
@@ -64,12 +64,9 @@ executable experiment
   build-depends:
       base >=4.11 && <5
     , bytestring
-    , core-data >=0.3.4.0
-    , core-program >=0.5.1.0
-    , core-telemetry >=0.2.3.5
-    , core-text >=0.3.8.0
-    , core-webserver-servant >=0.1.1.2
-    , core-webserver-warp >=0.1.1.6
+    , core-data
+    , core-program
+    , core-text
     , prettyprinter
     , unordered-containers
   buildable: False
@@ -83,13 +80,9 @@ executable snippet
   build-depends:
       base >=4.11 && <5
     , bytestring
-    , core-data >=0.3.4.0
-    , core-program >=0.5.1.0
-    , core-telemetry >=0.2.3.5
-    , core-text >=0.3.8.0
-    , core-webserver-servant >=0.1.1.2
-    , core-webserver-warp >=0.1.1.6
-  buildable: False
+    , core-data
+    , core-program
+    , core-text
   default-language: Haskell2010
 
 test-suite check
@@ -114,12 +107,12 @@ test-suite check
     , aeson
     , base >=4.11 && <5
     , bytestring
-    , core-data >=0.3.4.0
-    , core-program >=0.5.1.0
-    , core-telemetry >=0.2.3.5
-    , core-text >=0.3.8.0
-    , core-webserver-servant >=0.1.1.2
-    , core-webserver-warp >=0.1.1.6
+    , core-data
+    , core-program
+    , core-telemetry
+    , core-text
+    , core-webserver-servant
+    , core-webserver-warp
     , fingertree
     , hashable
     , hspec
@@ -145,12 +138,9 @@ benchmark performance
   build-depends:
       base >=4.11 && <5
     , bytestring
-    , core-data >=0.3.4.0
-    , core-program >=0.5.1.0
-    , core-telemetry >=0.2.3.5
-    , core-text >=0.3.8.0
-    , core-webserver-servant >=0.1.1.2
-    , core-webserver-warp >=0.1.1.6
+    , core-data
+    , core-program
+    , core-text
     , gauge
     , text
   default-language: Haskell2010


### PR DESCRIPTION
Refactor the implementation of forking, waiting, and racing threads.

This is based on the ideas from the **ki** package. We attempted an implementation using that code in #149 but we ran into severe STM race conditions and had to abandon that approach.

This branch implements the idea of structured concurrency in a similar manner, providing bi-directional exception passing in the case where you have `waitThread`ed for a forked child. Here we define a "scope" as a simple Set of ThreadIds whose only purpose is to be able to cancel (kill) them if/when the scope exits. You can enter a new scope with the `createScope` function.

The mechanism that makes this work is simple use of MVars to mark the end of the the core output and telemetry processing threads (removing the craziness of them attempting to shut down causing race condidtions) and userspace threads are recorded in a simple Set ThreadId guarded in a single TVar so that they can be cleaned up when exiting the enclosing scope.

We're now getting correct behaviour when racing threads together, when using ^C to interrupt the program, and when a scope containing threads exits: an exception leaving the scope will cause the scope to kill its child threads. You can wait for a single thread or a list of threads (assuming they have the same return type). The helper functions for running two threads to completion or racing two threads we had before are now restored.

Closes #150.

This is a major API bump to 0.6.0 since the internal definition of Thread has changed (it's no longer a wraper over **async**'s Thread, so the return type of `unThread` is different), `linkThread` is now gone, and there are behaviour changes with respect to waiting for threads and scopes.