### PR TITLE
Fix documentation

### DIFF
--- a/core-data/core-data.cabal
+++ b/core-data/core-data.cabal
@@ -21,7 +21,7 @@ homepage:       https://github.com/aesiniath/unbeliever#readme
 bug-reports:    https://github.com/aesiniath/unbeliever/issues
 author:         Andrew Cowie <istathar@gmail.com>
 maintainer:     Andrew Cowie <istathar@gmail.com>
-copyright:      © 2018-2022 Athae Eredh Siniath and Others
+copyright:      © 2018-2023 Athae Eredh Siniath and Others
 license:        MIT
 license-file:   LICENSE
 build-type:     Simple

--- a/core-data/package.yaml
+++ b/core-data/package.yaml
@@ -16,7 +16,7 @@ license: MIT
 license-file: LICENSE
 author: Andrew Cowie <istathar@gmail.com>
 maintainer: Andrew Cowie <istathar@gmail.com>
-copyright: © 2018-2022 Athae Eredh Siniath and Others
+copyright: © 2018-2023 Athae Eredh Siniath and Others
 tested-with: GHC == 8.10.7, GHC == 9.2.5
 category: System
 ghc-options: -Wall -Wwarn -fwarn-tabs

--- a/core-program/core-program.cabal
+++ b/core-program/core-program.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           core-program
-version:        0.6.2.2
+version:        0.6.2.3
 synopsis:       Opinionated Haskell Interoperability
 description:    A library to help build command-line programs, both tools and
                 longer-running daemons.

--- a/core-program/core-program.cabal
+++ b/core-program/core-program.cabal
@@ -22,7 +22,7 @@ homepage:       https://github.com/aesiniath/unbeliever#readme
 bug-reports:    https://github.com/aesiniath/unbeliever/issues
 author:         Andrew Cowie <istathar@gmail.com>
 maintainer:     Andrew Cowie <istathar@gmail.com>
-copyright:      © 2018-2022 Athae Eredh Siniath and Others
+copyright:      © 2018-2023 Athae Eredh Siniath and Others
 license:        MIT
 license-file:   LICENSE
 build-type:     Simple

--- a/core-program/lib/Core/Program.hs
+++ b/core-program/lib/Core/Program.hs
@@ -1,4 +1,4 @@
-{-# OPTIONS_HADDOCK not-home #-}
+{-# OPTIONS_HADDOCK not-home, prune #-}
 
 -- actually, they're there to group implementation too, but hey.
 
@@ -20,8 +20,7 @@ module Core.Program
       -- |
       -- A top-level Program type giving you unified access to logging, concurrency,
       -- and more.
-        module Core.Program.Context
-    , module Core.Program.Execute
+      module Core.Program.Execute
     , module Core.Program.Threads
     , module Core.Program.Unlift
     , module Core.Program.Metadata
@@ -49,7 +48,6 @@ module Core.Program
 where
 
 import Core.Program.Arguments
-import Core.Program.Context
 import Core.Program.Exceptions
 import Core.Program.Execute
 import Core.Program.Logging

--- a/core-program/package.yaml
+++ b/core-program/package.yaml
@@ -1,5 +1,5 @@
 name: core-program
-version: 0.6.2.2
+version: 0.6.2.3
 synopsis: Opinionated Haskell Interoperability
 description: |
   A library to help build command-line programs, both tools and

--- a/core-program/package.yaml
+++ b/core-program/package.yaml
@@ -17,7 +17,7 @@ license: MIT
 license-file: LICENSE
 author: Andrew Cowie <istathar@gmail.com>
 maintainer: Andrew Cowie <istathar@gmail.com>
-copyright: © 2018-2022 Athae Eredh Siniath and Others
+copyright: © 2018-2023 Athae Eredh Siniath and Others
 tested-with: GHC == 8.10.7, GHC == 9.2.5
 category: System
 ghc-options: -Wall -Wwarn -fwarn-tabs

--- a/core-telemetry/core-telemetry.cabal
+++ b/core-telemetry/core-telemetry.cabal
@@ -23,12 +23,12 @@ homepage:       https://github.com/aesiniath/unbeliever#readme
 bug-reports:    https://github.com/aesiniath/unbeliever/issues
 author:         Andrew Cowie <istathar@gmail.com>
 maintainer:     Andrew Cowie <istathar@gmail.com>
-copyright:      © 2021-2022 Athae Eredh Siniath and Others
+copyright:      © 2021-2023 Athae Eredh Siniath and Others
 license:        MIT
 license-file:   LICENSE
 build-type:     Simple
 tested-with:
-    GHC == 8.10.7
+    GHC == 8.10.7, GHC == 9.2.5
 extra-doc-files:
     HoneycombTraceExample.png
     honeycomb-sad-trace.png

--- a/core-telemetry/package.yaml
+++ b/core-telemetry/package.yaml
@@ -18,8 +18,8 @@ license: MIT
 license-file: LICENSE
 author: Andrew Cowie <istathar@gmail.com>
 maintainer: Andrew Cowie <istathar@gmail.com>
-copyright: © 2021-2022 Athae Eredh Siniath and Others
-tested-with: GHC == 8.10.7
+copyright: © 2021-2023 Athae Eredh Siniath and Others
+tested-with: GHC == 8.10.7, GHC == 9.2.5
 category: System
 ghc-options: -Wall -Wwarn -fwarn-tabs
 github: aesiniath/unbeliever

--- a/core-text/core-text.cabal
+++ b/core-text/core-text.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.18
 
--- This file has been generated from package.yaml by hpack version 0.35.0.
+-- This file has been generated from package.yaml by hpack version 0.35.1.
 --
 -- see: https://github.com/sol/hpack
 
@@ -27,7 +27,7 @@ homepage:       https://github.com/aesiniath/unbeliever#readme
 bug-reports:    https://github.com/aesiniath/unbeliever/issues
 author:         Andrew Cowie <istathar@gmail.com>
 maintainer:     Andrew Cowie <istathar@gmail.com>
-copyright:      © 2018-2022 Athae Eredh Siniath and Others
+copyright:      © 2018-2023 Athae Eredh Siniath and Others
 license:        MIT
 license-file:   LICENSE
 build-type:     Simple

--- a/core-text/package.yaml
+++ b/core-text/package.yaml
@@ -22,7 +22,7 @@ license: MIT
 license-file: LICENSE
 author: Andrew Cowie <istathar@gmail.com>
 maintainer: Andrew Cowie <istathar@gmail.com>
-copyright: © 2018-2022 Athae Eredh Siniath and Others
+copyright: © 2018-2023 Athae Eredh Siniath and Others
 tested-with: GHC == 8.10.7, GHC == 9.2.5
 category: System
 ghc-options: -Wall -Wwarn -fwarn-tabs

--- a/core-webserver-servant/core-webserver-servant.cabal
+++ b/core-webserver-servant/core-webserver-servant.cabal
@@ -19,7 +19,7 @@ homepage:       https://github.com/aesiniath/unbeliever#readme
 bug-reports:    https://github.com/aesiniath/unbeliever/issues
 author:         Carlos D'Agostino <carlos.dagostino@gmail.com>
 maintainer:     Andrew Cowie <istathar@gmail.com>
-copyright:      © 2021-2022 Athae Eredh Siniath and Others
+copyright:      © 2021-2023 Athae Eredh Siniath and Others
 license:        MIT
 license-file:   LICENSE
 build-type:     Simple

--- a/core-webserver-servant/package.yaml
+++ b/core-webserver-servant/package.yaml
@@ -14,7 +14,7 @@ license: MIT
 license-file: LICENSE
 author: Carlos D'Agostino <carlos.dagostino@gmail.com>
 maintainer: Andrew Cowie <istathar@gmail.com>
-copyright: © 2021-2022 Athae Eredh Siniath and Others
+copyright: © 2021-2023 Athae Eredh Siniath and Others
 tested-with: GHC == 8.10.7, GHC == 9.2.5
 category: System
 ghc-options: -Wall -Wwarn -fwarn-tabs

--- a/core-webserver-warp/core-webserver-warp.cabal
+++ b/core-webserver-warp/core-webserver-warp.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.0.
+-- This file has been generated from package.yaml by hpack version 0.35.1.
 --
 -- see: https://github.com/sol/hpack
 
@@ -19,7 +19,7 @@ homepage:       https://github.com/aesiniath/unbeliever#readme
 bug-reports:    https://github.com/aesiniath/unbeliever/issues
 author:         Andrew Cowie <istathar@gmail.com>
 maintainer:     Andrew Cowie <istathar@gmail.com>
-copyright:      © 2021-2022 Athae Eredh Siniath and Others
+copyright:      © 2021-2023 Athae Eredh Siniath and Others
 license:        MIT
 license-file:   LICENSE
 build-type:     Simple

--- a/core-webserver-warp/package.yaml
+++ b/core-webserver-warp/package.yaml
@@ -14,7 +14,7 @@ license: MIT
 license-file: LICENSE
 author: Andrew Cowie <istathar@gmail.com>
 maintainer: Andrew Cowie <istathar@gmail.com>
-copyright: © 2021-2022 Athae Eredh Siniath and Others
+copyright: © 2021-2023 Athae Eredh Siniath and Others
 tested-with: GHC == 8.10.7, GHC == 9.2.5
 category: System
 ghc-options: -Wall -Wwarn -fwarn-tabs

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: unbeliever
-version: 0.11.3.1
+version: 0.11.3.2
 synopsis: Opinionated Haskell Interoperability
 description: |
   A library to help build command-line programs, both tools and
@@ -29,7 +29,8 @@ description: |
   * __core-program__
   * __core-telemetry__
   * __core-webserver-warp__
-  * __core-webservver-servant__
+  * __core-webserver-servant__
+  * __core-effect-effectful__
   
   with more forthcoming as we continue to add convenince and
   interoperability wrappers around streaming, webservers, and database
@@ -40,7 +41,7 @@ license: MIT
 license-file: LICENSE
 author: Andrew Cowie <istathar@gmail.com>
 maintainer: Andrew Cowie <istathar@gmail.com>
-copyright: © 2018-2022 Athae Eredh Siniath and Others
+copyright: © 2018-2023 Athae Eredh Siniath and Others
 tested-with: GHC == 9.2.5
 category: System
 ghc-options: -Wall -Wwarn -fwarn-tabs

--- a/unbeliever.cabal
+++ b/unbeliever.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           unbeliever
-version:        0.11.3.1
+version:        0.11.3.2
 synopsis:       Opinionated Haskell Interoperability
 description:    A library to help build command-line programs, both tools and
                 longer-running daemons. Its @Program@ type provides unified ouptut &
@@ -34,7 +34,8 @@ description:    A library to help build command-line programs, both tools and
                 * __core-program__
                 * __core-telemetry__
                 * __core-webserver-warp__
-                * __core-webservver-servant__
+                * __core-webserver-servant__
+                * __core-effect-effectful__
                 .
                 with more forthcoming as we continue to add convenince and
                 interoperability wrappers around streaming, webservers, and database
@@ -45,7 +46,7 @@ homepage:       https://github.com/aesiniath/unbeliever#readme
 bug-reports:    https://github.com/aesiniath/unbeliever/issues
 author:         Andrew Cowie <istathar@gmail.com>
 maintainer:     Andrew Cowie <istathar@gmail.com>
-copyright:      © 2018-2022 Athae Eredh Siniath and Others
+copyright:      © 2018-2023 Athae Eredh Siniath and Others
 license:        MIT
 license-file:   LICENSE
 build-type:     Simple


### PR DESCRIPTION
I'm not sure when this snuck in (well, in at least 2021, possibly earlier) but the Core.Program.Context module is internals, and _not_ meant to be in the public documentation. I just realized that the Haddock for Core.Program was full of internals that had leaked out (because Haddock chooses a place of last resort for symbols that don't have a home). 

Returns to the circa version 0.2.12 behaviour of Core.Program.Context _not_ being exposed in the Haddock. A user who needs these symbols (why? They're internals, but anyway) can import that module directly if needed, but otherwise it's not part of the documentation.

What a mess.