### PR TITLE
Add MonadUnliftIO instance

### DIFF
--- a/core-program/core-program.cabal
+++ b/core-program/core-program.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           core-program
-version:        0.6.2.0
+version:        0.6.2.1
 synopsis:       Opinionated Haskell Interoperability
 description:    A library to help build command-line programs, both tools and
                 longer-running daemons.
@@ -76,4 +76,5 @@ library
     , transformers
     , typed-process
     , unix
+    , unliftio-core
   default-language: Haskell2010

--- a/core-program/lib/Core/Program/Unlift.hs
+++ b/core-program/lib/Core/Program/Unlift.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}

--- a/core-program/lib/Core/Program/Unlift.hs
+++ b/core-program/lib/Core/Program/Unlift.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
@@ -145,6 +146,8 @@ following pattern:
             -- now in Program monad
         ...
 @
+
+Note there is a 'MonadUnliftIO' instance which may be useful to you as well.
 -}
 
 -- I think I just discovered the same pattern as **unliftio**? Certainly

--- a/core-program/package.yaml
+++ b/core-program/package.yaml
@@ -1,5 +1,5 @@
 name: core-program
-version: 0.6.2.0
+version: 0.6.2.1
 synopsis: Opinionated Haskell Interoperability
 description: |
   A library to help build command-line programs, both tools and
@@ -48,6 +48,7 @@ library:
    - terminal-size
    - transformers
    - unix
+   - unliftio-core
   source-dirs: lib
   exposed-modules:
    - Core.Program


### PR DESCRIPTION
Nothing in this set of packages requires a MonadUnliftIO instance, but I've come across a few possible use sites where it might potentially be useful to have. **unliftio-core** is a transitive dependency for lots of things so it's not a burden to add.