### PR TITLE
Enable changing application state type in sub programs

### DIFF
--- a/core-program/core-program.cabal
+++ b/core-program/core-program.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           core-program
-version:        0.6.2.3
+version:        0.6.3.0
 synopsis:       Opinionated Haskell Interoperability
 description:    A library to help build command-line programs, both tools and
                 longer-running daemons.

--- a/core-program/lib/Core/Program/Context.hs
+++ b/core-program/lib/Core/Program/Context.hs
@@ -310,7 +310,8 @@ reason to use this; to access your top-level application data @τ@ within the
 getContext :: Program τ (Context τ)
 getContext = do
     context <- ask
-    return context
+    pure context
+{-# INLINABLE getContext #-}
 
 {- |
 Run a subprogram from within a lifted @IO@ block.

--- a/core-program/lib/Core/Program/Execute.hs
+++ b/core-program/lib/Core/Program/Execute.hs
@@ -118,6 +118,7 @@ import Control.Concurrent.MVar
     ( MVar
     , modifyMVar_
     , newEmptyMVar
+    , newMVar
     , putMVar
     , readMVar
     , tryPutMVar
@@ -602,7 +603,8 @@ changeProgram :: υ -> Program υ α -> Program τ α
 changeProgram user' program = do
     context1 <- ask
     liftIO $ do
-        context2 <- fmapContext (const user') context1
+        u <- newMVar user'
+        let context2 = context1 {applicationDataFrom = u}
         subProgram context2 program
 
 {- |

--- a/core-program/lib/Core/Program/Execute.hs
+++ b/core-program/lib/Core/Program/Execute.hs
@@ -591,11 +591,39 @@ present at the top-level when the program starts.
 While the original intent of providing an initial value of type @τ@ to
 'configure' was that your application state would be available at startup, an
 alternative pattern is to form the application state as the first actions that
-your program takes in the 'Program' @τ@ monad. This is especially true if you
+your program takes in the 'Program' @τ@ monad. This is especially common if you
 are processing command-line options. In that case, you may find it useful to
-initialize the program at type 'None' and then change to the application type
-you intend to run through the program with once the full settings object is
-available.
+initialize the program at type 'None', say, and then change to the 'Program'
+@υ@ monad you intend to run through the actual program with once the full
+settings object is available. You can do that using this function.
+
+For example:
+
+@
+main :: 'IO' ()
+main = do
+    context <- 'Core.Program.Execute.configure' \"1.0\" 'None' ('simpleConfig' ...)
+    'Core.Program.Execute.executeWith' context program1
+
+program1 :: 'Program' 'None' ()
+program1 = do
+    -- do things to form top-level application state
+    let settings =
+            Settings
+                { ...
+                }
+    
+    'changeProgram' settings program2
+
+program2 :: 'Program' Settings ()
+program2 = do
+    -- now carry on with application logic
+    ...
+@
+
+This allows your code do do 'queryOptionValue' and the like in @program1@ and
+then, once all the settings and initialization is complete, you can switch to
+the actual type you intend to run at in @program2@.
 
 @since 0.6.3
 -}

--- a/core-program/package.yaml
+++ b/core-program/package.yaml
@@ -1,5 +1,5 @@
 name: core-program
-version: 0.6.2.3
+version: 0.6.3.0
 synopsis: Opinionated Haskell Interoperability
 description: |
   A library to help build command-line programs, both tools and

--- a/tests/CheckProgramMonad.hs
+++ b/tests/CheckProgramMonad.hs
@@ -73,6 +73,24 @@ checkProgramMonad = do
                     user2 <- runProgram getApplicationState -- unlift!
                     user2 `shouldBe` user1
 
+        it "type of application state can be changed" $ do
+            context <- configure "0.1" None blankConfig
+            executeWith context $ do
+                user1 <- getApplicationState
+                liftIO $ do
+                    user1 `shouldBe` None
+
+                let truth = True
+                changeProgram truth $ do
+                    user' <- getApplicationState
+                    liftIO $ do
+                        user' `shouldBe` True
+
+                user2 <- getApplicationState
+                liftIO $ do
+                    user2 `shouldBe` None
+
+
         it "thrown Exceptions can be caught" $ do
             context <- configure "0.1" None blankConfig
             (subProgram context (throw Boom)) `shouldThrow` boom
@@ -110,4 +128,4 @@ checkProgramMonad = do
 
     describe "Package metadata" $ do
         it "the source location is accessible" $ do
-            render 80 __LOCATION__ `shouldBe` "tests/CheckProgramMonad.hs:113"
+            render 80 __LOCATION__ `shouldBe` "tests/CheckProgramMonad.hs:131"


### PR DESCRIPTION
Introduce `changeProgram` to go from one top level type, Program τ, to another, Program υ.

This enables you to switch from a simple type when starting your application (Program None, say) to the actual user data type you intend to run at (Program Settings or whatever) once initialization is complete, thereby avoiding the hassle of needing an `mempty` value for the settings type just so you can get past `configure`.

Credit to @guaraqe who had the idea that this would be useful.