### PR TITLE
Formatting

### DIFF
--- a/bench/GeneralPerformance.hs
+++ b/bench/GeneralPerformance.hs
@@ -1,8 +1,9 @@
 {-# LANGUAGE OverloadedStrings #-}
+
 {-# OPTIONS -fno-warn-unused-do-bind #-}
 
-import Gauge.Main
 import GHC.Conc
+import Gauge.Main
 
 import qualified Data.ByteString as B
 import qualified Data.Text as T
@@ -22,11 +23,13 @@ main = do
 
     GHC.Conc.setNumCapabilities 4
     defaultMain
-        [ bgroup "to-file"
+        [ bgroup
+            "to-file"
             [ bench "data-text" (nfIO (runTextToFile (httpResponseText bodyText)))
             , bench "core-rope" (nfIO (runRopeToFile (httpResponseRope bodyRope)))
             ]
-        , bgroup "convert-to-rope"
+        , bgroup
+            "convert-to-rope"
             [ bench "original" (nf (complexMess intoRope) b')
             , bench "experiment" (nf (complexMess unsafeIntoRope) b')
             ]
@@ -36,12 +39,12 @@ main = do
 ----
 
 runTextToFile :: U.Builder -> IO ()
-runTextToFile build = do 
+runTextToFile build = do
     withFile "/tmp/garbage-text.txt" WriteMode $ \handle -> do
         T.hPutStr handle (U.toStrict (U.toLazyText build))
 
 runRopeToFile :: Rope -> IO ()
-runRopeToFile text = do 
+runRopeToFile text = do
     withFile "/tmp/garbage-rope.txt" WriteMode $ \handle -> do
         hWrite handle text
 
@@ -49,42 +52,123 @@ runRopeToFile text = do
 
 httpResponseText :: T.Text -> U.Builder
 httpResponseText body =
-    "HTTP/1.1" <> " " <> "200 OK" <> "\r\n" <>
-    "Cache-Control" <> ": " <> "no-cache, must-revalidate" <> "\r\n" <>
-    "Connection" <> ": " <> "keep-alive" <> "\r\n" <>
-    "Content-Length" <> ": " <> "1609" <> "\r\n" <>
-    "Content-Type" <> ": " <> "text/plain; charset=utf-8" <> "\r\n" <>
-    "Date" <> ": " <> "Sun, 23 Sep 2018 09:16:05 GMT" <> "\r\n" <>
-    "Expires" <> ": " <> "Thu, 01 Jan 1970 05:05:05 GMT" <> "\r\n" <>
-    "Server" <> ": " <> "nginx/1.9.15" <> "\r\n" <>
-    "Vary" <> ": " <> "Accept, Accept-Language" <> "\r\n" <>
-    "\r\n" <>
-    U.fromText body
+    "HTTP/1.1"
+        <> " "
+        <> "200 OK"
+        <> "\r\n"
+        <> "Cache-Control"
+        <> ": "
+        <> "no-cache, must-revalidate"
+        <> "\r\n"
+        <> "Connection"
+        <> ": "
+        <> "keep-alive"
+        <> "\r\n"
+        <> "Content-Length"
+        <> ": "
+        <> "1609"
+        <> "\r\n"
+        <> "Content-Type"
+        <> ": "
+        <> "text/plain; charset=utf-8"
+        <> "\r\n"
+        <> "Date"
+        <> ": "
+        <> "Sun, 23 Sep 2018 09:16:05 GMT"
+        <> "\r\n"
+        <> "Expires"
+        <> ": "
+        <> "Thu, 01 Jan 1970 05:05:05 GMT"
+        <> "\r\n"
+        <> "Server"
+        <> ": "
+        <> "nginx/1.9.15"
+        <> "\r\n"
+        <> "Vary"
+        <> ": "
+        <> "Accept, Accept-Language"
+        <> "\r\n"
+        <> "\r\n"
+        <> U.fromText body
 
 httpResponseRope :: Rope -> Rope
 httpResponseRope body =
-    "HTTP/1.1" <> " " <> "200 OK" <> "\r\n" <>
-    "Cache-Control" <> ": " <> "no-cache, must-revalidate" <> "\r\n" <>
-    "Connection" <> ": " <> "keep-alive" <> "\r\n" <>
-    "Content-Length" <> ": " <> "1609" <> "\r\n" <>
-    "Content-Type" <> ": " <> "text/plain; charset=utf-8" <> "\r\n" <>
-    "Date" <> ": " <> "Sun, 23 Sep 2018 09:16:05 GMT" <> "\r\n" <>
-    "Expires" <> ": " <> "Thu, 01 Jan 1970 05:05:05 GMT" <> "\r\n" <>
-    "Server" <> ": " <> "nginx/1.9.15" <> "\r\n" <>
-    "Vary" <> ": " <> "Accept, Accept-Language" <> "\r\n" <>
-    "\r\n" <>
-    body
+    "HTTP/1.1"
+        <> " "
+        <> "200 OK"
+        <> "\r\n"
+        <> "Cache-Control"
+        <> ": "
+        <> "no-cache, must-revalidate"
+        <> "\r\n"
+        <> "Connection"
+        <> ": "
+        <> "keep-alive"
+        <> "\r\n"
+        <> "Content-Length"
+        <> ": "
+        <> "1609"
+        <> "\r\n"
+        <> "Content-Type"
+        <> ": "
+        <> "text/plain; charset=utf-8"
+        <> "\r\n"
+        <> "Date"
+        <> ": "
+        <> "Sun, 23 Sep 2018 09:16:05 GMT"
+        <> "\r\n"
+        <> "Expires"
+        <> ": "
+        <> "Thu, 01 Jan 1970 05:05:05 GMT"
+        <> "\r\n"
+        <> "Server"
+        <> ": "
+        <> "nginx/1.9.15"
+        <> "\r\n"
+        <> "Vary"
+        <> ": "
+        <> "Accept, Accept-Language"
+        <> "\r\n"
+        <> "\r\n"
+        <> body
 
 complexMess :: (B.ByteString -> Rope) -> B.ByteString -> Rope
 complexMess f body =
-    "HTTP/1.1" <> " " <> "200 OK" <> "\n" <>
-    "Cache-Control" <> ": " <> "no-cache, must-revalidate" <> "\n" <>
-    "Connection" <> ": " <> "keep-alive" <> "\n" <>
-    "Content-Length" <> ": " <> "1609" <> "\n" <>
-    "Content-Type" <> ": " <> "text/plain; charset=utf-8" <> "\n" <>
-    "Date" <> ": " <> "Sun, 23 Sep 2018 09:16:05 GMT" <> "\n" <>
-    "Expires" <> ": " <> "Thu, 01 Jan 1970 05:05:05 GMT" <> "\n" <>
-    "Server" <> ": " <> "nginx/1.9.15" <> "\n" <>
-    "Vary" <> ": " <> "Accept, Accept-Language" <> "\n" <>
-    "\n" <>
-    f body
+    "HTTP/1.1"
+        <> " "
+        <> "200 OK"
+        <> "\n"
+        <> "Cache-Control"
+        <> ": "
+        <> "no-cache, must-revalidate"
+        <> "\n"
+        <> "Connection"
+        <> ": "
+        <> "keep-alive"
+        <> "\n"
+        <> "Content-Length"
+        <> ": "
+        <> "1609"
+        <> "\n"
+        <> "Content-Type"
+        <> ": "
+        <> "text/plain; charset=utf-8"
+        <> "\n"
+        <> "Date"
+        <> ": "
+        <> "Sun, 23 Sep 2018 09:16:05 GMT"
+        <> "\n"
+        <> "Expires"
+        <> ": "
+        <> "Thu, 01 Jan 1970 05:05:05 GMT"
+        <> "\n"
+        <> "Server"
+        <> ": "
+        <> "nginx/1.9.15"
+        <> "\n"
+        <> "Vary"
+        <> ": "
+        <> "Accept, Accept-Language"
+        <> "\n"
+        <> "\n"
+        <> f body

--- a/core-data/lib/Core/Data.hs
+++ b/core-data/lib/Core/Data.hs
@@ -12,17 +12,17 @@ import "Core.Data"
 
 as this module re-exports all of its various components.
 -}
-module Core.Data (
-    -- * Wrappers
+module Core.Data
+    ( -- * Wrappers
 
-    -- |
-    -- Exposes 'Map', a wrapper around a dictionary type, and 'Set', for
-    -- collections of elements.
-    module Core.Data.Structures,
-    -- |
-    -- Facilities for making timestamps and for converting between different representations of instants of time.
-    module Core.Data.Clock,
-) where
+      -- |
+      -- Exposes 'Map', a wrapper around a dictionary type, and 'Set', for
+      -- collections of elements.
+        module Core.Data.Structures
+      -- |
+      -- Facilities for making timestamps and for converting between different representations of instants of time.
+    , module Core.Data.Clock
+    ) where
 
 import Core.Data.Clock
 import Core.Data.Structures

--- a/core-data/lib/Core/Data/Clock.hs
+++ b/core-data/lib/Core/Data/Clock.hs
@@ -32,18 +32,18 @@ There are quite a few other time formats around the Haskell ecosystem. You can
 use the 'fromTime' and 'intoTime' methods of the 'Instant' typeclass  to
 convert from one to another if you need to.
 -}
-module Core.Data.Clock (
-    -- * Time type
-    Time,
-    getCurrentTimeNanoseconds,
+module Core.Data.Clock
+    ( -- * Time type
+      Time
+    , getCurrentTimeNanoseconds
 
-    -- * Conversions
-    Instant (fromTime, intoTime),
+      -- * Conversions
+    , Instant (fromTime, intoTime)
 
-    -- * Internals
-    unTime,
-    epochTime,
-) where
+      -- * Internals
+    , unTime
+    , epochTime
+    ) where
 
 import Control.Applicative ((<|>))
 import Core.Data.Format
@@ -51,31 +51,31 @@ import Core.Text.Rope
 import Data.Aeson qualified as Aeson (FromJSON (..), ToJSON (..), Value (..))
 import Data.Aeson.Encoding qualified as Aeson (string)
 import Data.Aeson.Types qualified as Aeson (typeMismatch)
-import Data.Hourglass qualified as H (
-    DateTime (..),
-    Elapsed (..),
-    ElapsedP (..),
-    ISO8601_Date (..),
-    ISO8601_DateAndTime (..),
-    NanoSeconds (..),
-    Seconds (..),
-    Timeable (timeGetElapsedP),
-    timeParse,
-    timePrint,
- )
+import Data.Hourglass qualified as H
+    ( DateTime (..)
+    , Elapsed (..)
+    , ElapsedP (..)
+    , ISO8601_Date (..)
+    , ISO8601_DateAndTime (..)
+    , NanoSeconds (..)
+    , Seconds (..)
+    , Timeable (timeGetElapsedP)
+    , timeParse
+    , timePrint
+    )
 import Data.Int (Int64)
 import Data.Maybe (maybeToList)
 import Data.Time.Calendar (Day)
 import Data.Time.Clock (UTCTime (UTCTime, utctDay, utctDayTime))
-import Data.Time.Clock.POSIX (
-    POSIXTime,
-    posixSecondsToUTCTime,
-    utcTimeToPOSIXSeconds,
- )
+import Data.Time.Clock.POSIX
+    ( POSIXTime
+    , posixSecondsToUTCTime
+    , utcTimeToPOSIXSeconds
+    )
 import GHC.Generics
-import Time.System qualified as H (
-    timeCurrentP,
- )
+import Time.System qualified as H
+    ( timeCurrentP
+    )
 
 {- |
 Number of nanoseconds since the Unix epoch.
@@ -195,7 +195,7 @@ convertFromPosix :: POSIXTime -> Time
 convertFromPosix =
     let nano :: POSIXTime -> Int64
         nano = floor . (* 1000000000) . toRational
-     in Time . fromIntegral . nano
+    in  Time . fromIntegral . nano
 
 convertToPosix :: Time -> POSIXTime
 convertToPosix = fromRational . (/ 1e9) . fromIntegral . unTime
@@ -213,12 +213,12 @@ convertFromElapsed :: H.ElapsedP -> Time
 convertFromElapsed (H.ElapsedP (H.Elapsed (H.Seconds seconds)) (H.NanoSeconds nanoseconds)) =
     let s = fromIntegral seconds :: Int64
         ns = fromIntegral nanoseconds
-     in Time $! (s * 1000000000) + ns
+    in  Time $! (s * 1000000000) + ns
 
 convertToElapsed :: Time -> H.ElapsedP
 convertToElapsed (Time ticks) =
     let (s, ns) = divMod ticks 1000000000
-     in H.ElapsedP (H.Elapsed (H.Seconds (s))) (H.NanoSeconds (ns))
+    in  H.ElapsedP (H.Elapsed (H.Seconds (s))) (H.NanoSeconds (ns))
 
 {- |
 This instance may be useful if you need to work with calendar dates with
@@ -230,7 +230,7 @@ timestamp of midnight 00:00:00.0 on that date.
 -}
 instance Instant Day where
     fromTime = utctDay . fromTime
-    intoTime x = intoTime (UTCTime{utctDay = x, utctDayTime = 0})
+    intoTime x = intoTime (UTCTime {utctDay = x, utctDayTime = 0})
 
 instance Aeson.ToJSON Time where
     toEncoding = Aeson.string . H.timePrint ISO8601_Precise . convertToElapsed
@@ -239,7 +239,7 @@ instance Aeson.FromJSON Time where
     parseJSON (Aeson.String value) =
         let str = (fromRope (intoRope value))
             result = parseInput str
-         in case result of
+        in  case result of
                 Just t -> pure t
                 Nothing -> fail "Unable to parse input as a TimeStamp"
     parseJSON (invalid) = Aeson.typeMismatch "TimeStamp" invalid

--- a/core-data/lib/Core/Data/Format.hs
+++ b/core-data/lib/Core/Data/Format.hs
@@ -4,11 +4,11 @@
 
 module Core.Data.Format where
 
-import Data.Hourglass qualified as H (
-    TimeFormat (..),
-    TimeFormatElem (..),
-    TimeFormatString (..),
- )
+import Data.Hourglass qualified as H
+    ( TimeFormat (..)
+    , TimeFormatElem (..)
+    , TimeFormatString (..)
+    )
 
 {- |
 Format string describing full (nanosecond) precision ISO8601 time,

--- a/core-data/lib/Core/Data/Structures.hs
+++ b/core-data/lib/Core/Data/Structures.hs
@@ -9,35 +9,35 @@ Convenience wrappers around dictionary and collection types and tools
 facilitating conversion between them and various map and set types in
 common use in the Haskell ecosystem.
 -}
-module Core.Data.Structures (
-    -- * Map type
-    Map,
-    emptyMap,
-    singletonMap,
-    insertKeyValue,
-    containsKey,
-    lookupKeyValue,
-    removeKeyValue,
+module Core.Data.Structures
+    ( -- * Map type
+      Map
+    , emptyMap
+    , singletonMap
+    , insertKeyValue
+    , containsKey
+    , lookupKeyValue
+    , removeKeyValue
 
-    -- * Conversions
-    Dictionary (K, V, fromMap, intoMap),
+      -- * Conversions
+    , Dictionary (K, V, fromMap, intoMap)
 
-    -- * Set type
-    Set,
-    emptySet,
-    singletonSet,
-    insertElement,
-    containsElement,
-    removeElement,
+      -- * Set type
+    , Set
+    , emptySet
+    , singletonSet
+    , insertElement
+    , containsElement
+    , removeElement
 
-    -- * Conversions
-    Collection (E, fromSet, intoSet),
+      -- * Conversions
+    , Collection (E, fromSet, intoSet)
 
-    -- * Internals
-    Key,
-    unMap,
-    unSet,
-) where
+      -- * Internals
+    , Key
+    , unMap
+    , unSet
+    ) where
 
 import Control.Concurrent qualified as Base (ThreadId)
 import Core.Text.Bytes (Bytes)

--- a/core-data/lib/Core/Encoding.hs
+++ b/core-data/lib/Core/Encoding.hs
@@ -16,11 +16,10 @@ wide use across the Haskell community; these modules are here as wrappers
 providing for ease of use and interoperability across the various tools in
 this package.
 -}
-module Core.Encoding (
-    module Core.Encoding.Json,
-
-    module Core.Encoding.External,
-) where
+module Core.Encoding
+    ( module Core.Encoding.Json
+    , module Core.Encoding.External
+    ) where
 
 import Core.Encoding.External
 import Core.Encoding.Json

--- a/core-data/lib/Core/Encoding/External.hs
+++ b/core-data/lib/Core/Encoding/External.hs
@@ -45,10 +45,9 @@ canonical, stable form, even if the original input was written differently.
 See the discussion of creating 'Core.Data.Clock.Time' types from varying
 inputs for an example.
 -}
-module Core.Encoding.External (
-    -- * Conversions
-    Externalize (formatExternal, parseExternal),
-) where
+module Core.Encoding.External
+    ( Externalize (formatExternal, parseExternal)
+    ) where
 
 import Core.Data.Clock
 import Core.Text.Rope

--- a/core-data/lib/Core/Encoding/Json.hs
+++ b/core-data/lib/Core/Encoding/Json.hs
@@ -51,21 +51,21 @@ which you is somewhat less cumbersome in declaration-heavy code. You're
 certainly welcome to use the constructors if you find it makes for more
 readable code or if you need the type annotations.
 -}
-module Core.Encoding.Json (
-    -- * Encoding and Decoding
-    encodeToUTF8,
-    encodeToRope,
-    decodeFromUTF8,
-    decodeFromRope,
-    JsonValue (..),
-    JsonKey (..),
+module Core.Encoding.Json
+    ( -- * Encoding and Decoding
+      encodeToUTF8
+    , encodeToRope
+    , decodeFromUTF8
+    , decodeFromRope
+    , JsonValue (..)
+    , JsonKey (..)
 
-    -- * Syntax highlighting
-    JsonToken (..),
-    colourizeJson,
-    prettyKey,
-    prettyValue,
-) where
+      -- * Syntax highlighting
+    , JsonToken (..)
+    , colourizeJson
+    , prettyKey
+    , prettyValue
+    ) where
 
 #if MIN_VERSION_aeson(2,0,1)
 import qualified Data.Aeson.Key as Aeson
@@ -76,68 +76,68 @@ import qualified Data.HashMap.Strict as HashMap
 
 import Core.Data.Structures (Key, Map, fromMap, intoMap)
 import Core.Text.Bytes (Bytes, fromBytes, intoBytes)
-import Core.Text.Colour (
-    AnsiColour,
-    brightBlue,
-    brightGrey,
-    brightMagenta,
-    dullBlue,
-    dullCyan,
-    dullGreen,
-    dullYellow,
-    pureGrey,
- )
-import Core.Text.Rope (
-    Rope,
-    Textual,
-    fromRope,
-    intoRope,
-    singletonRope,
-    unconsRope,
- )
-import Core.Text.Utilities (
-    Render (Token, colourize, highlight),
-    breakRope,
- )
+import Core.Text.Colour
+    ( AnsiColour
+    , brightBlue
+    , brightGrey
+    , brightMagenta
+    , dullBlue
+    , dullCyan
+    , dullGreen
+    , dullYellow
+    , pureGrey
+    )
+import Core.Text.Rope
+    ( Rope
+    , Textual
+    , fromRope
+    , intoRope
+    , singletonRope
+    , unconsRope
+    )
+import Core.Text.Utilities
+    ( Render (Token, colourize, highlight)
+    , breakRope
+    )
 import Data.Aeson (FromJSON, Value (String))
 import qualified Data.Aeson as Aeson
 import Data.Char (intToDigit)
 import Data.Coerce
 import Data.Hashable (Hashable)
 import qualified Data.List as List
-import Data.Scientific (
-    FPFormat (..),
-    Scientific,
-    formatScientific,
-    isFloating,
- )
+import Data.Scientific
+    ( FPFormat (..)
+    , Scientific
+    , formatScientific
+    , isFloating
+    )
 import Data.String (IsString (..))
 import qualified Data.Text as T
 import qualified Data.Vector as V
 import GHC.Generics
-import Prettyprinter (
-    Doc,
-    Pretty (..),
-    annotate,
-    comma,
-    dquote,
-    group,
-    hcat,
-    indent,
-    lbrace,
-    lbracket,
-    line,
-    line',
-    nest,
-    punctuate,
-    rbrace,
-    rbracket,
-    sep,
-    unAnnotate,
-    viaShow,
-    vsep,
-    (<+>),
- )
+import Prettyprinter
+    ( Doc
+    , Pretty (..)
+    , annotate
+    , comma
+    , dquote
+    , group
+    , hcat
+    , indent
+    , lbrace
+    , lbracket
+    , line
+    , line'
+    , nest
+    , punctuate
+    , rbrace
+    , rbracket
+    , sep
+    , unAnnotate
+    , viaShow
+    , vsep
+    , (<+>)
+    )
 
 {- |
 Given a JSON value, encode it to UTF-8 bytes
@@ -157,7 +157,7 @@ encodeToRope value = case value of
     JsonObject xm ->
         let kvs = fromMap xm
             members = fmap (\((JsonKey k), v) -> doublequote <> escapeString k <> doublequote <> colonspace <> encodeToRope v) kvs
-         in openbrace <> mconcat (List.intersperse commaspace members) <> closebrace
+        in  openbrace <> mconcat (List.intersperse commaspace members) <> closebrace
     JsonArray xs ->
         openbracket <> mconcat (List.intersperse commaspace (fmap encodeToRope xs)) <> closebracket
     JsonString x ->
@@ -184,7 +184,7 @@ Escape any quotes, backslashes, or other possible rubbish in a 'JsonString'.
 escapeString :: Rope -> Rope
 escapeString text =
     let (before, after) = breakRope needsEscaping text
-     in case unconsRope after of
+    in  case unconsRope after of
             Nothing ->
                 text
             Just (c, after') ->
@@ -215,7 +215,7 @@ decodeFromUTF8 :: Bytes -> Maybe JsonValue
 decodeFromUTF8 b =
     let x :: Maybe Aeson.Value
         x = Aeson.decodeStrict' (fromBytes b)
-     in fmap fromAeson x
+    in  fmap fromAeson x
 
 {- |
 Given an string that is full of a bunch of JSON, attempt to decode
@@ -225,7 +225,7 @@ decodeFromRope :: Rope -> Maybe JsonValue
 decodeFromRope text =
     let x :: Maybe Aeson.Value
         x = Aeson.decodeStrict' (fromRope text)
-     in fmap fromAeson x
+    in  fmap fromAeson x
 
 {- |
 A JSON value.
@@ -277,6 +277,7 @@ instance Textual JsonKey where
     fromRope t = coerce t
     intoRope x = coerce x
 
+{- FOURMOLU_DISABLE -}
 fromAeson :: Aeson.Value -> JsonValue
 fromAeson value = case value of
 #if MIN_VERSION_aeson(2,0,1)
@@ -314,6 +315,7 @@ fromAeson value = case value of
     Aeson.Number n -> JsonNumber n
     Aeson.Bool x -> JsonBool x
     Aeson.Null -> JsonNull
+{- FOURMOLU_ENABLE -}
 
 --
 -- Pretty printing
@@ -405,12 +407,12 @@ prettyValue value = case value of
                 (JsonObject _) -> line <> doc
                 (JsonArray _) -> group doc
                 _ -> doc
-         in if length entries == 0
+        in  if length entries == 0
                 then annotate SymbolToken (lbrace <> rbrace)
                 else annotate SymbolToken lbrace <> line <> indent 4 (vsep (punctuate (annotate SymbolToken comma) entries)) <> line <> annotate SymbolToken rbrace
     JsonArray xs ->
         let entries = fmap prettyValue xs
-         in line'
+        in  line'
                 <> nest
                     4
                     ( annotate SymbolToken lbracket
@@ -435,7 +437,7 @@ escapeText text =
     let t = fromRope text :: T.Text
         ts = T.split (== '"') t
         ds = fmap pretty ts
-     in hcat (punctuate (annotate EscapeToken "\\\"") ds)
+    in  hcat (punctuate (annotate EscapeToken "\\\"") ds)
 {-# INLINEABLE escapeText #-}
 
 --

--- a/core-program/lib/Core/Program.hs
+++ b/core-program/lib/Core/Program.hs
@@ -2,50 +2,50 @@
 
 -- actually, they're there to group implementation too, but hey.
 
--- |
--- Support for building command-line programs, ranging from simple tools to
--- long-running daemons.
---
--- This is intended to be used directly:
---
--- @
--- import "Core.Program"
--- @
---
--- the submodules are mostly there to group documentation.
+{- |
+Support for building command-line programs, ranging from simple tools to
+long-running daemons.
+
+This is intended to be used directly:
+
+@
+import "Core.Program"
+@
+
+the submodules are mostly there to group documentation.
+-}
 module Core.Program
-  ( -- * Executing a program
+    ( -- * Executing a program
 
-    -- |
-    -- A top-level Program type giving you unified access to logging, concurrency,
-    -- and more.
-    module Core.Program.Context,
-    module Core.Program.Execute,
-    module Core.Program.Threads,
-    module Core.Program.Unlift,
-    module Core.Program.Metadata,
-    module Core.Program.Exceptions,
+      -- |
+      -- A top-level Program type giving you unified access to logging, concurrency,
+      -- and more.
+        module Core.Program.Context
+    , module Core.Program.Execute
+    , module Core.Program.Threads
+    , module Core.Program.Unlift
+    , module Core.Program.Metadata
+    , module Core.Program.Exceptions
 
-    -- * Command-line argument parsing
+      -- * Command-line argument parsing
 
-    -- |
-    -- Including declaring what options your program accepts, generating help, and
-    -- for more complex cases [sub]commands, mandatory arguments, and environment
-    -- variable handling.
-    module Core.Program.Arguments,
+      -- |
+      -- Including declaring what options your program accepts, generating help, and
+      -- for more complex cases [sub]commands, mandatory arguments, and environment
+      -- variable handling.
+    , module Core.Program.Arguments
 
-    -- * Logging facilities
+      -- * Logging facilities
 
-    -- |
-    -- Facilities for noting events through your program and doing debugging.
-    module Core.Program.Logging,
-
-    -- |
-    -- There are a few common use cases which require a bit of wrapping to use
-    -- effectively. Watching files for changes and taking action in the event of a
-    -- change is one.
-    module Core.Program.Notify,
-  )
+      -- |
+      -- Facilities for noting events through your program and doing debugging.
+    , module Core.Program.Logging
+      -- |
+      -- There are a few common use cases which require a bit of wrapping to use
+      -- effectively. Watching files for changes and taking action in the event of a
+      -- change is one.
+    , module Core.Program.Notify
+    )
 where
 
 import Core.Program.Arguments

--- a/core-program/lib/Core/Program/Arguments.hs
+++ b/core-program/lib/Core/Program/Arguments.hs
@@ -20,53 +20,53 @@ in the program's Context.
 Additionally, this module allows you to specify environment variables that,
 if present, will be incorporated into the stored configuration.
 -}
-module Core.Program.Arguments (
-    -- * Setup
-    Config,
-    blankConfig,
-    simpleConfig,
-    complexConfig,
-    baselineOptions,
-    Parameters (..),
-    ParameterValue (..),
+module Core.Program.Arguments
+    ( -- * Setup
+      Config
+    , blankConfig
+    , simpleConfig
+    , complexConfig
+    , baselineOptions
+    , Parameters (..)
+    , ParameterValue (..)
 
-    -- * Options and Arguments
-    LongName (..),
-    ShortName,
-    Description,
-    Options (..),
+      -- * Options and Arguments
+    , LongName (..)
+    , ShortName
+    , Description
+    , Options (..)
 
-    -- * Programs with Commands
-    Commands (..),
-    appendOption,
+      -- * Programs with Commands
+    , Commands (..)
+    , appendOption
 
-    -- * Internals
-    parseCommandLine,
-    extractValidEnvironments,
-    InvalidCommandLine (..),
-    buildUsage,
-    buildVersion,
-    emptyParameters,
-) where
+      -- * Internals
+    , parseCommandLine
+    , extractValidEnvironments
+    , InvalidCommandLine (..)
+    , buildUsage
+    , buildVersion
+    , emptyParameters
+    ) where
 
 import Data.Hashable (Hashable)
 import Data.List qualified as List
 import Data.Maybe (fromMaybe)
 import Data.String (IsString (..))
-import Prettyprinter (
-    Doc,
-    Pretty (..),
-    align,
-    emptyDoc,
-    fillBreak,
-    fillCat,
-    fillSep,
-    hardline,
-    indent,
-    nest,
-    softline,
-    (<+>),
- )
+import Prettyprinter
+    ( Doc
+    , Pretty (..)
+    , align
+    , emptyDoc
+    , fillBreak
+    , fillCat
+    , fillSep
+    , hardline
+    , indent
+    , nest
+    , softline
+    , (<+>)
+    )
 import Prettyprinter.Util (reflow)
 import System.Environment (getProgName)
 
@@ -498,12 +498,12 @@ with complex values escaped according to the rules of your shell:
 
 For options valid in this program, please see --help.
         |]
-             in one ++ two
+            in  one ++ two
         UnknownOption name -> "Sorry, option '" ++ name ++ "' not recognized."
         MissingArgument (LongName name) -> "Mandatory argument '" ++ name ++ "' missing."
         UnexpectedArguments args ->
             let quoted = List.intercalate "', '" args
-             in [quote|
+            in  [quote|
 Unexpected trailing arguments:
 
 |]
@@ -557,7 +557,7 @@ parseCommandLine config argv = case config of
     Complex commands ->
         let globalOptions = extractGlobalOptions commands
             modes = extractValidModes commands
-         in do
+        in  do
                 (possibles, argv') <- splitCommandLine1 argv
                 (params1, _) <- extractor Nothing globalOptions possibles
                 (first, moreArgs) <- splitCommandLine2 argv'
@@ -572,7 +572,7 @@ parseCommandLine config argv = case config of
             valids = extractValidNames options
             shorts = extractShortNames options
             needed = extractRequiredArguments options
-         in do
+        in  do
                 list1 <- parsePossibleOptions mode valids shorts possibles
                 (list2, arguments') <- parseRequiredArguments needed arguments
                 pure (((<>) (intoMap list1) (intoMap list2)), arguments')
@@ -602,12 +602,12 @@ isOption arg = case arg of
     ('-' : _) -> True
     _ -> False
 
-parsePossibleOptions ::
-    Maybe LongName ->
-    Set LongName ->
-    Map ShortName LongName ->
-    [String] ->
-    Either InvalidCommandLine [(LongName, ParameterValue)]
+parsePossibleOptions
+    :: Maybe LongName
+    -> Set LongName
+    -> Map ShortName LongName
+    -> [String]
+    -> Either InvalidCommandLine [(LongName, ParameterValue)]
 parsePossibleOptions mode valids shorts args = mapM f args
   where
     f arg = case arg of
@@ -626,7 +626,7 @@ parsePossibleOptions mode valids shorts args = mapM f args
             value' = case List.uncons value of
                 Just (_, remainder) -> Value remainder
                 Nothing -> Empty
-         in if containsElement candidate valids
+        in  if containsElement candidate valids
                 then Right (candidate, value')
                 else Left (UnknownOption ("--" ++ name))
 
@@ -636,10 +636,10 @@ parsePossibleOptions mode valids shorts args = mapM f args
             Just name -> Right (name, Empty)
             Nothing -> Left (UnknownOption ['-', c])
 
-parseRequiredArguments ::
-    [LongName] ->
-    [String] ->
-    Either InvalidCommandLine ([(LongName, ParameterValue)], [String])
+parseRequiredArguments
+    :: [LongName]
+    -> [String]
+    -> Either InvalidCommandLine ([(LongName, ParameterValue)], [String])
 parseRequiredArguments needed argv = iter needed argv
   where
     iter :: [LongName] -> [String] -> Either InvalidCommandLine ([(LongName, ParameterValue)], [String])
@@ -650,17 +650,17 @@ parseRequiredArguments needed argv = iter needed argv
     iter (name : _) [] = Left (MissingArgument name)
     iter (name : names) (arg : args) =
         let deeper = iter names args
-         in case deeper of
+        in  case deeper of
                 Left e -> Left e
                 Right (list, remainder) -> Right (((name, Value arg) : list), remainder)
 
-parseIndicatedCommand ::
-    Map LongName [Options] ->
-    String ->
-    Either InvalidCommandLine (LongName, [Options])
+parseIndicatedCommand
+    :: Map LongName [Options]
+    -> String
+    -> Either InvalidCommandLine (LongName, [Options])
 parseIndicatedCommand modes first =
     let candidate = LongName first
-     in case lookupKeyValue candidate modes of
+    in  case lookupKeyValue candidate modes of
             Just options -> Right (candidate, options)
             Nothing -> Left (UnknownCommand first)
 
@@ -722,14 +722,14 @@ We do it this way so that `parseCommandLine` can pas the global options to
 splitCommandLine1 :: [String] -> Either InvalidCommandLine ([String], [String])
 splitCommandLine1 args =
     let (possibles, remainder) = List.span isOption args
-     in if null possibles && null remainder
+    in  if null possibles && null remainder
             then Left NoCommandFound
             else Right (possibles, remainder)
 
 splitCommandLine2 :: [String] -> Either InvalidCommandLine (String, [String])
 splitCommandLine2 argv' =
     let x = List.uncons argv'
-     in case x of
+    in  case x of
             Just (mode, remainingArgs) -> Right (mode, remainingArgs)
             Nothing -> Left NoCommandFound
 
@@ -747,7 +747,7 @@ extractValidEnvironments mode config = case config of
 
             locals = extractLocalVariables commands (fromMaybe "" mode)
             variables2 = extractVariableNames locals
-         in variables1 <> variables2
+        in  variables1 <> variables2
 
 extractLocalVariables :: [Commands] -> LongName -> [Options]
 extractLocalVariables commands mode =
@@ -777,7 +777,9 @@ buildUsage config mode = case config of
     Blank -> emptyDoc
     Simple options ->
         let (o, a, v) = partitionParameters options
-         in "Usage:" <> hardline <> hardline
+        in  "Usage:"
+                <> hardline
+                <> hardline
                 <> indent
                     4
                     ( nest
@@ -802,7 +804,7 @@ buildUsage config mode = case config of
             modes = extractValidModes commands
 
             (oG, _, vG) = partitionParameters globalOptions
-         in "Usage:" <> hardline <> hardline <> case mode of
+        in  "Usage:" <> hardline <> hardline <> case mode of
                 Nothing ->
                     indent
                         2
@@ -826,7 +828,7 @@ buildUsage config mode = case config of
                     let (oL, aL, vL) = case lookupKeyValue longname modes of
                             Just localOptions -> partitionParameters localOptions
                             Nothing -> error "Illegal State"
-                     in indent
+                    in  indent
                             2
                             ( nest
                                 4
@@ -913,7 +915,7 @@ buildUsage config mode = case config of
                 Nothing -> "      --"
             l = pretty longname
             d = fromRope description
-         in case valued of
+        in  case valued of
                 Empty ->
                     fillBreak 16 (s <> l <> " ") <+> align (reflow d) <> hardline <> acc
                 Value label ->
@@ -921,14 +923,14 @@ buildUsage config mode = case config of
     g acc (Argument longname description) =
         let l = pretty longname
             d = fromRope description
-         in fillBreak 16 ("  <" <> l <> "> ") <+> align (reflow d) <> hardline <> acc
+        in  fillBreak 16 ("  <" <> l <> "> ") <+> align (reflow d) <> hardline <> acc
     g acc (Remaining description) =
         let d = fromRope description
-         in fillBreak 16 ("  " <> "... ") <+> align (reflow d) <> hardline <> acc
+        in  fillBreak 16 ("  " <> "... ") <+> align (reflow d) <> hardline <> acc
     g acc (Variable longname description) =
         let l = pretty longname
             d = fromRope description
-         in fillBreak 16 ("  " <> l <> " ") <+> align (reflow d) <> hardline <> acc
+        in  fillBreak 16 ("  " <> l <> " ") <+> align (reflow d) <> hardline <> acc
 
     formatCommands :: [Commands] -> Doc ann
     formatCommands commands = hardline <> List.foldl' h emptyDoc commands
@@ -937,12 +939,12 @@ buildUsage config mode = case config of
     h acc (Command longname description _) =
         let l = pretty longname
             d = fromRope description
-         in acc <> fillBreak 16 ("  " <> l <> " ") <+> align (reflow d) <> hardline
+        in  acc <> fillBreak 16 ("  " <> l <> " ") <+> align (reflow d) <> hardline
     h acc _ = acc
 
 buildVersion :: Version -> Doc ann
 buildVersion version =
     pretty (projectNameFrom version)
         <+> "v"
-        <> pretty (versionNumberFrom version)
-        <> hardline
+            <> pretty (versionNumberFrom version)
+            <> hardline

--- a/core-program/lib/Core/Program/Context.hs
+++ b/core-program/lib/Core/Program/Context.hs
@@ -13,29 +13,29 @@
 {-# OPTIONS_HADDOCK hide #-}
 
 -- This is an Internal module, hidden from Haddock
-module Core.Program.Context (
-    Datum (..),
-    emptyDatum,
-    Trace (..),
-    unTrace,
-    Span (..),
-    unSpan,
-    Context (..),
-    handleCommandLine,
-    handleVerbosityLevel,
-    handleTelemetryChoice,
-    Exporter (..),
-    Forwarder (..),
-    None (..),
-    isNone,
-    configure,
-    Verbosity (..),
-    Program (..),
-    unProgram,
-    getContext,
-    fmapContext,
-    subProgram,
-) where
+module Core.Program.Context
+    ( Datum (..)
+    , emptyDatum
+    , Trace (..)
+    , unTrace
+    , Span (..)
+    , unSpan
+    , Context (..)
+    , handleCommandLine
+    , handleVerbosityLevel
+    , handleTelemetryChoice
+    , Exporter (..)
+    , Forwarder (..)
+    , None (..)
+    , isNone
+    , configure
+    , Verbosity (..)
+    , Program (..)
+    , unProgram
+    , getContext
+    , fmapContext
+    , subProgram
+    ) where
 
 import Control.Concurrent (ThreadId)
 import Control.Concurrent.MVar (MVar, newEmptyMVar, newMVar, putMVar, readMVar)
@@ -198,7 +198,7 @@ fmapContext f context = do
     state <- readMVar (applicationDataFrom context)
     let state' = f state
     u <- newMVar state'
-    return (context{applicationDataFrom = u})
+    return (context {applicationDataFrom = u})
 
 {- |
 A 'Program' with no user-supplied state to be threaded throughout the
@@ -487,7 +487,7 @@ queryVerbosityLevel :: Parameters -> Either ExitCode Verbosity
 queryVerbosityLevel params =
     let debug = lookupKeyValue "debug" (parameterValuesFrom params)
         verbose = lookupKeyValue "verbose" (parameterValuesFrom params)
-     in case debug of
+    in  case debug of
             Just value -> case value of
                 Empty -> Right Debug
                 Value "internal" -> Right Internal

--- a/core-program/lib/Core/Program/Exceptions.hs
+++ b/core-program/lib/Core/Program/Exceptions.hs
@@ -72,30 +72,30 @@ fail fast if something goes wrong and you can get an appropriate error message
 back to the surface (in our case the 'Program' @τ@ monad) and you can 'throw'
 from there.
 -}
-module Core.Program.Exceptions (
-    catch,
-    try,
-    throw,
-    bracket,
-    finally,
-    onException,
-    Boom (..),
-) where
+module Core.Program.Exceptions
+    ( catch
+    , try
+    , throw
+    , bracket
+    , finally
+    , onException
+    , Boom (..)
+    ) where
 
-import Control.Exception qualified as Base (
-    Exception,
- )
-import Control.Exception.Safe qualified as Safe (
-    bracket,
-    catch,
-    finally,
-    onException,
-    throw,
-    try,
- )
-import Core.Program.Context (
-    Program,
- )
+import Control.Exception qualified as Base
+    ( Exception
+    )
+import Control.Exception.Safe qualified as Safe
+    ( bracket
+    , catch
+    , finally
+    , onException
+    , throw
+    , try
+    )
+import Core.Program.Context
+    ( Program
+    )
 
 {- |
 Catch an exception.
@@ -188,7 +188,7 @@ which will get you a nice crash message as your world falls down around you:
 
 @
 22:54:39Z (00.002) SomeoneWrongOnInternet \"Ashley thinks there are more than three Star Wars movies\"
-$
+\$
 @
 
 but if you're in a hurry and don't want to define a local exception type to

--- a/core-program/lib/Core/Program/Execute.hs
+++ b/core-program/lib/Core/Program/Execute.hs
@@ -49,98 +49,98 @@ runtime, but to specify the allowed command-line options and expected
 arguments you can initialize your program using 'configure' and then run
 with 'executeWith'.
 -}
-module Core.Program.Execute (
-    Program (),
+module Core.Program.Execute
+    ( Program ()
 
-    -- * Running programs
-    configure,
-    execute,
-    executeWith,
+      -- * Running programs
+    , configure
+    , execute
+    , executeWith
 
-    -- * Exiting a program
-    terminate,
+      -- * Exiting a program
+    , terminate
 
-    -- * Accessing program context
-    getCommandLine,
-    queryCommandName,
-    queryOptionFlag,
-    queryOptionValue,
-    queryOptionValue',
-    queryArgument,
-    queryRemaining,
-    queryEnvironmentValue,
-    getProgramName,
-    setProgramName,
-    getVerbosityLevel,
-    setVerbosityLevel,
-    getConsoleWidth,
-    getApplicationState,
-    setApplicationState,
+      -- * Accessing program context
+    , getCommandLine
+    , queryCommandName
+    , queryOptionFlag
+    , queryOptionValue
+    , queryOptionValue'
+    , queryArgument
+    , queryRemaining
+    , queryEnvironmentValue
+    , getProgramName
+    , setProgramName
+    , getVerbosityLevel
+    , setVerbosityLevel
+    , getConsoleWidth
+    , getApplicationState
+    , setApplicationState
 
-    -- * Useful actions
-    outputEntire,
-    inputEntire,
-    execProcess,
-    sleepThread,
-    resetTimer,
-    trap_,
+      -- * Useful actions
+    , outputEntire
+    , inputEntire
+    , execProcess
+    , sleepThread
+    , resetTimer
+    , trap_
 
-    -- * Exception handling
-    catch,
-    throw,
-    try,
+      -- * Exception handling
+    , catch
+    , throw
+    , try
 
-    -- * Internals
-    Context,
-    None (..),
-    isNone,
-    unProgram,
-    invalid,
-    Boom (..),
-    loopForever,
-    lookupOptionFlag,
-    lookupOptionValue,
-    lookupArgument,
-    lookupEnvironmentValue,
-) where
+      -- * Internals
+    , Context
+    , None (..)
+    , isNone
+    , unProgram
+    , invalid
+    , Boom (..)
+    , loopForever
+    , lookupOptionFlag
+    , lookupOptionValue
+    , lookupArgument
+    , lookupEnvironmentValue
+    ) where
 
-import Control.Concurrent (
-    forkFinally,
-    forkIO,
-    killThread,
-    myThreadId,
-    threadDelay,
- )
-import Control.Concurrent.MVar (
-    MVar,
-    modifyMVar_,
-    newEmptyMVar,
-    putMVar,
-    readMVar,
-    tryPutMVar,
- )
+import Control.Concurrent
+    ( forkFinally
+    , forkIO
+    , killThread
+    , myThreadId
+    , threadDelay
+    )
+import Control.Concurrent.MVar
+    ( MVar
+    , modifyMVar_
+    , newEmptyMVar
+    , putMVar
+    , readMVar
+    , tryPutMVar
+    )
 import Control.Concurrent.STM (atomically)
-import Control.Concurrent.STM.TQueue (
-    TQueue,
-    readTQueue,
-    tryReadTQueue,
-    unGetTQueue,
-    writeTQueue,
- )
-import Control.Concurrent.STM.TVar (
-    readTVarIO,
- )
+import Control.Concurrent.STM.TQueue
+    ( TQueue
+    , readTQueue
+    , tryReadTQueue
+    , unGetTQueue
+    , writeTQueue
+    )
+import Control.Concurrent.STM.TVar
+    ( readTVarIO
+    )
 import Control.Exception qualified as Base (throwIO)
-import Control.Exception.Safe qualified as Safe (
-    catch,
-    throw,
- )
-import Control.Monad (
-    forM_,
-    forever,
-    void,
-    when,
- )
+import Control.Exception.Safe qualified as Safe
+    ( catch
+    , throw
+    )
+import Control.Monad
+    ( forM_
+    , forever
+    , void
+    , when
+    )
 import Control.Monad.Reader.Class (MonadReader (ask))
 import Core.Data.Clock
 import Core.Data.Structures
@@ -150,15 +150,15 @@ import Core.Program.Context
 import Core.Program.Exceptions
 import Core.Program.Logging
 import Core.Program.Signal
-import Core.System.Base (
-    Exception,
-    Handle,
-    SomeException,
-    displayException,
-    hFlush,
-    liftIO,
-    stdout,
- )
+import Core.System.Base
+    ( Exception
+    , Handle
+    , SomeException
+    , displayException
+    , hFlush
+    , liftIO
+    , stdout
+    )
 import Core.Text.Bytes
 import Core.Text.Rope
 import Data.ByteString qualified as B (hPut)
@@ -166,9 +166,9 @@ import Data.ByteString.Char8 qualified as C (singleton)
 import Data.List qualified as List (intersperse)
 import GHC.Conc (getNumProcessors, numCapabilities, setNumCapabilities)
 import GHC.IO.Encoding (setLocaleEncoding, utf8)
-import System.Directory (
-    findExecutable,
- )
+import System.Directory
+    ( findExecutable
+    )
 import System.Exit (ExitCode (..))
 import System.Process.Typed (nullStream, proc, readProcess, setStdin)
 import Prelude hiding (log)
@@ -203,7 +203,7 @@ trap_ action =
         (void action)
         ( \(e :: SomeException) ->
             let text = intoRope (displayException e)
-             in do
+            in  do
                     warn "Trapped uncaught exception"
                     debug "e" text
         )
@@ -637,7 +637,7 @@ execProcess (cmd : args) =
         task = proc cmd' args'
         task1 = setStdin nullStream task
         command = mconcat (List.intersperse (singletonRope ' ') (cmd : args))
-     in do
+    in  do
             debug "command" command
 
             probe <- liftIO $ do
@@ -698,7 +698,7 @@ example, to delay a second and a half, do:
 sleepThread :: Rational -> Program τ ()
 sleepThread seconds =
     let us = floor (toRational (seconds * 1e6))
-     in liftIO $ threadDelay us
+    in  liftIO $ threadDelay us
 
 {- |
 Retrieve the values of parameters parsed from options and arguments supplied

--- a/core-program/lib/Core/Program/Logging.hs
+++ b/core-program/lib/Core/Program/Logging.hs
@@ -121,32 +121,32 @@ to the program using /kill/:
 \$
 @
 -}
-module Core.Program.Logging (
-    putMessage,
-    formatLogMessage,
-    Severity (..),
-    Verbosity (..),
+module Core.Program.Logging
+    ( putMessage
+    , formatLogMessage
+    , Severity (..)
+    , Verbosity (..)
 
-    -- * Normal output
-    write,
-    writeS,
-    writeR,
+      -- * Normal output
+    , write
+    , writeS
+    , writeR
 
-    -- * Informational
-    info,
-    warn,
-    critical,
+      -- * Informational
+    , info
+    , warn
+    , critical
 
-    -- * Debugging
-    debug,
-    debugS,
-    debugR,
+      -- * Debugging
+    , debug
+    , debugS
+    , debugR
     -- internal
-    internal,
-    isEvent,
-    isDebug,
-    isInternal,
-) where
+    , internal
+    , isEvent
+    , isDebug
+    , isInternal
+    ) where
 
 import Control.Concurrent.MVar (readMVar)
 import Control.Concurrent.STM (atomically)
@@ -221,7 +221,7 @@ formatLogMessage start now coloured severity message =
             SeverityInternal -> intoEscapes dullBlue
 
         !reset = intoEscapes resetColour
-     in case coloured of
+    in  case coloured of
             True ->
                 mconcat
                     [ intoEscapes dullWhite

--- a/core-program/lib/Core/Program/Metadata.hs
+++ b/core-program/lib/Core/Program/Metadata.hs
@@ -8,18 +8,18 @@
 Digging metadata out of the description of your project, and other useful
 helpers.
 -}
-module Core.Program.Metadata (
-    Version,
-    versionNumberFrom,
-    projectNameFrom,
-    projectSynopsisFrom,
+module Core.Program.Metadata
+    ( Version
+    , versionNumberFrom
+    , projectNameFrom
+    , projectSynopsisFrom
 
-    -- * Splice
-    fromPackage,
+      -- * Splice
+    , fromPackage
 
-    -- * Source code
-    __LOCATION__,
-) where
+      -- * Source code
+    , __LOCATION__
+    ) where
 
 import Core.Data
 import Core.System.Base (IOMode (..), withFile)
@@ -66,7 +66,7 @@ emptyVersion :: Version
 emptyVersion = Version "" "" "0"
 
 instance IsString Version where
-    fromString x = emptyVersion{versionNumberFrom = x}
+    fromString x = emptyVersion {versionNumberFrom = x}
 
 {- |
 This is a splice which includes key built-time metadata, including the number
@@ -154,7 +154,7 @@ readCabalFile = runIO $ do
 parseCabalFile :: Bytes -> Map Rope Rope
 parseCabalFile contents =
     let breakup = intoMap . fmap (\(a, b) -> (a, trimValue b)) . fmap (breakRope (== ':')) . breakLines . fromBytes
-     in breakup contents
+    in  breakup contents
 
 -- knock off the colon and whitespace in ":      hello"
 trimValue :: Rope -> Rope

--- a/core-program/lib/Core/Program/Signal.hs
+++ b/core-program/lib/Core/Program/Signal.hs
@@ -1,21 +1,21 @@
 {-# OPTIONS_GHC -fno-warn-unused-do-bind #-}
 
-module Core.Program.Signal (
-    setupSignalHandlers,
-) where
+module Core.Program.Signal
+    ( setupSignalHandlers
+    ) where
 
 import Control.Concurrent.MVar (MVar, modifyMVar_, putMVar)
 import Core.Program.Context
 import Foreign.C.Types (CInt)
 import System.Exit (ExitCode (..))
 import System.IO (hFlush, hPutStrLn, stdout)
-import System.Posix.Signals (
-    Handler (Catch),
-    installHandler,
-    sigINT,
-    sigTERM,
-    sigUSR1,
- )
+import System.Posix.Signals
+    ( Handler (Catch)
+    , installHandler
+    , sigINT
+    , sigTERM
+    , sigUSR1
+    )
 
 {- |
 Make a non-zero exit code which is 0b1000000 + the number of the signal.

--- a/core-program/lib/Core/Program/Threads.hs
+++ b/core-program/lib/Core/Program/Threads.hs
@@ -23,39 +23,39 @@ them easily from the 'Program' monad.
 Note that when you fire off a new thread the top-level application state is
 /shared/; it's the same @τ@ inherited from the parent 'Program'.
 -}
-module Core.Program.Threads (
-    -- * Concurrency
-    createScope,
-    forkThread,
-    forkThread_,
-    linkThread,
-    waitThread,
-    waitThread_,
-    waitThread',
-    waitThreads',
-    cancelThread,
+module Core.Program.Threads
+    ( -- * Concurrency
+      createScope
+    , forkThread
+    , forkThread_
+    , linkThread
+    , waitThread
+    , waitThread_
+    , waitThread'
+    , waitThreads'
+    , cancelThread
 
-    -- * Helper functions
-    concurrentThreads,
-    concurrentThreads_,
-    raceThreads,
-    raceThreads_,
+      -- * Helper functions
+    , concurrentThreads
+    , concurrentThreads_
+    , raceThreads
+    , raceThreads_
 
-    -- * Internals
-    Thread,
-    unThread,
-) where
+      -- * Internals
+    , Thread
+    , unThread
+    ) where
 
 import Control.Concurrent (ThreadId, forkIO, killThread)
 import Control.Concurrent.MVar (MVar, newEmptyMVar, newMVar, putMVar, readMVar)
 import Control.Concurrent.STM (atomically)
 import Control.Concurrent.STM.TVar (modifyTVar', newTVarIO, readTVarIO)
 import Control.Exception.Safe qualified as Safe (catch, finally, onException, throw)
-import Control.Monad (
-    forM,
-    forM_,
-    void,
- )
+import Control.Monad
+    ( forM
+    , forM_
+    , void
+    )
 import Control.Monad.Reader.Class (MonadReader (ask))
 import Core.Data.Structures
 import Core.Program.Context

--- a/core-program/lib/Core/Program/Unlift.hs
+++ b/core-program/lib/Core/Program/Unlift.hs
@@ -93,14 +93,14 @@ probably at the top where you have the lambda. This can be confusing. If
 you're having trouble with the types try putting @return ()@ at the end of
 your subprogram.
 -}
-module Core.Program.Unlift (
-    -- * Unlifting
-    withContext,
+module Core.Program.Unlift
+    ( -- * Unlifting
+      withContext
 
-    -- * Internals
-    getContext,
-    subProgram,
-) where
+      -- * Internals
+    , getContext
+    , subProgram
+    ) where
 
 import Core.Program.Context
 import Core.Program.Execute
@@ -151,9 +151,9 @@ following pattern:
 -- the signature is similar. I'm not sure if there is any benefit to
 -- restating this as a `withRunInIO` action; we're deliberately trying to
 -- constrain the types.
-withContext ::
-    ((forall β. Program τ β -> IO β) -> IO α) ->
-    Program τ α
+withContext
+    :: ((forall β. Program τ β -> IO β) -> IO α)
+    -> Program τ α
 withContext action = do
     context <- getContext
     let runThing = subProgram context

--- a/core-program/lib/Core/System.hs
+++ b/core-program/lib/Core/System.hs
@@ -17,32 +17,32 @@ import "Core.System"
 
 as there's no particular benefit to cherry-picking the various sub-modules.
 -}
-module Core.System (
-    -- * Base libraries
+module Core.System
+    ( -- * Base libraries
 
-    -- |
-    -- Re-exports from foundational libraries supplied by the compiler runtime,
-    -- or from re-implementations of those areas.
-    module Core.System.Base,
+      -- |
+      -- Re-exports from foundational libraries supplied by the compiler runtime,
+      -- or from re-implementations of those areas.
+        module Core.System.Base
 
-    -- * External dependencies
+      -- * External dependencies
 
-    -- |
-    -- Dependencies from libraries outside the traditional ecosystem of Haskell.
-    -- These are typically special cases or custom re-implementations of things
-    -- which are maintained either by ourselves or people we are in regular
-    -- contact with.
-    module Core.System.External,
+      -- |
+      -- Dependencies from libraries outside the traditional ecosystem of Haskell.
+      -- These are typically special cases or custom re-implementations of things
+      -- which are maintained either by ourselves or people we are in regular
+      -- contact with.
+    , module Core.System.External
 
-    -- * Pretty Printing
+      -- * Pretty Printing
 
-    -- |
-    -- When using the Render typeclass from "Core.Text.Utilities" you are
-    -- presented with the @Doc a@ type for accumulating a \"document\" to be
-    -- pretty printed. There are a large family of combinators used when doing
-    -- this. For convenience they are exposed here.
-    module Core.System.Pretty,
-) where
+      -- |
+      -- When using the Render typeclass from "Core.Text.Utilities" you are
+      -- presented with the @Doc a@ type for accumulating a \"document\" to be
+      -- pretty printed. There are a large family of combinators used when doing
+      -- this. For convenience they are exposed here.
+    , module Core.System.Pretty
+    ) where
 
 import Core.System.Base
 import Core.System.External

--- a/core-program/lib/Core/System/Base.hs
+++ b/core-program/lib/Core/System/Base.hs
@@ -5,37 +5,36 @@
 {- |
 Re-exports of Haskell base and GHC system libraries.
 -}
-module Core.System.Base (
-    -- * Input/Output
+module Core.System.Base
+    ( -- * Input/Output
 
-    -- ** from Control.Monad.IO.Class
+      -- ** from Control.Monad.IO.Class
 
-    -- | Re-exported from "Control.Monad.IO.Class" in __base__:
-    liftIO,
-    MonadIO,
+      -- | Re-exported from "Control.Monad.IO.Class" in __base__:
+      liftIO
+    , MonadIO
 
-    -- ** from System.IO
+      -- ** from System.IO
 
-    -- | Re-exported from "System.IO" in __base__:
-    Handle,
-    IOMode (..),
-    withFile,
-    stdin,
-    stdout,
-    stderr,
-    hFlush,
-    unsafePerformIO,
+      -- | Re-exported from "System.IO" in __base__:
+    , Handle
+    , IOMode (..)
+    , withFile
+    , stdin
+    , stdout
+    , stderr
+    , hFlush
+    , unsafePerformIO
 
-    -- * Exception handling
+      -- * Exception handling
+    , Exception (..)
+    , SomeException
+    ) where
 
-    Exception (..),
-    SomeException,
-) where
-
-import Control.Exception (
-    Exception (..),
-    SomeException,
- )
+import Control.Exception
+    ( Exception (..)
+    , SomeException
+    )
 import Control.Monad.IO.Class (MonadIO, liftIO)
 import System.IO (Handle, IOMode (..), hFlush, stderr, stdin, stdout, withFile)
 import System.IO.Unsafe (unsafePerformIO)

--- a/core-program/lib/Core/System/External.hs
+++ b/core-program/lib/Core/System/External.hs
@@ -3,5 +3,6 @@
 {- |
 Re-exports of dependencies from various external libraries.
 -}
-module Core.System.External (
+module Core.System.External
+    (
     ) where

--- a/core-program/lib/Core/System/Pretty.hs
+++ b/core-program/lib/Core/System/Pretty.hs
@@ -1,47 +1,47 @@
 {-# OPTIONS_HADDOCK not-home #-}
 
 -- | Re-exports of combinators for use when building 'Core.Text.Utilities.Render' instances.
-module Core.System.Pretty (
-    -- * Pretty Printing
+module Core.System.Pretty
+    ( -- * Pretty Printing
 
-    -- ** from Data.Text.Prettyprint.Doc
+      -- ** from Data.Text.Prettyprint.Doc
 
-    -- | Re-exported from "Data.Text.Prettyprint.Doc" in __prettyprinter__ and "Data.Text.Prettyprint.Doc.Render.Terminal" in __prettyprinter-ansi-terminal__:
-    Doc,
-    Pretty (pretty),
-    dquote,
-    squote,
-    comma,
-    punctuate,
-    enclose,
-    lbracket,
-    rbracket,
-    (<+>),
-    lbrace,
-    rbrace,
-    lparen,
-    rparen,
-    emptyDoc,
-    sep,
-    hsep,
-    vsep,
-    fillCat,
-    fillSep,
-    flatAlt,
-    hcat,
-    vcat,
-    annotate,
-    unAnnotate,
-    line,
-    line',
-    softline,
-    softline',
-    hardline,
-    group,
-    hang,
-    indent,
-    nest,
-    concatWith,
-) where
+      -- | Re-exported from "Data.Text.Prettyprint.Doc" in __prettyprinter__ and "Data.Text.Prettyprint.Doc.Render.Terminal" in __prettyprinter-ansi-terminal__:
+      Doc
+    , Pretty (pretty)
+    , dquote
+    , squote
+    , comma
+    , punctuate
+    , enclose
+    , lbracket
+    , rbracket
+    , (<+>)
+    , lbrace
+    , rbrace
+    , lparen
+    , rparen
+    , emptyDoc
+    , sep
+    , hsep
+    , vsep
+    , fillCat
+    , fillSep
+    , flatAlt
+    , hcat
+    , vcat
+    , annotate
+    , unAnnotate
+    , line
+    , line'
+    , softline
+    , softline'
+    , hardline
+    , group
+    , hang
+    , indent
+    , nest
+    , concatWith
+    ) where
 
 import Prettyprinter

--- a/core-telemetry/lib/Core/Telemetry.hs
+++ b/core-telemetry/lib/Core/Telemetry.hs
@@ -14,28 +14,28 @@ import "Core.Telemetry"
 the submodules are mostly there to group documentation, along with grouping
 the implementations for each of the different supported backends.
 -}
-module Core.Telemetry (
-    -- * Traces and Spans
+module Core.Telemetry
+    ( -- * Traces and Spans
 
-    -- |
-    -- Adding observability tracing to your program.
-    module Core.Telemetry.Observability,
+      -- |
+      -- Adding observability tracing to your program.
+        module Core.Telemetry.Observability
 
-    -- * Exporting to backends
+      -- * Exporting to backends
 
-    -- |
-    -- Processors to export telemetry to a backend.
-    module Core.Telemetry.Console,
-    module Core.Telemetry.General,
-    module Core.Telemetry.Honeycomb,
-    module Core.Telemetry.Structured,
+      -- |
+      -- Processors to export telemetry to a backend.
+    , module Core.Telemetry.Console
+    , module Core.Telemetry.General
+    , module Core.Telemetry.Honeycomb
+    , module Core.Telemetry.Structured
 
-    -- * Internals
+      -- * Internals
 
-    -- |
-    -- Various helper functions.
-    module Core.Telemetry.Identifiers
-) where
+      -- |
+      -- Various helper functions.
+    , module Core.Telemetry.Identifiers
+    ) where
 
 import Core.Telemetry.Console
 import Core.Telemetry.General

--- a/core-telemetry/lib/Core/Telemetry/Console.hs
+++ b/core-telemetry/lib/Core/Telemetry/Console.hs
@@ -18,9 +18,9 @@ would be:
   precise = 45.0
 @
 -}
-module Core.Telemetry.Console (
-    consoleExporter,
-) where
+module Core.Telemetry.Console
+    ( consoleExporter
+    ) where
 
 import Control.Concurrent.STM (atomically)
 import Control.Concurrent.STM.TQueue (TQueue, writeTQueue)
@@ -74,7 +74,7 @@ processConsoleOutput out datums = do
                     <> singletonRope ':'
                     <> let pairs :: [(JsonKey, JsonValue)]
                            pairs = fromMap (attachedMetadataFrom datum)
-                        in List.foldl' f emptyRope pairs
+                       in  List.foldl' f emptyRope pairs
                             <> intoEscapes resetColour
 
         now <- getCurrentTimeNanoseconds
@@ -90,7 +90,8 @@ processConsoleOutput out datums = do
 
 f :: Rope -> (JsonKey, JsonValue) -> Rope
 f acc (k, v) =
-    acc <> "\n  "
+    acc
+        <> "\n  "
         <> intoEscapes pureGrey
         <> intoRope k
         <> " = "

--- a/core-telemetry/lib/Core/Telemetry/General.hs
+++ b/core-telemetry/lib/Core/Telemetry/General.hs
@@ -5,9 +5,9 @@ A generic exporter that may someday send metrics to an OpenTelemetry backend.
 
 /unimplemented/
 -}
-module Core.Telemetry.General (
-    generalExporter,
-) where
+module Core.Telemetry.General
+    ( generalExporter
+    ) where
 
 import Core.Program.Context
 

--- a/core-telemetry/lib/Core/Telemetry/Honeycomb.hs
+++ b/core-telemetry/lib/Core/Telemetry/Honeycomb.hs
@@ -30,10 +30,10 @@ applications. In the future you may be able to look at
 "Core.Telemetry.General" if you instead want to forward to a generic
 OpenTelemetry provider.
 -}
-module Core.Telemetry.Honeycomb (
-    Dataset,
-    honeycombExporter,
-) where
+module Core.Telemetry.Honeycomb
+    ( Dataset
+    , honeycombExporter
+    ) where
 
 import Codec.Compression.GZip qualified as GZip (compress)
 import Control.Exception.Safe qualified as Safe (catch, finally, throw)
@@ -113,7 +113,7 @@ setupHoneycombConfig config0 =
                     "The name of the dataset within your Honeycomb account that this program's telemetry will be written to."
                 )
                 config1
-     in config2
+    in  config2
 
 setupHoneycombAction :: Context τ -> IO Forwarder
 setupHoneycombAction context = do
@@ -211,7 +211,7 @@ convertDatumToJson datum =
                     , (JsonKey "data", JsonObject meta6)
                     ]
                 )
-     in point
+    in  point
 
 acquireConnection :: IORef (Maybe Connection) -> IO Connection
 acquireConnection r = do

--- a/core-telemetry/lib/Core/Telemetry/Identifiers.hs
+++ b/core-telemetry/lib/Core/Telemetry/Identifiers.hs
@@ -15,24 +15,24 @@ specification, specifically as relates to forming trace identifiers and span
 identifiers into @traceparent@ headers. The key requirements are that traces
 be globally unique and that spans be unique within a trace.
 -}
-module Core.Telemetry.Identifiers (
-    -- * Traces and Spans
-    getIdentifierTrace,
-    getIdentifierSpan,
-    setIdentifierSpan,
+module Core.Telemetry.Identifiers
+    ( -- * Traces and Spans
+      getIdentifierTrace
+    , getIdentifierSpan
+    , setIdentifierSpan
 
-    -- * Internals
-    createIdentifierTrace,
-    createIdentifierSpan,
-    hostMachineIdentity,
-    createTraceParentHeader,
-    parseTraceParentHeader,
+      -- * Internals
+    , createIdentifierTrace
+    , createIdentifierSpan
+    , hostMachineIdentity
+    , createTraceParentHeader
+    , parseTraceParentHeader
     -- for testing
-    toHexNormal64,
-    toHexReversed64,
-    toHexNormal32,
-    toHexReversed32,
-) where
+    , toHexNormal64
+    , toHexReversed64
+    , toHexNormal32
+    , toHexReversed32
+    ) where
 
 import Control.Concurrent.MVar (modifyMVar_, readMVar)
 import Core.Data.Clock
@@ -63,7 +63,7 @@ hostMachineIdentity = unsafePerformIO $ do
     go [] = bogusAddress
     go (interface : remainder) =
         let address = mac interface
-         in if address /= loopbackAddress
+        in  if address /= loopbackAddress
                 then address
                 else go remainder
 
@@ -88,68 +88,68 @@ createIdentifierTrace time rand address =
     let p1 = packRope (toHexReversed64 (fromIntegral (unTime time)))
         p2 = packRope (toHexNormal16 rand)
         p3 = packRope (convertMACToHex address)
-     in Trace
+    in  Trace
             (p1 <> p2 <> p3)
 
 convertMACToHex :: MAC -> [Char]
 convertMACToHex (MAC b1 b2 b3 b4 b5 b6) =
-    nibbleToHex b1 4 :
-    nibbleToHex b1 0 :
-    nibbleToHex b2 4 :
-    nibbleToHex b2 0 :
-    nibbleToHex b3 4 :
-    nibbleToHex b3 0 :
-    nibbleToHex b4 4 :
-    nibbleToHex b4 0 :
-    nibbleToHex b5 4 :
-    nibbleToHex b5 0 :
-    nibbleToHex b6 4 :
-    nibbleToHex b6 0 :
-    []
+    nibbleToHex b1 4
+        : nibbleToHex b1 0
+        : nibbleToHex b2 4
+        : nibbleToHex b2 0
+        : nibbleToHex b3 4
+        : nibbleToHex b3 0
+        : nibbleToHex b4 4
+        : nibbleToHex b4 0
+        : nibbleToHex b5 4
+        : nibbleToHex b5 0
+        : nibbleToHex b6 4
+        : nibbleToHex b6 0
+        : []
   where
     nibbleToHex w = unsafeToDigit . fromIntegral . (.&.) 0x0f . shiftR w
 
 toHexReversed64 :: Word64 -> [Char]
 toHexReversed64 w =
-    nibbleToHex 00 :
-    nibbleToHex 04 :
-    nibbleToHex 08 :
-    nibbleToHex 12 :
-    nibbleToHex 16 :
-    nibbleToHex 20 :
-    nibbleToHex 24 :
-    nibbleToHex 28 : -- Word32
-    nibbleToHex 32 :
-    nibbleToHex 36 :
-    nibbleToHex 40 :
-    nibbleToHex 44 :
-    nibbleToHex 48 :
-    nibbleToHex 52 :
-    nibbleToHex 56 :
-    nibbleToHex 60 :
-    []
+    nibbleToHex 00
+        : nibbleToHex 04
+        : nibbleToHex 08
+        : nibbleToHex 12
+        : nibbleToHex 16
+        : nibbleToHex 20
+        : nibbleToHex 24
+        : nibbleToHex 28
+        : nibbleToHex 32 -- Word32
+        : nibbleToHex 36
+        : nibbleToHex 40
+        : nibbleToHex 44
+        : nibbleToHex 48
+        : nibbleToHex 52
+        : nibbleToHex 56
+        : nibbleToHex 60
+        : []
   where
     nibbleToHex = unsafeToDigit . fromIntegral . (.&.) 0x0f . shiftR w
 
 toHexNormal64 :: Word64 -> [Char]
 toHexNormal64 w =
-    nibbleToHex 60 :
-    nibbleToHex 56 :
-    nibbleToHex 52 :
-    nibbleToHex 48 :
-    nibbleToHex 44 :
-    nibbleToHex 40 :
-    nibbleToHex 36 :
-    nibbleToHex 32 :
-    nibbleToHex 28 : -- Word32
-    nibbleToHex 24 :
-    nibbleToHex 20 :
-    nibbleToHex 16 :
-    nibbleToHex 12 :
-    nibbleToHex 08 :
-    nibbleToHex 04 :
-    nibbleToHex 00 :
-    []
+    nibbleToHex 60
+        : nibbleToHex 56
+        : nibbleToHex 52
+        : nibbleToHex 48
+        : nibbleToHex 44
+        : nibbleToHex 40
+        : nibbleToHex 36
+        : nibbleToHex 32
+        : nibbleToHex 28
+        : nibbleToHex 24 -- Word32
+        : nibbleToHex 20
+        : nibbleToHex 16
+        : nibbleToHex 12
+        : nibbleToHex 08
+        : nibbleToHex 04
+        : nibbleToHex 00
+        : []
   where
     nibbleToHex = unsafeToDigit . fromIntegral . (.&.) 0x0f . shiftR w
 
@@ -159,39 +159,39 @@ toHexNormal64 w =
 --
 toHexReversed32 :: Word32 -> [Char]
 toHexReversed32 w =
-    nibbleToHex 00 :
-    nibbleToHex 04 :
-    nibbleToHex 08 :
-    nibbleToHex 12 :
-    nibbleToHex 16 :
-    nibbleToHex 20 :
-    nibbleToHex 24 :
-    nibbleToHex 28 :
-    []
+    nibbleToHex 00
+        : nibbleToHex 04
+        : nibbleToHex 08
+        : nibbleToHex 12
+        : nibbleToHex 16
+        : nibbleToHex 20
+        : nibbleToHex 24
+        : nibbleToHex 28
+        : []
   where
     nibbleToHex = unsafeToDigit . fromIntegral . (.&.) 0x0f . shiftR w
 
 toHexNormal32 :: Word32 -> [Char]
 toHexNormal32 w =
-    nibbleToHex 28 :
-    nibbleToHex 24 :
-    nibbleToHex 20 :
-    nibbleToHex 16 :
-    nibbleToHex 12 :
-    nibbleToHex 08 :
-    nibbleToHex 04 :
-    nibbleToHex 00 :
-    []
+    nibbleToHex 28
+        : nibbleToHex 24
+        : nibbleToHex 20
+        : nibbleToHex 16
+        : nibbleToHex 12
+        : nibbleToHex 08
+        : nibbleToHex 04
+        : nibbleToHex 00
+        : []
   where
     nibbleToHex = unsafeToDigit . fromIntegral . (.&.) 0x0f . shiftR w
 
 toHexNormal16 :: Word16 -> [Char]
 toHexNormal16 w =
-    nibbleToHex 12 :
-    nibbleToHex 08 :
-    nibbleToHex 04 :
-    nibbleToHex 00 :
-    []
+    nibbleToHex 12
+        : nibbleToHex 08
+        : nibbleToHex 04
+        : nibbleToHex 00
+        : []
   where
     nibbleToHex = unsafeToDigit . fromIntegral . (.&.) 0x0f . shiftR w
 
@@ -222,7 +222,7 @@ createIdentifierSpan time rand =
     let t = fromIntegral (unTime time) :: Word64
         r = fromIntegral rand :: Word64
         w = (t .&. 0x0000ffffffffffff) .|. (shiftL r 48)
-     in Span
+    in  Span
             ( packRope
                 ( toHexReversed64 w
                 )
@@ -244,7 +244,7 @@ createTraceParentHeader :: Trace -> Span -> Rope
 createTraceParentHeader trace unique =
     let version = "00"
         flags = "00"
-     in version <> "-" <> unTrace trace <> "-" <> unSpan unique <> "-" <> flags
+    in  version <> "-" <> unTrace trace <> "-" <> unSpan unique <> "-" <> flags
 
 {- |
 Parse a @traceparent@ header into a 'Trace' and 'Span', assuming it was a
@@ -258,7 +258,7 @@ spans to an existing trace started by another program or service.
 parseTraceParentHeader :: Rope -> Maybe (Trace, Span)
 parseTraceParentHeader header =
     let pieces = breakPieces (== '-') header
-     in case pieces of
+    in  case pieces of
             ("00" : trace : unique : _ : []) -> Just (Trace trace, Span unique)
             _ -> Nothing
 
@@ -317,4 +317,4 @@ setIdentifierSpan unique = do
         let v = currentDatumFrom context
         modifyMVar_
             v
-            (\datum -> pure datum{spanIdentifierFrom = Just unique})
+            (\datum -> pure datum {spanIdentifierFrom = Just unique})

--- a/core-telemetry/lib/Core/Telemetry/Observability.hs
+++ b/core-telemetry/lib/Core/Telemetry/Observability.hs
@@ -135,35 +135,35 @@ Either way, explicitly sending an event, or upon exiting a span, the telemetry
 will be gathered up and sent via the chosen exporter and forwarded to the
 observability or monitoring service you have chosen.
 -}
-module Core.Telemetry.Observability (
-    -- * Initializing
-    Exporter,
-    initializeTelemetry,
+module Core.Telemetry.Observability
+    ( -- * Initializing
+      Exporter
+    , initializeTelemetry
 
-    -- * Traces
-    Trace (..),
-    Span (..),
-    beginTrace,
-    usingTrace,
-    usingTrace',
-    setServiceName,
+      -- * Traces
+    , Trace (..)
+    , Span (..)
+    , beginTrace
+    , usingTrace
+    , usingTrace'
+    , setServiceName
 
-    -- * Spans
-    Label,
-    encloseSpan,
-    setStartTime,
-    setSpanName,
+      -- * Spans
+    , Label
+    , encloseSpan
+    , setStartTime
+    , setSpanName
 
-    -- * Creating telemetry
-    MetricValue,
-    Telemetry (metric),
-    telemetry,
+      -- * Creating telemetry
+    , MetricValue
+    , Telemetry (metric)
+    , telemetry
 
-    -- * Events
-    sendEvent,
-    clearMetrics,
-    clearTrace,
-) where
+      -- * Events
+    , sendEvent
+    , clearMetrics
+    , clearTrace
+    ) where
 
 import Control.Concurrent.MVar (modifyMVar_, newMVar, readMVar)
 import Control.Concurrent.STM (atomically)
@@ -396,7 +396,7 @@ initializeTelemetry exporters1 context =
                 config0
 
         config2 = List.foldl' f config1 exporters2
-     in pure
+    in  pure
             ( context
                 { initialConfigFrom = config2
                 , initialExportersFrom = exporters2
@@ -410,7 +410,7 @@ initializeTelemetry exporters1 context =
     f :: Config -> Exporter -> Config
     f config exporter =
         let setup = setupConfigFrom exporter
-         in setup config
+        in  setup config
 
 type Label = Rope
 
@@ -757,7 +757,7 @@ setStartTime time = do
         let v = currentDatumFrom context
         modifyMVar_
             v
-            (\datum -> pure datum{spanTimeFrom = time})
+            (\datum -> pure datum {spanTimeFrom = time})
 
 {- |
 Override the name of the current span.
@@ -779,7 +779,7 @@ setSpanName label = do
         let v = currentDatumFrom context
         modifyMVar_
             v
-            (\datum -> pure datum{spanNameFrom = label})
+            (\datum -> pure datum {spanNameFrom = label})
 
 {- |
 Reset the accumulated metadata metrics to the emtpy set.

--- a/core-telemetry/lib/Core/Telemetry/Structured.hs
+++ b/core-telemetry/lib/Core/Telemetry/Structured.hs
@@ -68,9 +68,9 @@ relevant contextual information will be added to the output:
 }
 @
 -}
-module Core.Telemetry.Structured (
-    structuredExporter,
-) where
+module Core.Telemetry.Structured
+    ( structuredExporter
+    ) where
 
 import Control.Concurrent.STM (atomically)
 import Control.Concurrent.STM.TQueue (TQueue, writeTQueue)
@@ -139,7 +139,7 @@ convertDatumToJson datum =
 
         time = intoRope (show (spanTimeFrom datum))
         meta7 = insertKeyValue "timestamp" (JsonString time) meta6
-     in JsonObject meta7
+    in  JsonObject meta7
 
 processStructuredOutput :: TQueue (Maybe Rope) -> [Datum] -> IO ()
 processStructuredOutput out datums = do

--- a/core-text/lib/Core/Text.hs
+++ b/core-text/lib/Core/Text.hs
@@ -1,33 +1,34 @@
 {-# OPTIONS_HADDOCK not-home #-}
 
--- |
--- A unified Text type providing interoperability between various text
--- back-ends present in the Haskell ecosystem.
---
--- This is intended to be used directly:
---
--- @
--- import "Core.Text"
--- @
---
--- as this module re-exports all of the various components making up this
--- library's text handling subsystem.
+{- |
+A unified Text type providing interoperability between various text
+back-ends present in the Haskell ecosystem.
+
+This is intended to be used directly:
+
+@
+import "Core.Text"
+@
+
+as this module re-exports all of the various components making up this
+library's text handling subsystem.
+-}
 module Core.Text
-  ( -- * Internal representation
+    ( -- * Internal representation
 
-    -- |
-    -- Exposes 'Bytes', a wrapper around different types of binary data, and 'Rope',
-    -- a finger-tree over buffers containing text.
-    module Core.Text.Bytes,
-    module Core.Text.Rope,
+      -- |
+      -- Exposes 'Bytes', a wrapper around different types of binary data, and 'Rope',
+      -- a finger-tree over buffers containing text.
+        module Core.Text.Bytes
+    , module Core.Text.Rope
 
-    -- * Useful utilities
+      -- * Useful utilities
 
-    -- |
-    -- Useful functions for common use cases.
-    module Core.Text.Colour,
-    module Core.Text.Utilities,
-  )
+      -- |
+      -- Useful functions for common use cases.
+    , module Core.Text.Colour
+    , module Core.Text.Utilities
+    )
 where
 
 import Core.Text.Bytes

--- a/core-text/lib/Core/Text/Breaking.hs
+++ b/core-text/lib/Core/Text/Breaking.hs
@@ -2,15 +2,15 @@
 {-# OPTIONS_HADDOCK hide #-}
 
 -- This is an Internal module, hidden from Haddock
-module Core.Text.Breaking (
-    breakRope,
-    breakWords,
-    breakLines,
-    breakPieces,
-    intoPieces,
-    intoChunks,
-    isNewline,
-) where
+module Core.Text.Breaking
+    ( breakRope
+    , breakWords
+    , breakLines
+    , breakPieces
+    , intoPieces
+    , intoChunks
+    , isNewline
+    ) where
 
 import Core.Text.Rope
 import Data.Char (isSpace)
@@ -53,7 +53,7 @@ breakLines text =
     let result = breakPieces isNewline text
         n = length result - 1
         (fore, aft) = splitAt n result
-     in case result of
+    in  case result of
             [] -> []
             [p] -> [p]
             _ ->
@@ -78,7 +78,7 @@ breakPieces :: (Char -> Bool) -> Rope -> [Rope]
 breakPieces predicate text =
     let x = unRope text
         (final, result) = foldr (intoPieces predicate) (Nothing, []) x
-     in case final of
+    in  case final of
             Nothing -> result
             Just piece -> intoRope piece : result
 
@@ -94,7 +94,7 @@ intoPieces predicate piece (stream, list) =
             Nothing -> piece
             Just previous -> piece <> previous -- more rope, less text?
         pieces = intoChunks predicate piece'
-     in case uncons pieces of
+    in  case uncons pieces of
             Nothing -> (Nothing, list)
             Just (text, remainder) -> (Just (fromRope text), remainder ++ list)
 
@@ -140,7 +140,7 @@ intoChunks predicate piece =
                 if S.null remaining
                     then (predicate c, S.empty)
                     else (False, remaining)
-     in if trailing
+    in  if trailing
             then intoRope chunk : emptyRope : []
             else intoRope chunk : intoChunks predicate remainder'
 
@@ -161,6 +161,6 @@ site where that predicate returns 'True'.
 breakRope :: (Char -> Bool) -> Rope -> (Rope, Rope)
 breakRope predicate text =
     let possibleIndex = findIndexRope predicate text
-     in case possibleIndex of
+    in  case possibleIndex of
             Nothing -> (text, emptyRope)
             Just i -> splitRope i text

--- a/core-text/lib/Core/Text/Bytes.hs
+++ b/core-text/lib/Core/Text/Bytes.hs
@@ -23,30 +23,30 @@ This module presents a simple wrapper around various representations of binary
 data to make it easier to interoperate with libraries supplying or consuming
 bytes.
 -}
-module Core.Text.Bytes (
-    Bytes,
-    emptyBytes,
-    packBytes,
-    Binary (fromBytes, intoBytes),
-    hOutput,
-    hInput,
+module Core.Text.Bytes
+    ( Bytes
+    , emptyBytes
+    , packBytes
+    , Binary (fromBytes, intoBytes)
+    , hOutput
+    , hInput
 
-    -- * Internals
-    unBytes,
-) where
+      -- * Internals
+    , unBytes
+    ) where
 
-import qualified Data.ByteString as B (
-    ByteString,
-    empty,
-    hGetContents,
-    hPut,
-    pack,
-    unpack,
- )
+import qualified Data.ByteString as B
+    ( ByteString
+    , empty
+    , hGetContents
+    , hPut
+    , pack
+    , unpack
+    )
 import qualified Data.ByteString.Builder as B (Builder, byteString, toLazyByteString)
-import qualified Data.ByteString.Char8 as C (
-    pack
- )
+import qualified Data.ByteString.Char8 as C
+    ( pack
+    )
 import qualified Data.ByteString.Lazy as L (ByteString, fromStrict, toStrict)
 import Data.Hashable (Hashable)
 import Data.Word (Word8)

--- a/core-text/lib/Core/Text/Colour.hs
+++ b/core-text/lib/Core/Text/Colour.hs
@@ -7,37 +7,37 @@ Support for colour in the terminal.
 
 ![ANSI colours](AnsiColours.png)
 -}
-module Core.Text.Colour (
-    AnsiColour,
-    intoEscapes,
-    boldColour,
-    dullRed,
-    brightRed,
-    pureRed,
-    dullGreen,
-    brightGreen,
-    pureGreen,
-    dullBlue,
-    brightBlue,
-    pureBlue,
-    dullCyan,
-    brightCyan,
-    pureCyan,
-    dullMagenta,
-    brightMagenta,
-    pureMagenta,
-    dullYellow,
-    brightYellow,
-    pureYellow,
-    pureBlack,
-    dullGrey,
-    brightGrey,
-    pureGrey,
-    pureWhite,
-    dullWhite,
-    brightWhite,
-    resetColour,
-) where
+module Core.Text.Colour
+    ( AnsiColour
+    , intoEscapes
+    , boldColour
+    , dullRed
+    , brightRed
+    , pureRed
+    , dullGreen
+    , brightGreen
+    , pureGreen
+    , dullBlue
+    , brightBlue
+    , pureBlue
+    , dullCyan
+    , brightCyan
+    , pureCyan
+    , dullMagenta
+    , brightMagenta
+    , pureMagenta
+    , dullYellow
+    , brightYellow
+    , pureYellow
+    , pureBlack
+    , dullGrey
+    , brightGrey
+    , pureGrey
+    , pureWhite
+    , dullWhite
+    , brightWhite
+    , resetColour
+    ) where
 
 import Core.Text.Rope
 import Data.Colour.SRGB (sRGB, sRGB24read)
@@ -50,7 +50,7 @@ to console.
 -}
 newtype AnsiColour = Escapes [SGR]
 
-{-|
+{- |
 Convert an AnsiColour into the ANSI escape sequences which will make that
 colour appear in the user's terminal.
 -}

--- a/core-text/lib/Core/Text/Parsing.hs
+++ b/core-text/lib/Core/Text/Parsing.hs
@@ -4,8 +4,8 @@
 
 -- This is an Internal module, hidden from Haddock
 module Core.Text.Parsing
-  ( calculatePositionEnd,
-  )
+    ( calculatePositionEnd
+    )
 where
 
 import Core.Text.Rope
@@ -18,20 +18,21 @@ is a block of text in a file). By the convention observed by all leading
 brands of text editor, lines and columns are @1@ origin, so an empty Rope is
 position @(1,1)@.
 -}
+
 -- Of course, if Rope itself cached position information in the FingerTree
 -- monoid this would be trivial.
 calculatePositionEnd :: Rope -> (Int, Int)
 calculatePositionEnd text =
-  let x = unRope text
-      (l, c) = foldl' calculateChunk (1, 1) x
-   in (l, c)
+    let x = unRope text
+        (l, c) = foldl' calculateChunk (1, 1) x
+    in  (l, c)
 
 calculateChunk :: (Int, Int) -> S.ShortText -> (Int, Int)
 calculateChunk loc piece =
-  S.foldl' f loc piece
+    S.foldl' f loc piece
   where
     f :: (Int, Int) -> Char -> (Int, Int)
     f !(!l, !c) ch =
-      if ch == '\n'
-        then (l + 1, 1)
-        else (l, c + 1)
+        if ch == '\n'
+            then (l + 1, 1)
+            else (l, c + 1)

--- a/core-text/lib/Core/Text/Rope.hs
+++ b/core-text/lib/Core/Text/Rope.hs
@@ -73,94 +73,94 @@ customary convenience functions you would find in the other libraries; so far
 of) small pieces, and then efficiently taking the resultant text object out to
 a file handle, be that the terminal console, a file, or a network socket.
 -}
-module Core.Text.Rope (
-    -- * Rope type
-    Rope,
-    emptyRope,
-    singletonRope,
-    packRope,
-    replicateRope,
-    replicateChar,
-    widthRope,
-    unconsRope,
-    splitRope,
-    takeRope,
-    insertRope,
-    containsCharacter,
-    findIndexRope,
+module Core.Text.Rope
+    ( -- * Rope type
+      Rope
+    , emptyRope
+    , singletonRope
+    , packRope
+    , replicateRope
+    , replicateChar
+    , widthRope
+    , unconsRope
+    , splitRope
+    , takeRope
+    , insertRope
+    , containsCharacter
+    , findIndexRope
 
-    -- * Interoperation and Output
-    Textual (fromRope, intoRope, appendRope),
-    hWrite,
+      -- * Interoperation and Output
+    , Textual (fromRope, intoRope, appendRope)
+    , hWrite
 
-    -- * Internals
-    unRope,
-    nullRope,
-    unsafeIntoRope,
-    copyRope,
-    Width (..),
-) where
+      -- * Internals
+    , unRope
+    , nullRope
+    , unsafeIntoRope
+    , copyRope
+    , Width (..)
+    ) where
 
 import Control.DeepSeq (NFData (..))
 import Core.Text.Bytes
 import Data.ByteString qualified as B (ByteString)
-import Data.ByteString.Builder qualified as B (
-    Builder,
-    hPutBuilder,
-    toLazyByteString,
- )
-import Data.ByteString.Lazy qualified as L (
-    ByteString,
-    foldrChunks,
-    toStrict,
- )
-import Data.FingerTree qualified as F (
-    FingerTree,
-    Measured (..),
-    SearchResult (..),
-    ViewL (..),
-    empty,
-    null,
-    search,
-    singleton,
-    viewl,
-    (<|),
-    (><),
-    (|>),
- )
+import Data.ByteString.Builder qualified as B
+    ( Builder
+    , hPutBuilder
+    , toLazyByteString
+    )
+import Data.ByteString.Lazy qualified as L
+    ( ByteString
+    , foldrChunks
+    , toStrict
+    )
+import Data.FingerTree qualified as F
+    ( FingerTree
+    , Measured (..)
+    , SearchResult (..)
+    , ViewL (..)
+    , empty
+    , null
+    , search
+    , singleton
+    , viewl
+    , (<|)
+    , (><)
+    , (|>)
+    )
 import Data.Foldable (foldl', toList)
 import Data.Hashable (Hashable, hashWithSalt)
 import Data.String (IsString (..))
 import Data.Text qualified as T (Text)
-import Data.Text.Lazy qualified as U (
-    Text,
-    foldrChunks,
-    fromChunks,
-    toStrict,
- )
-import Data.Text.Lazy.Builder qualified as U (
-    Builder,
-    fromText,
-    toLazyText,
- )
-import Data.Text.Short qualified as S (
-    ShortText,
-    any,
-    append,
-    empty,
-    findIndex,
-    fromByteString,
-    fromText,
-    length,
-    pack,
-    replicate,
-    singleton,
-    splitAt,
-    toBuilder,
-    toText,
-    uncons,
-    unpack,
- )
+import Data.Text.Lazy qualified as U
+    ( Text
+    , foldrChunks
+    , fromChunks
+    , toStrict
+    )
+import Data.Text.Lazy.Builder qualified as U
+    ( Builder
+    , fromText
+    , toLazyText
+    )
+import Data.Text.Short qualified as S
+    ( ShortText
+    , any
+    , append
+    , empty
+    , findIndex
+    , fromByteString
+    , fromText
+    , length
+    , pack
+    , replicate
+    , singleton
+    , splitAt
+    , toBuilder
+    , toText
+    , uncons
+    , unpack
+    )
 import Data.Text.Short.Unsafe qualified as S (fromByteStringUnsafe)
 import GHC.Generics (Generic)
 import Prettyprinter (Pretty (..), emptyDoc)
@@ -310,7 +310,7 @@ hold /n/ references to the provided input text.
 replicateRope :: Int -> Rope -> Rope
 replicateRope count (Rope x) =
     let x' = foldr (\_ acc -> (F.><) x acc) F.empty [1 .. count]
-     in Rope x'
+    in  Rope x'
 
 {- |
 Repeat the input 'Char' @n@ times. This is a special case of 'replicateRope'
@@ -331,7 +331,7 @@ widthRope :: Rope -> Int
 widthRope text =
     let x = unRope text
         (Width w) = F.measure x
-     in w
+    in  w
 
 nullRope :: Rope -> Bool
 nullRope text = widthRope text == 0
@@ -346,7 +346,7 @@ returning 'Just' that character and the remainder of the text. Returns
 unconsRope :: Rope -> Maybe (Char, Rope)
 unconsRope text =
     let x = unRope text
-     in case F.viewl x of
+    in  case F.viewl x of
             F.EmptyL -> Nothing
             (F.:<) piece x' ->
                 case S.uncons piece of
@@ -380,11 +380,11 @@ splitRope :: Int -> Rope -> (Rope, Rope)
 splitRope i text@(Rope x) =
     let pos = Width i
         result = F.search (\w1 _ -> w1 >= pos) x
-     in case result of
+    in  case result of
             F.Position before piece after ->
                 let (Width w) = F.measure before
                     (one, two) = S.splitAt (i - w) piece
-                 in (Rope ((F.|>) before one), Rope ((F.<|) two after))
+                in  (Rope ((F.|>) before one), Rope ((F.<|) two after))
             F.OnLeft -> (Rope F.empty, text)
             F.OnRight -> (text, Rope F.empty)
             F.Nowhere -> error "Position not found in split. Probable cause: predicate function given not monotonic. This is supposed to be unreachable"
@@ -400,7 +400,7 @@ Take the first _n_ characters from the beginning of the Rope.
 takeRope :: Int -> Rope -> Rope
 takeRope i text =
     let (before, _) = splitRope i text
-     in before
+    in  before
 
 {- |
 Insert a new piece of text into an existing @Rope@ at the specified offset.
@@ -418,7 +418,7 @@ insertRope :: Int -> Rope -> Rope -> Rope
 insertRope 0 (Rope new) (Rope x) = Rope ((F.><) new x)
 insertRope i (Rope new) text =
     let (Rope before, Rope after) = splitRope i text
-     in Rope (mconcat [before, new, after])
+    in  Rope (mconcat [before, new, after])
 
 findIndexRope :: (Char -> Bool) -> Rope -> Maybe Int
 findIndexRope predicate = fst . foldl f (Nothing, 0) . unRope
@@ -449,7 +449,7 @@ instance Hashable Rope where
             piece = case F.viewl x' of
                 F.EmptyL -> S.empty
                 (F.:<) first _ -> first
-         in hashWithSalt salt piece
+        in  hashWithSalt salt piece
 
 {- |
 Copy the pieces underlying a 'Rope' into a single piece object.

--- a/core-text/lib/Core/Text/Utilities.hs
+++ b/core-text/lib/Core/Text/Utilities.hs
@@ -13,39 +13,39 @@
 Useful tools for working with 'Rope's. Support for pretty printing, multi-line
 strings, and...
 -}
-module Core.Text.Utilities (
-    -- * Pretty printing
-    Render (..),
-    render,
-    renderNoAnsi,
+module Core.Text.Utilities
+    ( -- * Pretty printing
+      Render (..)
+    , render
+    , renderNoAnsi
 
-    -- * Helpers
-    indefinite,
-    oxford,
-    breakRope,
-    breakWords,
-    breakLines,
-    breakPieces,
-    isNewline,
-    wrap,
-    calculatePositionEnd,
-    underline,
-    leftPadWith,
-    rightPadWith,
+      -- * Helpers
+    , indefinite
+    , oxford
+    , breakRope
+    , breakWords
+    , breakLines
+    , breakPieces
+    , isNewline
+    , wrap
+    , calculatePositionEnd
+    , underline
+    , leftPadWith
+    , rightPadWith
 
-    -- * Multi-line strings
-    quote,
+      -- * Multi-line strings
+    , quote
     -- for testing
-    intoPieces,
-    intoChunks,
-    byteChunk,
+    , intoPieces
+    , intoChunks
+    , byteChunk
 
-    -- * Deprecated
-    intoDocA,
-    module Core.Text.Colour,
-    bold,
-    -- | AnsiColour and colour constants moved to this module.
-) where
+      -- * Deprecated
+    , intoDocA
+    , module Core.Text.Colour
+    , bold
+      -- | AnsiColour and colour constants moved to this module.
+    ) where
 
 import Core.Text.Breaking
 import Core.Text.Bytes
@@ -59,34 +59,34 @@ import Data.FingerTree qualified as F (ViewL (..), viewl, (<|))
 import Data.Kind (Type)
 import Data.List qualified as List (dropWhileEnd, foldl', splitAt)
 import Data.Text qualified as T
-import Data.Text.Short qualified as S (
-    ShortText,
-    replicate,
-    singleton,
-    toText,
-    uncons,
- )
+import Data.Text.Short qualified as S
+    ( ShortText
+    , replicate
+    , singleton
+    , toText
+    , uncons
+    )
 import Data.Word (Word8)
 import Language.Haskell.TH (litE, stringL)
 import Language.Haskell.TH.Quote (QuasiQuoter (QuasiQuoter))
-import Prettyprinter (
-    Doc,
-    LayoutOptions (LayoutOptions),
-    PageWidth (AvailablePerLine),
-    Pretty (..),
-    SimpleDocStream (..),
-    annotate,
-    emptyDoc,
-    flatAlt,
-    group,
-    hsep,
-    layoutPretty,
-    pretty,
-    reAnnotateS,
-    softline',
-    unAnnotateS,
-    vcat,
- )
+import Prettyprinter
+    ( Doc
+    , LayoutOptions (LayoutOptions)
+    , PageWidth (AvailablePerLine)
+    , Pretty (..)
+    , SimpleDocStream (..)
+    , annotate
+    , emptyDoc
+    , flatAlt
+    , group
+    , hsep
+    , layoutPretty
+    , pretty
+    , reAnnotateS
+    , softline'
+    , unAnnotateS
+    , vcat
+    )
 import Prettyprinter.Render.Text (renderLazy)
 
 {- |
@@ -155,7 +155,9 @@ instance Render Bytes where
 
 prettyBytes :: Bytes -> Doc ()
 prettyBytes =
-    annotate () . vcat . twoWords
+    annotate ()
+        . vcat
+        . twoWords
         . fmap wordToHex
         . byteChunk
         . unBytes
@@ -175,7 +177,7 @@ byteChunk = reverse . go []
   where
     go acc blob =
         let (eight, remainder) = B.splitAt 8 blob
-         in if B.length remainder == 0
+        in  if B.length remainder == 0
                 then eight : acc
                 else go (eight : acc) remainder
 
@@ -184,7 +186,7 @@ wordToHex :: B.ByteString -> Doc ann
 wordToHex eight =
     let ws = B.unpack eight
         ds = fmap byteToHex ws
-     in hsep ds
+    in  hsep ds
 
 byteToHex :: Word8 -> Doc ann
 byteToHex c = pretty hi <> pretty low
@@ -224,7 +226,8 @@ of the terminal.
 render :: Render α => Int -> α -> Rope
 render columns (thing :: α) =
     let options = LayoutOptions (AvailablePerLine (columns - 1) 1.0)
-     in go [] . reAnnotateS (colourize @α)
+    in  go []
+            . reAnnotateS (colourize @α)
             . layoutPretty options
             . highlight
             $ thing
@@ -268,7 +271,9 @@ escape codes so it comes outformatted but as plain black & white text.
 renderNoAnsi :: Render α => Int -> α -> Rope
 renderNoAnsi columns (thing :: α) =
     let options = LayoutOptions (AvailablePerLine (columns - 1) 1.0)
-     in intoRope . renderLazy . unAnnotateS
+    in  intoRope
+            . renderLazy
+            . unAnnotateS
             . layoutPretty options
             . highlight
             $ thing
@@ -282,7 +287,7 @@ it's a vowel or not.
 indefinite :: Rope -> Rope
 indefinite text =
     let x = unRope text
-     in case F.viewl x of
+    in  case F.viewl x of
             F.EmptyL -> text
             piece F.:< _ -> case S.uncons piece of
                 Nothing -> text
@@ -341,7 +346,7 @@ Any trailing newlines will be removed.
 wrap :: Int -> Rope -> Rope
 wrap margin text =
     let built = wrapHelper margin (breakWords text)
-     in built
+    in  built
 
 wrapHelper :: Int -> [Rope] -> Rope
 wrapHelper _ [] = ""
@@ -353,7 +358,7 @@ wrapLine :: Int -> (Int, Rope) -> Rope -> (Int, Rope)
 wrapLine margin (pos, builder) word =
     let wide = widthRope word
         wide' = pos + wide + 1
-     in if wide' > margin
+    in  if wide' > margin
             then (wide, builder <> "\n" <> word)
             else (wide', builder <> " " <> word)
 
@@ -361,7 +366,7 @@ underline :: Char -> Rope -> Rope
 underline level text =
     let title = fromRope text
         line = T.map (\_ -> level) title
-     in intoRope line
+    in  intoRope line
 
 {- |
 Pad a piece of text on the left with a specified character to the desired

--- a/core-webserver-servant/core-webserver-servant.cabal
+++ b/core-webserver-servant/core-webserver-servant.cabal
@@ -1,11 +1,11 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.0.
+-- This file has been generated from package.yaml by hpack version 0.35.1.
 --
 -- see: https://github.com/sol/hpack
 
 name:           core-webserver-servant
-version:        0.1.1.3
+version:        0.1.1.4
 synopsis:       Interoperability with Servant
 description:    This is part of a library to help build command-line programs, both tools and
                 longer-running daemons.

--- a/core-webserver-servant/lib/Core/Webserver/Servant.hs
+++ b/core-webserver-servant/lib/Core/Webserver/Servant.hs
@@ -27,29 +27,28 @@ main = do
         'launchWebserver' 8080 application
 @
 -}
-module Core.Webserver.Servant (
-    prepareRoutes,
-    prepareRoutesWithContext,
-) where
+module Core.Webserver.Servant
+    ( prepareRoutes
+    , prepareRoutesWithContext
+    ) where
 
-import Control.Exception.Safe qualified as Safe (try, throw)
+import Control.Exception.Safe qualified as Safe (throw, try)
 import Control.Monad.Except (ExceptT (..))
 import Core.Program
-import Core.System (Exception (..))
 import Core.Webserver.Warp
 import Data.Proxy (Proxy)
 import GHC.Base (Type)
 import Network.Wai (Application)
-import Servant qualified as Servant (
-    Handler (..),
-    ServerT,
- )
-import Servant.Server qualified as Servant (
-    Context (..),
-    HasServer,
-    ServerContext,
-    serveWithContextT,
- )
+import Servant qualified as Servant
+    ( Handler (..)
+    , ServerT
+    )
+import Servant.Server qualified as Servant
+    ( Context (..)
+    , HasServer
+    , ServerContext
+    , serveWithContextT
+    )
 
 {- |
 Convert a __servant__ API and set of handlers into a __warp__ 'Application'.
@@ -68,12 +67,12 @@ This code creates an Application which has sufficient information to unlift
 back to the 'Program' monad so that your handlers can be take advantage of the
 logging and telemetry facilities of __core-program__ and __core-telemetry__.
 -}
-prepareRoutes ::
-    forall τ (api :: Type).
-    Servant.HasServer api '[] =>
-    Proxy api ->
-    Servant.ServerT api (Program τ) ->
-    Program τ Application
+prepareRoutes
+    :: forall τ (api :: Type)
+     . Servant.HasServer api '[]
+    => Proxy api
+    -> Servant.ServerT api (Program τ)
+    -> Program τ Application
 prepareRoutes proxy = prepareRoutesWithContext proxy Servant.EmptyContext
 
 {- |
@@ -82,13 +81,13 @@ Prepare routes as with 'prepareRoutes' above, but providing a __servant__
 
 @since 0.1.1
 -}
-prepareRoutesWithContext ::
-    forall τ (api :: Type) context.
-    (Servant.HasServer api context, Servant.ServerContext context) =>
-    Proxy api ->
-    Servant.Context context ->
-    Servant.ServerT api (Program τ) ->
-    Program τ Application
+prepareRoutesWithContext
+    :: forall τ (api :: Type) context
+     . (Servant.HasServer api context, Servant.ServerContext context)
+    => Proxy api
+    -> Servant.Context context
+    -> Servant.ServerT api (Program τ)
+    -> Program τ Application
 prepareRoutesWithContext proxy sContext (routes :: Servant.ServerT api (Program τ)) =
     pure application
   where
@@ -119,4 +118,4 @@ prepareRoutesWithContext proxy sContext (routes :: Servant.ServerT api (Program 
                 Safe.try $
                     subProgram context $ do
                         program
-         in Servant.Handler (ExceptT output)
+        in  Servant.Handler (ExceptT output)

--- a/core-webserver-servant/package.yaml
+++ b/core-webserver-servant/package.yaml
@@ -1,5 +1,5 @@
 name: core-webserver-servant
-version: 0.1.1.3
+version: 0.1.1.4
 synopsis: Interoperability with Servant
 description: |
   This is part of a library to help build command-line programs, both tools and

--- a/core-webserver-warp/lib/Core/Webserver/Router.hs
+++ b/core-webserver-warp/lib/Core/Webserver/Router.hs
@@ -52,22 +52,22 @@ This results in an HTTP server responding to the following routes:
 Requests to any other paths (for example @\/api@ and
 @\/api\/servicename\/v3@) will result in a @404 Not Found@ response.
 -}
-module Core.Webserver.Router (
-    -- * Setup
-    Route,
-    Prefix,
-    Remainder,
-    literalRoute,
-    handleRoute,
-    captureRoute,
-    (</>),
+module Core.Webserver.Router
+    ( -- * Setup
+      Route
+    , Prefix
+    , Remainder
+    , literalRoute
+    , handleRoute
+    , captureRoute
+    , (</>)
 
-    -- * Compile
-    prepareRoutes,
+      -- * Compile
+    , prepareRoutes
 
-    -- * Internal
-    notFoundHandler,
-) where
+      -- * Internal
+    , notFoundHandler
+    ) where
 
 import Control.Exception.Safe qualified as Safe
 import Core.Program.Context (Program)
@@ -240,14 +240,14 @@ buildTrie :: Prefix -> [Route τ] -> Trie.Trie (Prefix -> Remainder -> Request -
 buildTrie prefix0 routes =
     List.foldl' f Trie.empty routes
   where
-    f ::
-        Trie.Trie (Prefix -> Remainder -> Request -> Program τ Response) ->
-        Route τ ->
-        Trie.Trie (Prefix -> Remainder -> Request -> Program τ Response)
+    f
+        :: Trie.Trie (Prefix -> Remainder -> Request -> Program τ Response)
+        -> Route τ
+        -> Trie.Trie (Prefix -> Remainder -> Request -> Program τ Response)
     f trie (Route prefix1 handler children) =
         let prefix' = prefix0 <> singletonRope '/' <> prefix1
             trie1 = Trie.insert (fromRope prefix') handler trie
-         in case children of
+        in  case children of
                 [] -> trie1
                 _ -> Trie.unionL trie1 (buildTrie prefix' children)
 

--- a/core-webserver-warp/lib/Core/Webserver/Warp.hs
+++ b/core-webserver-warp/lib/Core/Webserver/Warp.hs
@@ -66,13 +66,13 @@ This is useful for debugging during development but for production you are
 recommended to use the structured logging output or to send the traces to an
 observability service; this will be the root span of a trace.
 -}
-module Core.Webserver.Warp (
-    Port,
-    launchWebserver,
-    requestContextKey,
-    contextFromRequest,
-    ContextNotFoundInRequest(..),
-) where
+module Core.Webserver.Warp
+    ( Port
+    , launchWebserver
+    , requestContextKey
+    , contextFromRequest
+    , ContextNotFoundInRequest (..)
+    ) where
 
 --
 -- We follow the convention used elsewhere in this collection of libraries of
@@ -91,19 +91,19 @@ import Core.Telemetry.Observability
 import Core.Text.Rope
 import Data.List qualified as List
 import Data.Vault.Lazy qualified as Vault
-import Network.HTTP.Types (
-    Status,
-    hContentType,
-    status400,
-    status413,
-    status431,
-    status500,
-    statusCode,
- )
-import Network.HTTP2.Frame (
-    ErrorCodeId (UnknownErrorCode),
-    HTTP2Error (ConnectionError),
- )
+import Network.HTTP.Types
+    ( Status
+    , hContentType
+    , status400
+    , status413
+    , status431
+    , status500
+    , statusCode
+    )
+import Network.HTTP2.Frame
+    ( ErrorCodeId (UnknownErrorCode)
+    , HTTP2Error (ConnectionError)
+    )
 import Network.Wai
 import Network.Wai.Handler.Warp (InvalidRequest, Port)
 import Network.Wai.Handler.Warp qualified as Warp
@@ -163,7 +163,7 @@ loggingMiddleware (context0 :: Context τ) application request sendResponse = do
                     -- application to make sure that consumers can later fetch the appropriate
                     -- `Context t`.
                     let vault' = Vault.insert (requestContextKey @τ) context1 (vault request)
-                        request' = request{vault = vault'}
+                        request' = request {vault = vault'}
                     Safe.catch
                         ( application request' $ \response -> do
                             -- accumulate the details for logging
@@ -239,7 +239,7 @@ onExceptionHandler context possibleRequest e = do
             Nothing -> pure ()
             Just request ->
                 let line = intoRope (requestMethod request) <> " " <> intoRope (rawPathInfo request) <> intoRope (rawQueryString request)
-                 in debug "request" line
+                in  debug "request" line
 
 {- |
 Pull the Trace identifier and parent Span identifier out of the request
@@ -261,6 +261,6 @@ extractTraceParent :: Request -> Maybe (Trace, Span)
 extractTraceParent request =
     let headers = requestHeaders request
         possibleValue = List.lookup "traceparent" headers
-     in case possibleValue of
+    in  case possibleValue of
             Nothing -> Nothing
             Just value -> parseTraceParentHeader (intoRope value)

--- a/fourmolu.yaml
+++ b/fourmolu.yaml
@@ -1,0 +1,14 @@
+indentation: 4
+function-arrows: leading
+comma-style: leading
+import-export-style: leading
+record-brace-space: true
+indent-wheres: false
+respectful: true
+haddock-style: multi-line
+newlines-between-decls: 1
+haddock-style-module:
+let-style: auto
+in-style: left-align
+fixities: []
+unicode: never

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-20.0
+resolver: lts-20.4
 compiler: ghc-9.2.4
 packages:
  - ./core-data
@@ -9,4 +9,3 @@ packages:
  - ./core-webserver-warp
  - .
 extra-deps: []
-

--- a/tests/CheckArgumentsParsing.hs
+++ b/tests/CheckArgumentsParsing.hs
@@ -1,9 +1,9 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# OPTIONS_GHC -fno-warn-missing-signatures #-}
 
-module CheckArgumentsParsing (
-    checkArgumentsParsing,
-) where
+module CheckArgumentsParsing
+    ( checkArgumentsParsing
+    ) where
 
 import Core.Data.Structures
 import Core.Program.Arguments
@@ -86,7 +86,7 @@ checkArgumentsParsing = do
             let config = simpleConfig options1
                 actual = parseCommandLine config ["--verbose"]
                 expect = Parameters Nothing (intoMap [("verbose", Empty)]) [] emptyMap
-             in actual `shouldBe` Right expect
+            in  actual `shouldBe` Right expect
         it "recognizes all specified options" $
             let config = simpleConfig options1
                 actual = parseCommandLine config ["--verbose", "--quiet", "--dry-run=Tomorrow"]
@@ -101,7 +101,7 @@ checkArgumentsParsing = do
                         )
                         []
                         emptyMap
-             in actual `shouldBe` Right expect
+            in  actual `shouldBe` Right expect
 
         it "recognizes required arguments" $
             let config = simpleConfig options2
@@ -115,7 +115,7 @@ checkArgumentsParsing = do
                         )
                         []
                         emptyMap
-             in actual `shouldBe` Right expect
+            in  actual `shouldBe` Right expect
 
         it "handles valued parameter" $
             let config = simpleConfig options2
@@ -129,27 +129,27 @@ checkArgumentsParsing = do
                         )
                         []
                         emptyMap
-             in actual `shouldBe` Right expect
+            in  actual `shouldBe` Right expect
 
         it "rejects unknown options" $
             let config = simpleConfig options2
                 actual = parseCommandLine config ["-a"]
-             in actual `shouldBe` Left (UnknownOption "-a")
+            in  actual `shouldBe` Left (UnknownOption "-a")
 
         it "rejects a malformed option" $
             let config = simpleConfig options2
                 actual = parseCommandLine config ["-help"]
-             in actual `shouldBe` Left (InvalidOption "-help")
+            in  actual `shouldBe` Left (InvalidOption "-help")
 
         it "fails on missing argument" $
             let config = simpleConfig options2
                 actual = parseCommandLine config []
-             in actual `shouldBe` Left (MissingArgument "filename")
+            in  actual `shouldBe` Left (MissingArgument "filename")
 
         it "accepts request for version" $
             let config = simpleConfig options1
                 actual = parseCommandLine config ["--version"]
-             in actual `shouldBe` Left VersionRequest
+            in  actual `shouldBe` Left VersionRequest
 
     describe "Parsing of complex command-lines" $ do
         it "recognizes only single command" $
@@ -166,44 +166,44 @@ checkArgumentsParsing = do
                         )
                         []
                         emptyMap
-             in actual `shouldBe` Right expect
+            in  actual `shouldBe` Right expect
 
         it "fails on missing command" $
             let config = complexConfig commands1
                 actual = parseCommandLine config []
-             in actual `shouldBe` Left (NoCommandFound)
+            in  actual `shouldBe` Left (NoCommandFound)
 
         it "rejects an unknown command" $
             let config = complexConfig commands1
                 actual = parseCommandLine config ["launch"]
-             in actual `shouldBe` Left (UnknownCommand "launch")
+            in  actual `shouldBe` Left (UnknownCommand "launch")
 
         it "recognizes different command" $ -- ie, now from among multiple choices
             let config = complexConfig commands2
                 actual = parseCommandLine config ["commit"]
                 expect = Parameters (Just "commit") emptyMap [] emptyMap
-             in actual `shouldBe` Right expect
+            in  actual `shouldBe` Right expect
 
         it "rejects further trailing arguments" $
             let config = complexConfig commands2
                 actual = parseCommandLine config ["commit", "some"]
-             in actual `shouldBe` Left (UnexpectedArguments ["some"])
+            in  actual `shouldBe` Left (UnexpectedArguments ["some"])
 
         it "accepts trailing arguments as remainder" $
             let config = complexConfig commands4
                 actual = parseCommandLine config ["commit", "one", "two", "three"]
                 expect = Parameters (Just "commit") emptyMap ["one", "two", "three"] emptyMap
-             in actual `shouldBe` Right expect
+            in  actual `shouldBe` Right expect
 
         it "ensures required arguments as in order" $
             let config = simpleConfig options5
                 actual = parseCommandLine config ["un", "deux", "trois", "quatre", "cinq", "six"]
                 expect = Parameters Nothing (intoMap [("one", "un"), ("two", "deux"), ("three", "trois"), ("four", "quatre")]) ["cinq", "six"] emptyMap
-             in actual `shouldBe` Right expect
+            in  actual `shouldBe` Right expect
 
         -- in complex mode wasn't accpting --version as a global option.
 
         it "accepts request for version" $
             let config = complexConfig commands2
                 actual = parseCommandLine config ["--version"]
-             in actual `shouldBe` Left VersionRequest
+            in  actual `shouldBe` Left VersionRequest

--- a/tests/CheckBytesBehaviour.hs
+++ b/tests/CheckBytesBehaviour.hs
@@ -11,12 +11,12 @@ import Test.Hspec
 
 checkBytesBehaviour :: Spec
 checkBytesBehaviour = do
-  describe "Bytes data type" $ do
-    it "chunks Bytes in 64 bit words" $
-      let expected =
-            [ C.pack "Hello Wo",
-              C.pack "rld! Goo",
-              C.pack "d Bye."
-            ]
-       in do
-            byteChunk (C.pack "Hello World! Good Bye.") `shouldBe` expected
+    describe "Bytes data type" $ do
+        it "chunks Bytes in 64 bit words" $
+            let expected =
+                    [ C.pack "Hello Wo"
+                    , C.pack "rld! Goo"
+                    , C.pack "d Bye."
+                    ]
+            in  do
+                    byteChunk (C.pack "Hello World! Good Bye.") `shouldBe` expected

--- a/tests/CheckRopeBehaviour.hs
+++ b/tests/CheckRopeBehaviour.hs
@@ -2,9 +2,9 @@
 {-# LANGUAGE QuasiQuotes #-}
 {-# OPTIONS_GHC -fno-warn-missing-signatures #-}
 
-module CheckRopeBehaviour (
-    checkRopeBehaviour,
-) where
+module CheckRopeBehaviour
+    ( checkRopeBehaviour
+    ) where
 
 import Core.Text.Rope
 import Core.Text.Utilities
@@ -72,7 +72,7 @@ checkRopeBehaviour = do
 
         it "exports to ByteString" $
             let expected = T.encodeUtf8 (T.pack "H₂SO₄")
-             in do
+            in  do
                     fromRope sulfuric_acid `shouldBe` expected
 
         it "exports to Text (Strict)" $ do
@@ -84,8 +84,8 @@ checkRopeBehaviour = do
         it "knows how to use an Oxford comma properly" $ do
             oxford ["one", "two", "three"] `shouldBe` "one, two, and three"
             oxford ["four", "five"] `shouldBe` "four and five"
-            oxford ["six"]`shouldBe`"six"
-            oxford []`shouldBe`""
+            oxford ["six"] `shouldBe` "six"
+            oxford [] `shouldBe` ""
 
         it "does the splits" $ do
             -- compare behaviour on Haskell lists
@@ -175,27 +175,27 @@ World
 
         it "single piece containing multiple words splits correctly" $
             let text = "This is a test"
-             in do
+            in  do
                     breakWords text `shouldBe` ["This", "is", "a", "test"]
 
         it "single piece, long run of whitespace splits correctly" $
             let text = "This is\na    test"
-             in do
+            in  do
                     breakWords text `shouldBe` ["This", "is", "a", "test"]
 
         it "text spanning two pieces can be split into words" $
             let text = "This is " <> "a test"
-             in do
+            in  do
                     breakWords text `shouldBe` ["This", "is", "a", "test"]
 
         it "text spanning many pieces can be split into words" $
             let text = "st" <> "" <> "op" <> "" <> " " <> " " <> "and go" <> "op"
-             in do
+            in  do
                     breakWords text `shouldBe` ["stop", "and", "goop"]
 
         it "empty and whitespace-only corner cases handled correctly" $
             let text = "  " <> "" <> "stop" <> "" <> "  "
-             in do
+            in  do
                     breakWords text `shouldBe` ["stop"]
 
     describe "Splitting into lines" $ do
@@ -218,7 +218,7 @@ of the Emergency
 Broadcast
 System, beeeeep
 |]
-             in do
+            in  do
                     breakLines para
                         `shouldBe` [ "This is a test"
                                    , "of the Emergency"
@@ -233,7 +233,7 @@ First line.
 
 Third line.
 |]
-             in do
+            in  do
                     breakLines para
                         `shouldBe` [ "First line."
                                    , ""
@@ -248,7 +248,7 @@ Hello this is
 a test
  of the Emergency Broadcast System
             |]
-             in wrap 20 para
+            in  wrap 20 para
                     `shouldBe` [quote|
 Hello this is a test
 of the Emergency

--- a/tests/CheckTelemetryMachinery.hs
+++ b/tests/CheckTelemetryMachinery.hs
@@ -5,7 +5,7 @@
 
 module CheckTelemetryMachinery where
 
-import Control.Concurrent (threadDelay, forkIO)
+import Control.Concurrent (forkIO, threadDelay)
 import Control.Concurrent.MVar (MVar, modifyMVar_, newMVar, readMVar)
 import Control.Concurrent.STM (atomically)
 import Control.Concurrent.STM.TQueue (newTQueueIO, writeTQueue)
@@ -14,13 +14,12 @@ import Data.Word (Word32)
 import Network.Info (MAC (..))
 import Test.Hspec hiding (context)
 
+import Control.Concurrent.MVar (newEmptyMVar, putMVar)
 import Core.Data.Clock
 import Core.Program
 import Core.System
 import Core.Telemetry.Identifiers
 import Core.Text
-import Control.Concurrent.MVar (newEmptyMVar)
-import Control.Concurrent.MVar (putMVar)
 
 countingAction :: Int -> [Int] -> IO ()
 countingAction target ints = sum ints `shouldBe` target
@@ -92,7 +91,7 @@ checkTelemetryMachinery = do
             createIdentifierSpan (intoTime (1 :: Int64)) 0 `shouldBe` Span "1000000000000000"
             createIdentifierSpan (intoTime (fromIntegral (maxBound :: Int32) :: Int64)) 0 `shouldBe` Span "fffffff700000000"
             createIdentifierSpan (intoTime (fromIntegral (maxBound :: Word32) :: Int64)) 0 `shouldBe` Span "ffffffff00000000"
-            createIdentifierSpan (intoTime (fromIntegral (maxBound :: Word32) + 1 :: Int64) ) 0 `shouldBe` Span "0000000010000000"
+            createIdentifierSpan (intoTime (fromIntegral (maxBound :: Word32) + 1 :: Int64)) 0 `shouldBe` Span "0000000010000000"
             createIdentifierSpan (intoTime (1642770757512438606 :: Int64)) 0 `shouldBe` Span "e43ade8dc4b40000"
             createIdentifierSpan (intoTime (1642770757512438607 :: Int64)) 0 `shouldBe` Span "f43ade8dc4b40000"
             createIdentifierSpan (intoTime (1642770757512438607 :: Int64)) 0x1a2b `shouldBe` Span "f43ade8dc4b4b2a1"

--- a/tests/CheckTimeStamp.hs
+++ b/tests/CheckTimeStamp.hs
@@ -20,7 +20,7 @@ checkTimeStamp :: Spec
 checkTimeStamp = do
     describe "Smallest valid Time" $
         let t = intoTime (-9223372036854775808 :: Int64)
-         in do
+        in  do
                 it "should be representable" $ do
                     t `shouldBe` (minBound :: Time)
 
@@ -32,7 +32,7 @@ checkTimeStamp = do
 
     describe "Largest valid Time" $
         let t = intoTime (9223372036854775807 :: Int64)
-         in do
+        in  do
                 it "should be representable" $ do
                     t `shouldBe` (maxBound :: Time)
 

--- a/tests/CheckWebserverIntegration.hs
+++ b/tests/CheckWebserverIntegration.hs
@@ -3,9 +3,9 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-module CheckWebserverIntegration (
-    checkWebserverIntegration,
-) where
+module CheckWebserverIntegration
+    ( checkWebserverIntegration
+    ) where
 
 import Data.Trie qualified as Trie
 

--- a/tests/ColourSnippet.hs
+++ b/tests/ColourSnippet.hs
@@ -13,34 +13,34 @@ import Core.Data
 import Core.Encoding
 import Core.Program
 import Core.System
-import Core.Text (
-    Render (Token, colourize, highlight),
-    brightBlue,
-    brightCyan,
-    brightGreen,
-    brightGrey,
-    brightMagenta,
-    brightRed,
-    brightWhite,
-    brightYellow,
-    dullBlue,
-    dullCyan,
-    dullGreen,
-    dullGrey,
-    dullMagenta,
-    dullRed,
-    dullWhite,
-    dullYellow,
-    pureBlack,
-    pureBlue,
-    pureCyan,
-    pureGreen,
-    pureGrey,
-    pureMagenta,
-    pureRed,
-    pureWhite,
-    pureYellow,
- )
+import Core.Text
+    ( Render (Token, colourize, highlight)
+    , brightBlue
+    , brightCyan
+    , brightGreen
+    , brightGrey
+    , brightMagenta
+    , brightRed
+    , brightWhite
+    , brightYellow
+    , dullBlue
+    , dullCyan
+    , dullGreen
+    , dullGrey
+    , dullMagenta
+    , dullRed
+    , dullWhite
+    , dullYellow
+    , pureBlack
+    , pureBlue
+    , pureCyan
+    , pureGreen
+    , pureGrey
+    , pureMagenta
+    , pureRed
+    , pureWhite
+    , pureYellow
+    )
 import Data.Char (toLower)
 
 data Colours

--- a/tests/ComplexExperiment.hs
+++ b/tests/ComplexExperiment.hs
@@ -12,67 +12,67 @@ import Core.Text
 
 program :: Program None ()
 program = do
-  info "Starting..."
+    info "Starting..."
 
-  params <- getCommandLine
-  debugS "params" params
+    params <- getCommandLine
+    debugS "params" params
 
-  info "Done."
-  terminate 0
+    info "Done."
+    terminate 0
 
 main :: IO ()
 main = do
-  context <-
-    configure
-      "42.0"
-      None
-      ( complexConfig
-          [ Global
-              [ Option
-                  "logging-and-cutting"
-                  Nothing
-                  (Value "PLACE")
-                  [quote|
+    context <-
+        configure
+            "42.0"
+            None
+            ( complexConfig
+                [ Global
+                    [ Option
+                        "logging-and-cutting"
+                        Nothing
+                        (Value "PLACE")
+                        [quote|
                 Valid values are "console", "file:/path/to/file.log", and "syslog".
-              |],
-                Option
-                  "quiet"
-                  (Just 'q')
-                  Empty
-                  [quote|
+              |]
+                    , Option
+                        "quiet"
+                        (Just 'q')
+                        Empty
+                        [quote|
                 Supress normal output.
-              |],
-                Variable "GITHUB_TOKEN" "OAuth token to access GitHub."
-              ],
-            Command
-              "add"
-              "Add a file."
-              [ Argument "filename" "File to add.",
-                Variable "OVERRIDE_BROKEN" "Deal with broken line endings on Windows"
-              ],
-            Command
-              "commit"
-              "Commit your changes to the repository."
-              [ Option "message" Nothing (Value "MESSAGE") "Specify commit message (instead of using editor)."
-              ],
-            Command
-              "launch"
-              "Fire the weapons at the alien horde."
-              [ Option "all" (Just 'a') Empty "Target all the baddies.",
-                Option "other" Nothing (Value "THING") "Another option.",
-                Argument
-                  "input-file"
-                  [quote|
+              |]
+                    , Variable "GITHUB_TOKEN" "OAuth token to access GitHub."
+                    ]
+                , Command
+                    "add"
+                    "Add a file."
+                    [ Argument "filename" "File to add."
+                    , Variable "OVERRIDE_BROKEN" "Deal with broken line endings on Windows"
+                    ]
+                , Command
+                    "commit"
+                    "Commit your changes to the repository."
+                    [ Option "message" Nothing (Value "MESSAGE") "Specify commit message (instead of using editor)."
+                    ]
+                , Command
+                    "launch"
+                    "Fire the weapons at the alien horde."
+                    [ Option "all" (Just 'a') Empty "Target all the baddies."
+                    , Option "other" Nothing (Value "THING") "Another option."
+                    , Argument
+                        "input-file"
+                        [quote|
                 The file you want to read the launch codes from.
-              |],
-                Argument
-                  "main-output-device"
-                  [quote|
+              |]
+                    , Argument
+                        "main-output-device"
+                        [quote|
                 The device you want to draw the pretty picture to.
-              |],
-                Variable "CRAZY_MODE" "Specify how many crazies to activate."
-              ]
-          ]
-      )
+              |]
+                    , Variable "CRAZY_MODE" "Specify how many crazies to activate."
+                    ]
+                ]
+            )
 
-  executeWith context program
+    executeWith context program

--- a/tests/NotifySnippet.hs
+++ b/tests/NotifySnippet.hs
@@ -13,9 +13,9 @@ import qualified Data.ByteString.Char8 as C
 
 main :: IO ()
 main = execute $ do
-  setVerbosityLevel Debug
-  event "Starting..."
+    setVerbosityLevel Debug
+    event "Starting..."
 
-  forever (waitForChange ["tests/Snippet.hs"])
+    forever (waitForChange ["tests/Snippet.hs"])
 
-  write "Done"
+    write "Done"

--- a/tests/TestSuite.hs
+++ b/tests/TestSuite.hs
@@ -8,8 +8,8 @@ import CheckJsonWrapper
 import CheckProgramMonad
 import CheckRopeBehaviour (checkRopeBehaviour)
 import CheckTelemetryMachinery
-import CheckWebserverIntegration (checkWebserverIntegration)
 import CheckTimeStamp
+import CheckWebserverIntegration (checkWebserverIntegration)
 import Control.Exception (finally)
 import Test.Hspec
 

--- a/tests/WarpSnippet.hs
+++ b/tests/WarpSnippet.hs
@@ -43,7 +43,7 @@ exampleApplication request sendResponse =
     let path = intoRope (rawPathInfo request)
         query = intoRope (rawQueryString request)
         path' = fromRope (path <> query)
-     in do
+    in  do
             sendResponse (responseLBS status200 [] path')
 
 port :: Port


### PR DESCRIPTION
At last! **fourmolu** supports proper formatting of multiline functions! So, reformat code with leading commas in the imports and leading arrows in functions. This necessitates a _fourmolu.yaml_ file, which is added with the defaults and the divergences marked. 