### PR TITLE
Ensure threaded runtime present

### DIFF
--- a/core-program/core-program.cabal
+++ b/core-program/core-program.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           core-program
-version:        0.6.2.1
+version:        0.6.2.2
 synopsis:       Opinionated Haskell Interoperability
 description:    A library to help build command-line programs, both tools and
                 longer-running daemons.

--- a/core-program/lib/Core/Program/Execute.hs
+++ b/core-program/lib/Core/Program/Execute.hs
@@ -235,7 +235,7 @@ executeActual :: Context τ -> Program τ α -> IO ()
 executeActual context0 program = do
     -- ensure threaded runtime is active
     unless hostIsThreaded $ do
-        putStrLn "error: Program must be compiled with -threaded GHC option"
+        putStrLn "error: Application must be compiled with -threaded GHC option"
         Posix.exitImmediately (ExitFailure 98)
 
     -- command line +RTS -Nn -RTS value

--- a/core-program/package.yaml
+++ b/core-program/package.yaml
@@ -1,5 +1,5 @@
 name: core-program
-version: 0.6.2.1
+version: 0.6.2.2
 synopsis: Opinionated Haskell Interoperability
 description: |
   A library to help build command-line programs, both tools and

--- a/core-telemetry/core-telemetry.cabal
+++ b/core-telemetry/core-telemetry.cabal
@@ -1,11 +1,11 @@
 cabal-version: 1.18
 
--- This file has been generated from package.yaml by hpack version 0.35.0.
+-- This file has been generated from package.yaml by hpack version 0.35.1.
 --
 -- see: https://github.com/sol/hpack
 
 name:           core-telemetry
-version:        0.2.7.0
+version:        0.2.7.2
 synopsis:       Advanced telemetry
 description:    This is part of a library to help build command-line programs, both tools and
                 longer-running daemons.
@@ -54,7 +54,7 @@ library
       base >=4.11 && <5
     , bytestring
     , core-data >=0.3.8.0
-    , core-program >=0.6.1
+    , core-program >=0.6.2.2
     , core-text >=0.3.7.1
     , exceptions
     , http-streams

--- a/core-telemetry/package.yaml
+++ b/core-telemetry/package.yaml
@@ -1,5 +1,5 @@
 name: core-telemetry
-version: 0.2.7.0
+version: 0.2.7.2
 synopsis: Advanced telemetry
 description: |
   This is part of a library to help build command-line programs, both tools and
@@ -34,7 +34,7 @@ library:
   dependencies:
    - core-text >= 0.3.7.1
    - core-data >= 0.3.8.0
-   - core-program >= 0.6.1
+   - core-program >= 0.6.2.2
    - exceptions
    - http-streams
    - io-streams


### PR DESCRIPTION
Add a check at startup to ensure that the program was linked against the threaded runtime (using the `-threaded` GHC option).

This is necessary if any FFI is happening in multiple threads (which definitely happpens in the internals of **core-telemetry** when sending data to Honeycomb) but the default assumption is that this should just work at all times. We've never tested this library without the threaded runtime and I don't ever expect to start doing so.

Closes #161 