### PR TITLE
Invoke (and replace with) external processes

### DIFF
--- a/core-program/core-program.cabal
+++ b/core-program/core-program.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           core-program
-version:        0.6.3.0
+version:        0.6.4.0
 synopsis:       Opinionated Haskell Interoperability
 description:    A library to help build command-line programs, both tools and
                 longer-running daemons.

--- a/core-program/lib/Core/Program/Context.hs
+++ b/core-program/lib/Core/Program/Context.hs
@@ -175,7 +175,9 @@ data Context τ = Context
     , exitSemaphoreFrom :: MVar ExitCode
     , startTimeFrom :: MVar Time
     , verbosityLevelFrom :: MVar Verbosity
+    , outputSemaphoreFrom :: MVar ()
     , outputChannelFrom :: TQueue (Maybe Rope) -- communication channels
+    , telemetrySemaphoreFrom :: MVar ()
     , telemetryChannelFrom :: TQueue (Maybe Datum) -- machinery for telemetry
     , telemetryForwarderFrom :: Maybe Forwarder
     , currentScopeFrom :: TVar (Set ThreadId)
@@ -370,6 +372,8 @@ configure version t config = do
     columns <- getConsoleWidth
     coloured <- getConsoleColoured
     level <- newEmptyMVar
+    vo <- newEmptyMVar
+    vl <- newEmptyMVar
     out <- newTQueueIO
     tel <- newTQueueIO
 
@@ -389,7 +393,9 @@ configure version t config = do
             , exitSemaphoreFrom = q
             , startTimeFrom = i
             , verbosityLevelFrom = level -- will be filled in handleVerbosityLevel
+            , outputSemaphoreFrom = vo
             , outputChannelFrom = out
+            , telemetrySemaphoreFrom = vl
             , telemetryChannelFrom = tel
             , telemetryForwarderFrom = Nothing
             , currentScopeFrom = scope

--- a/core-program/lib/Core/Program/Execute.hs
+++ b/core-program/lib/Core/Program/Execute.hs
@@ -683,7 +683,7 @@ Keep in mind that this isn't invoking a shell; arguments and their values have
 to be enumerated separately:
 
 @
-    'readProcessExternal' [\"\/usr\/bin\/ssh\", \"-l\", \"admin\", \"203.0.113.42\", \"\\\'remote command here\\\'\"]
+    'readProcess' [\"\/usr\/bin\/ssh\", \"-l\", \"admin\", \"203.0.113.42\", \"\\\'remote command here\\\'\"]
 @
 
 having to write out the individual options and arguments and deal with
@@ -694,7 +694,7 @@ and its entire @stderr@, if any. Note that this is not a streaming interface,
 so if you're doing something that returns huge amounts of output you'll want
 to use something like __io-streams__ instead.
 
-(this wraps __typed-process__'s 'readProcess')
+(this wraps __typed-process__'s 'System.Process.Typed.readProcess')
 
 @since 0.6.4
 -}
@@ -731,7 +731,7 @@ not change.
 
 This function does not return.
 
-As with 'readProcessExternal' above, each of the arguments to the new process
+As with 'readProcess' above, each of the arguments to the new process
 must be supplied as individual values in the list. The first argument is the
 name of the binary to be executed. The @PATH@ will be searched for the binary
 if an absolute path is not given; an exception will be thrown if it is not

--- a/core-program/lib/Core/Program/Execute.hs
+++ b/core-program/lib/Core/Program/Execute.hs
@@ -82,8 +82,6 @@ module Core.Program.Execute
       -- * Useful actions
     , outputEntire
     , inputEntire
-    , readExternalProcess
-    , execExternalProcess
     , sleepThread
     , resetTimer
     , trap_
@@ -92,6 +90,10 @@ module Core.Program.Execute
     , catch
     , throw
     , try
+
+      -- * Running processes
+    , readExternalProcess
+    , execExternalProcess
 
       -- * Internals
     , Context
@@ -694,6 +696,8 @@ so if you're doing something that returns huge amounts of output you'll want
 to use something like __io-streams__ instead.
 
 (this wraps __typed-process__'s 'readProcess')
+
+@since 0.6.4
 -}
 readExternalProcess :: [Rope] -> Program τ (ExitCode, Rope, Rope)
 readExternalProcess [] = error "No command provided"
@@ -732,7 +736,7 @@ As with 'readProcessExternal' above, each of the arguments to the new process
 must be supplied as individual values in the list. The first argument is the
 name of the binary to be executed.
 
-(this function wraps __unix__'s 'executeFile' machinery, which results in an
+(this wraps __unix__'s 'executeFile' machinery, which results in an
 /execvp(2)/ system call)
 
 @since 0.6.4
@@ -761,7 +765,6 @@ execExternalProcess (cmd : args) = do
                 atomically $ do
                     writeTQueue tel Nothing
                     writeTQueue out Nothing
-
 
                 _ <- forkIO $ do
                     threadDelay 10000000

--- a/core-program/package.yaml
+++ b/core-program/package.yaml
@@ -1,5 +1,5 @@
 name: core-program
-version: 0.6.3.0
+version: 0.6.4.0
 synopsis: Opinionated Haskell Interoperability
 description: |
   A library to help build command-line programs, both tools and

--- a/tests/Snippet.hs
+++ b/tests/Snippet.hs
@@ -19,4 +19,4 @@ main = execute $ do
             debugS "value" i
 
     warn "Executing new process"
-    execExternalProcess ["/bin/echo", "Hello World"]
+    execProcess_ ["echo", "Hello World"]

--- a/tests/Snippet.hs
+++ b/tests/Snippet.hs
@@ -1,50 +1,22 @@
-{-# LANGUAGE AllowAmbiguousTypes #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE QuasiQuotes #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE TypeOperators #-}
 {-# OPTIONS_GHC -fno-warn-missing-signatures #-}
 {-# OPTIONS_GHC -fno-warn-unused-do-bind #-}
 {-# OPTIONS_GHC -fno-warn-unused-imports #-}
 {-# OPTIONS_GHC -fno-warn-unused-top-binds #-}
 
-import Core.Effect.Effectful
+import Control.Monad (forM_)
 import Core.Program
 import Core.System
 import Core.Text
 import Data.ByteString.Char8 qualified as C
-import Effectful qualified as Effect
-import Effectful.Environment qualified as Effect
-import Effectful.Internal.Effect (type (:>))
 
 main :: IO ()
 main = execute $ do
-    context <- getContext
-    liftIO $ do
-        Effect.runEff $ do
-            --         Effect.runEnvironment $ do
-            --             Effect.getProgName
-            -- debugS "name" name
-            runProgramE context $ do
-                thing
+    info "Begin"
+    forkThread $ do
+        forM_ [1 :: Int ..] $ \i -> do
+            debugS "value" i
 
-    write "Done"
-
-thing :: (Effect.IOE :> es, ProgramE τ :> es) => Effect.Eff es ()
-thing = do
-    withEffect $ \runEffect -> do
-        info "Running in Program"
-
-        name <- runEffect $ do
-            -- an example of something that needs IOE
-            Effect.runEnvironment $ do
-                Effect.getProgName
-
-        debugS "name" (name :: String)
-
-        info "Done running effects"
-
-        pure ()
+    warn "Executing new process"
+    execExternalProcess ["/bin/echo", "Hello World"]


### PR DESCRIPTION
Add new action `execExternalProcess`, to wrap the _execvp(2)_ system call.

Move the output and logging semaphore MVars to the Context τ type, so that they can be used by this function to ensure the output is flushed before exec'ing.

Rename (and deprecate) `execProcess` to `readExternalProcess`.
