### PR TITLE
add back `linkThread` for backwards compatibility

### DIFF
--- a/core-program/lib/Core/Program/Threads.hs
+++ b/core-program/lib/Core/Program/Threads.hs
@@ -473,5 +473,5 @@ Exceptions are bidirectional so linkThread no longer needed.
 @since 0.4.2
 -}
 linkThread :: Thread a -> Program t ()
-linkThread = pure ()
+linkThread = pure $ pure ()
 {-# DEPRECATED linkThread "Exceptions are bidirectional so linkThread no longer needed" #-}

--- a/core-program/lib/Core/Program/Threads.hs
+++ b/core-program/lib/Core/Program/Threads.hs
@@ -472,7 +472,6 @@ Exceptions are bidirectional so linkThread no longer needed.
 
 @since 0.4.2
 -}
-linkedThread :: Thread a -> Program t ()
-linkedThread = pure ()
-
+linkThread :: Thread a -> Program t ()
+linkThread = pure ()
 {-# DEPRECATED linkThread "Exceptions are bidirectional so linkThread no longer needed" #-}

--- a/core-program/lib/Core/Program/Threads.hs
+++ b/core-program/lib/Core/Program/Threads.hs
@@ -28,6 +28,7 @@ module Core.Program.Threads (
     createScope,
     forkThread,
     forkThread_,
+    linkThread,
     waitThread,
     waitThread_,
     waitThread',
@@ -464,3 +465,14 @@ timeouts:
 -}
 raceThreads_ :: Program τ α -> Program τ β -> Program τ ()
 raceThreads_ one two = void (raceThreads one two)
+
+{- |
+Does nothing except maintain the legacy API for backwards compatibility.
+Exceptions are bidirectional so linkThread no longer needed.
+
+@since 0.4.2
+-}
+linkedThread :: Thread a -> Program t ()
+linkedThread = pure ()
+
+{-# DEPRECATED linkThread "Exceptions are bidirectional so linkThread no longer needed" #-}

--- a/core-program/package.yaml
+++ b/core-program/package.yaml
@@ -1,5 +1,5 @@
 name: core-program
-version: 0.6.0.1
+version: 0.6.1.0
 synopsis: Opinionated Haskell Interoperability
 description: |
   A library to help build command-line programs, both tools and


### PR DESCRIPTION
The removal of `linkThread` would force upstream users to make small rewrites of their applications. This little amend will mean everything old will still compile and work, hopefully without rewrites.

`linkThread` now does nothing except maintain the legacy API for backwards compatibility. Exceptions are bidirectional so linkThread no longer needed.
