### PR TITLE
Parse Externalizable values from environment variables

### DIFF
--- a/core-data/core-data.cabal
+++ b/core-data/core-data.cabal
@@ -1,11 +1,11 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.0.
+-- This file has been generated from package.yaml by hpack version 0.35.1.
 --
 -- see: https://github.com/sol/hpack
 
 name:           core-data
-version:        0.3.8.0
+version:        0.3.9.0
 synopsis:       Convenience wrappers around common data structures and encodings
 description:    Wrappers around common data structures and encodings.
                 .

--- a/core-data/lib/Core/Encoding/External.hs
+++ b/core-data/lib/Core/Encoding/External.hs
@@ -47,16 +47,18 @@ inputs for an example.
 -}
 module Core.Encoding.External
     ( Externalize (formatExternal, parseExternal)
-    ) where
+    )
+where
 
 import Core.Data.Clock
 import Core.Text.Rope
 import Data.ByteString.Builder qualified as Builder
-import Data.Int (Int32, Int64)
+import Data.Int (Int16, Int32, Int64, Int8)
 import Data.Scientific (FPFormat (Exponent), Scientific, formatScientific)
 import Data.Time.Calendar qualified as Base (Day)
 import Data.Time.Format.ISO8601 qualified as Base (formatParseM, formatShow, iso8601Format)
 import Data.UUID qualified as Uuid (UUID, fromText, toText)
+import Data.Word (Word16, Word32, Word64, Word8)
 import Text.Read (readMaybe)
 
 {- |
@@ -133,6 +135,28 @@ Integers are represented in decimal:
 42
 @
 -}
+instance Externalize Int8 where
+    formatExternal = intoRope . Builder.toLazyByteString . Builder.int8Dec
+    parseExternal = readMaybe . fromRope
+
+{- |
+Integers are represented in decimal:
+
+@
+42
+@
+-}
+instance Externalize Int16 where
+    formatExternal = intoRope . Builder.toLazyByteString . Builder.int16Dec
+    parseExternal = readMaybe . fromRope
+
+{- |
+Integers are represented in decimal:
+
+@
+42
+@
+-}
 instance Externalize Int32 where
     formatExternal = intoRope . Builder.toLazyByteString . Builder.int32Dec
     parseExternal = readMaybe . fromRope
@@ -146,6 +170,50 @@ Integers are represented in decimal:
 -}
 instance Externalize Int64 where
     formatExternal = intoRope . Builder.toLazyByteString . Builder.int64Dec
+    parseExternal = readMaybe . fromRope
+
+{- |
+Words are likewise represented in decimal:
+
+@
+255
+@
+-}
+instance Externalize Word8 where
+    formatExternal = intoRope . Builder.toLazyByteString . Builder.word8Dec
+    parseExternal = readMaybe . fromRope
+
+{- |
+Words are likewise represented in decimal:
+
+@
+65535
+@
+-}
+instance Externalize Word16 where
+    formatExternal = intoRope . Builder.toLazyByteString . Builder.word16Dec
+    parseExternal = readMaybe . fromRope
+
+{- |
+Words are likewise represented in decimal:
+
+@
+4294967295
+@
+-}
+instance Externalize Word32 where
+    formatExternal = intoRope . Builder.toLazyByteString . Builder.word32Dec
+    parseExternal = readMaybe . fromRope
+
+{- |
+Words are likewise represented in decimal:
+
+@
+18446744073709551615
+@
+-}
+instance Externalize Word64 where
+    formatExternal = intoRope . Builder.toLazyByteString . Builder.word64Dec
     parseExternal = readMaybe . fromRope
 
 {- |

--- a/core-data/package.yaml
+++ b/core-data/package.yaml
@@ -1,5 +1,5 @@
 name: core-data
-version: 0.3.8.0
+version: 0.3.9.0
 synopsis: Convenience wrappers around common data structures and encodings
 description: |
   Wrappers around common data structures and encodings.

--- a/core-program/core-program.cabal
+++ b/core-program/core-program.cabal
@@ -1,11 +1,11 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.0.
+-- This file has been generated from package.yaml by hpack version 0.35.1.
 --
 -- see: https://github.com/sol/hpack
 
 name:           core-program
-version:        0.6.1.1
+version:        0.6.2.0
 synopsis:       Opinionated Haskell Interoperability
 description:    A library to help build command-line programs, both tools and
                 longer-running daemons.

--- a/core-program/lib/Core/Program/Execute.hs
+++ b/core-program/lib/Core/Program/Execute.hs
@@ -925,8 +925,13 @@ queryEnvironmentValue name = do
 Look to see if the user supplied the named environment variable and if so,
 return what its value was.
 
-This makes the assumption that the requested environment variable must be
-present, and that it must not be the empty string.
+Like 'queryOptionValue'' above, this function attempts to parse the supplied
+value as 'Just' the inferred type. This makes the assumption that the
+requested environment variable is populated. If it is not set in the
+environment, or is set to the empty string, then this function will return
+'Nothing'.
+
+If the attempt to parse the supplied value fails an exception will be thrown.
 
 @since 0.6.2
 -}

--- a/core-program/package.yaml
+++ b/core-program/package.yaml
@@ -1,5 +1,5 @@
 name: core-program
-version: 0.6.1.1
+version: 0.6.2.0
 synopsis: Opinionated Haskell Interoperability
 description: |
   A library to help build command-line programs, both tools and

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-20.4
+resolver: lts-20.8
 compiler: ghc-9.2.4
 packages:
  - ./core-data

--- a/tests/CheckExternalizing.hs
+++ b/tests/CheckExternalizing.hs
@@ -12,6 +12,7 @@ import Data.Scientific
 import Data.Time.Calendar (Day (ModifiedJulianDay))
 import Test.Hspec
 import Test.QuickCheck (property)
+import Data.Word
 
 checkExternalizing :: Spec
 checkExternalizing = do
@@ -24,8 +25,11 @@ checkExternalizing = do
             formatExternal (9223372036854775807 :: Int64) `shouldBe` packRope "9223372036854775807"
             parseExternal (packRope "9223372036854775807") `shouldBe` Just (9223372036854775807 :: Int64)
 
-        it "behaves when QuickChecked" $ do
+        it "Int64 behaves when QuickChecked" $ do
             property (prop_RoundTrip_External :: Int64 -> Bool)
+
+        it "Word16 behaves when QuickChecked" $ do
+            property (prop_RoundTrip_External :: Word16 -> Bool)
 
         it "Timestamps and Days" $ do
             formatExternal (intoTime (1660802416710578538 :: Int64)) `shouldBe` packRope "2022-08-18T06:00:16.710578538Z"

--- a/unbeliever.cabal
+++ b/unbeliever.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.0.
+-- This file has been generated from package.yaml by hpack version 0.35.1.
 --
 -- see: https://github.com/sol/hpack
 


### PR DESCRIPTION
We previously had `queryOptionValue'` as a convenience for reading a value (notably numeric values) from a command-line option. This branch adds the a similar convenience for declared environment variables `queryEnvironmentVariable'`.

Externalize instances for Int8 and Word{8,16,32,64} are added.

