### PR TITLE
Use stackage lts-20.10 at GHC 9.2.5

### DIFF
--- a/core-data/core-data.cabal
+++ b/core-data/core-data.cabal
@@ -26,7 +26,7 @@ license:        MIT
 license-file:   LICENSE
 build-type:     Simple
 tested-with:
-    GHC == 8.10.7, GHC == 9.2.4
+    GHC == 8.10.7, GHC == 9.2.5
 
 source-repository head
   type: git

--- a/core-data/package.yaml
+++ b/core-data/package.yaml
@@ -17,7 +17,7 @@ license-file: LICENSE
 author: Andrew Cowie <istathar@gmail.com>
 maintainer: Andrew Cowie <istathar@gmail.com>
 copyright: © 2018-2022 Athae Eredh Siniath and Others
-tested-with: GHC == 8.10.7, GHC == 9.2.4
+tested-with: GHC == 8.10.7, GHC == 9.2.5
 category: System
 ghc-options: -Wall -Wwarn -fwarn-tabs
 github: aesiniath/unbeliever

--- a/core-effect-effectful/core-effect-effectful.cabal
+++ b/core-effect-effectful/core-effect-effectful.cabal
@@ -26,7 +26,7 @@ license:        MIT
 license-file:   LICENSE
 build-type:     Simple
 tested-with:
-    GHC == 9.2.4
+    GHC == 9.2.5
 
 source-repository head
   type: git

--- a/core-effect-effectful/package.yaml
+++ b/core-effect-effectful/package.yaml
@@ -17,7 +17,7 @@ license-file: LICENSE
 author: Juan Raphael Diaz Simões <juanrapha@gmail.com>
 maintainer: Andrew Cowie <istathar@gmail.com>
 copyright: © 2023- Athae Eredh Siniath and Others
-tested-with: GHC == 9.2.4
+tested-with: GHC == 9.2.5
 category: System
 ghc-options: -Wall -Wwarn -fwarn-tabs
 github: aesiniath/unbeliever

--- a/core-program/core-program.cabal
+++ b/core-program/core-program.cabal
@@ -27,7 +27,7 @@ license:        MIT
 license-file:   LICENSE
 build-type:     Simple
 tested-with:
-    GHC == 8.10.7, GHC == 9.2.4
+    GHC == 8.10.7, GHC == 9.2.5
 
 source-repository head
   type: git

--- a/core-program/package.yaml
+++ b/core-program/package.yaml
@@ -18,7 +18,7 @@ license-file: LICENSE
 author: Andrew Cowie <istathar@gmail.com>
 maintainer: Andrew Cowie <istathar@gmail.com>
 copyright: © 2018-2022 Athae Eredh Siniath and Others
-tested-with: GHC == 8.10.7, GHC == 9.2.4
+tested-with: GHC == 8.10.7, GHC == 9.2.5
 category: System
 ghc-options: -Wall -Wwarn -fwarn-tabs
 github: aesiniath/unbeliever

--- a/core-text/core-text.cabal
+++ b/core-text/core-text.cabal
@@ -32,7 +32,7 @@ license:        MIT
 license-file:   LICENSE
 build-type:     Simple
 tested-with:
-    GHC == 8.10.7, GHC == 9.2.4
+    GHC == 8.10.7, GHC == 9.2.5
 extra-doc-files:
     AnsiColours.png
 

--- a/core-text/package.yaml
+++ b/core-text/package.yaml
@@ -23,7 +23,7 @@ license-file: LICENSE
 author: Andrew Cowie <istathar@gmail.com>
 maintainer: Andrew Cowie <istathar@gmail.com>
 copyright: © 2018-2022 Athae Eredh Siniath and Others
-tested-with: GHC == 8.10.7, GHC == 9.2.4
+tested-with: GHC == 8.10.7, GHC == 9.2.5
 category: System
 ghc-options: -Wall -Wwarn -fwarn-tabs
 github: aesiniath/unbeliever

--- a/core-webserver-servant/core-webserver-servant.cabal
+++ b/core-webserver-servant/core-webserver-servant.cabal
@@ -24,7 +24,7 @@ license:        MIT
 license-file:   LICENSE
 build-type:     Simple
 tested-with:
-    GHC == 8.10.7, GHC == 9.2.4
+    GHC == 8.10.7, GHC == 9.2.5
 
 source-repository head
   type: git

--- a/core-webserver-servant/package.yaml
+++ b/core-webserver-servant/package.yaml
@@ -15,7 +15,7 @@ license-file: LICENSE
 author: Carlos D'Agostino <carlos.dagostino@gmail.com>
 maintainer: Andrew Cowie <istathar@gmail.com>
 copyright: © 2021-2022 Athae Eredh Siniath and Others
-tested-with: GHC == 8.10.7, GHC == 9.2.4
+tested-with: GHC == 8.10.7, GHC == 9.2.5
 category: System
 ghc-options: -Wall -Wwarn -fwarn-tabs
 github: aesiniath/unbeliever

--- a/core-webserver-warp/core-webserver-warp.cabal
+++ b/core-webserver-warp/core-webserver-warp.cabal
@@ -24,7 +24,7 @@ license:        MIT
 license-file:   LICENSE
 build-type:     Simple
 tested-with:
-    GHC == 8.10.7, GHC == 9.2.4
+    GHC == 8.10.7, GHC == 9.2.5
 
 source-repository head
   type: git

--- a/core-webserver-warp/package.yaml
+++ b/core-webserver-warp/package.yaml
@@ -15,7 +15,7 @@ license-file: LICENSE
 author: Andrew Cowie <istathar@gmail.com>
 maintainer: Andrew Cowie <istathar@gmail.com>
 copyright: © 2021-2022 Athae Eredh Siniath and Others
-tested-with: GHC == 8.10.7, GHC == 9.2.4
+tested-with: GHC == 8.10.7, GHC == 9.2.5
 category: System
 ghc-options: -Wall -Wwarn -fwarn-tabs
 github: aesiniath/unbeliever

--- a/package.yaml
+++ b/package.yaml
@@ -41,7 +41,7 @@ license-file: LICENSE
 author: Andrew Cowie <istathar@gmail.com>
 maintainer: Andrew Cowie <istathar@gmail.com>
 copyright: © 2018-2022 Athae Eredh Siniath and Others
-tested-with: GHC == 9.2.4
+tested-with: GHC == 9.2.5
 category: System
 ghc-options: -Wall -Wwarn -fwarn-tabs
 github: aesiniath/unbeliever

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,5 @@
-resolver: lts-20.8
-compiler: ghc-9.2.4
+resolver: lts-20.10
+compiler: ghc-9.2.5
 packages:
  - ./core-data
  - ./core-effect-effectful

--- a/unbeliever.cabal
+++ b/unbeliever.cabal
@@ -50,7 +50,7 @@ license:        MIT
 license-file:   LICENSE
 build-type:     Simple
 tested-with:
-    GHC == 9.2.4
+    GHC == 9.2.5
 
 source-repository head
   type: git


### PR DESCRIPTION
Updates relevant stack/cabal control files to use lts-20.10 and fixes compiler at GHC-9.2.5.

HLS 9.2.5 compatibility tested by @istathar, found acceptable.
`stack test` passes, no other explicit tests performed.