### PR TITLE
Allow for overriding the default honeycomb host

### DIFF
--- a/core-telemetry/core-telemetry.cabal
+++ b/core-telemetry/core-telemetry.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           core-telemetry
-version:        0.2.7.3
+version:        0.2.8.0
 synopsis:       Advanced telemetry
 description:    This is part of a library to help build command-line programs, both tools and
                 longer-running daemons.

--- a/core-telemetry/lib/Core/Telemetry/Honeycomb.hs
+++ b/core-telemetry/lib/Core/Telemetry/Honeycomb.hs
@@ -22,6 +22,19 @@ If you annotate your program with spans, you can get a trace like this:
 
 ![Example Trace](HoneycombTraceExample.png)
 
+This library by default will upload telemetry information to the default
+Honeycomb endpoint at 'api.honeycomb.io'. However, it also offers support for
+the Honeycomb Refinery when specifying a host override, such as:
+
+@
+\$ __export HONEYCOMB_OVERRIDE_HOST=my-refinery-service.internal__
+@
+
+The library still assumes that the service is running on port 443 and
+behind SSL.
+
+More details on Refinery: <https://docs.honeycomb.io/manage-data-volume/refinery/>
+
 /Notice/
 
 This library is Open Source but the Honeycomb service is /not/. Honeycomb

--- a/core-telemetry/lib/Core/Telemetry/Honeycomb.hs
+++ b/core-telemetry/lib/Core/Telemetry/Honeycomb.hs
@@ -105,8 +105,6 @@ type Dataset = Rope
 
 type ApiKey = Rope
 
-type HoneycombHost = Hostname
-
 {- |
 Configure your application to send telemetry in the form of spans and traces
 to the Honeycomb observability service.
@@ -214,7 +212,7 @@ setupHoneycombAction context = do
             }
 
 -- use partually applied
-process :: IORef (Maybe Connection) -> HoneycombHost -> ApiKey -> Dataset -> [Datum] -> IO ()
+process :: IORef (Maybe Connection) -> Hostname -> ApiKey -> Dataset -> [Datum] -> IO ()
 process r honeycombHost apikey dataset datums = do
     let json = JsonArray (fmap convertDatumToJson datums)
     postEventToHoneycombAPI r honeycombHost apikey dataset json
@@ -267,7 +265,7 @@ convertDatumToJson datum =
                 )
     in  point
 
-acquireConnection :: IORef (Maybe Connection) -> HoneycombHost -> IO Connection
+acquireConnection :: IORef (Maybe Connection) -> Hostname -> IO Connection
 acquireConnection r honeycombHost = do
     possible <- readIORef r
     case possible of
@@ -300,7 +298,7 @@ compressBody bytes o = do
     let b = Builder.lazyByteString x'
     Streams.write (Just b) o
 
-postEventToHoneycombAPI :: IORef (Maybe Connection) -> HoneycombHost -> ApiKey -> Dataset -> JsonValue -> IO ()
+postEventToHoneycombAPI :: IORef (Maybe Connection) -> Hostname -> ApiKey -> Dataset -> JsonValue -> IO ()
 postEventToHoneycombAPI r honeycombHost apikey dataset json = attempt False
   where
     attempt retrying = do

--- a/core-telemetry/package.yaml
+++ b/core-telemetry/package.yaml
@@ -1,5 +1,5 @@
 name: core-telemetry
-version: 0.2.7.3
+version: 0.2.8.0
 synopsis: Advanced telemetry
 description: |
   This is part of a library to help build command-line programs, both tools and


### PR DESCRIPTION
Support for situations where the Honeycomb host needs a tweak, such as when using
the Refinery:

https://docs.honeycomb.io/manage-data-volume/refinery/

Adding support for an environment variable `HONEYCOMB_HOST_OVERRIDE` but
still using the default 443 port, and still assuming that the host is
behind SSL.

Bump core-telemetry to v0.2.8.0