### PR TITLE
add FromAeson class to easily bring Aeson.Value across

### DIFF
--- a/core-data/lib/Core/Data/Structures.hs
+++ b/core-data/lib/Core/Data/Structures.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralisedNewtypeDeriving #-}
 {-# LANGUAGE ImportQualifiedPost #-}
@@ -53,6 +54,7 @@ import Data.Set qualified as OrdSet
 import Data.Text qualified as T (Text)
 import Data.Text.Lazy qualified as U (Text)
 import GHC.Exts qualified as Exts (IsList (..))
+import GHC.Generics (Generic)
 
 -- Naming convention used throughout this file is (Thing u) where u is the
 -- underlying structure [from unordered-containers] wrapped in the Thing
@@ -77,7 +79,7 @@ extract the key/value pairs in a list the list will be ordered according to
 the keys' 'Ord' instance)
 -}
 newtype Map κ ν = Map (HashMap.HashMap κ ν)
-    deriving (Show, Eq, Bifoldable)
+    deriving (Show, Eq, Bifoldable, Generic)
 
 unMap :: Map κ ν -> HashMap.HashMap κ ν
 unMap (Map u) = u

--- a/package.yaml
+++ b/package.yaml
@@ -8,22 +8,22 @@ description: |
   put top-level application state. There's also an underlying @Rope@ text
   type built on a finger tree of UTF-8 fragments along with conveniences
   for pretty printing and colourizing terminal output.
-  
+
   A description of this package, a list of features, and some background
   to its design is contained in the
   <https://github.com/aesiniath/unbeliever/blob/master/README.markdown README>
   on GitHub.
-  
+
   Useful starting points in the documentation are
   <../core-program/docs/Core-Program-Execute.html Core.Program.Execute> and
   <../core-text/docs/Core-Text-Rope.html Core.Text.Rope>.
-  
+
   An ancillary purpose of this library is to facilitate interoperability
   between different package families and ecosystems. Having a single
   batteries-included package (as was originally the case) made using it
   easier, but the resulting dependency footprint was considerable and
   growing. The code is thus now spread across several packages:
-  
+
   * __core-text__
   * __core-data__
   * __core-program__
@@ -31,7 +31,7 @@ description: |
   * __core-webserver-warp__
   * __core-webserver-servant__
   * __core-effect-effectful__
-  
+
   with more forthcoming as we continue to add convenince and
   interoperability wrappers around streaming, webservers, and database
   access patterns.
@@ -135,6 +135,7 @@ tests:
      - CheckRopeBehaviour
      - CheckTelemetryMachinery
      - CheckTimeStamp
+     - CheckFromAesonInstance
      - CheckWebserverIntegration
 
 benchmarks:
@@ -146,5 +147,5 @@ benchmarks:
     ghc-options: -threaded
     source-dirs:
      - bench
-    main: GeneralPerformance.hs 
+    main: GeneralPerformance.hs
     other-modules: []

--- a/tests/CheckFromAesonInstance.hs
+++ b/tests/CheckFromAesonInstance.hs
@@ -1,0 +1,28 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -fno-warn-missing-signatures #-}
+
+module CheckFromAesonInstance where
+
+import Core.Data
+import Core.Encoding.Json
+import Data.Aeson
+import Data.Aeson.Types
+import Test.Hspec
+
+k = JsonKey "intro"
+
+v = JsonString "Hello"
+
+j = JsonObject (intoMap [(k, v)])
+
+r = JsonArray [JsonBool False, JsonNull, JsonNumber 42]
+
+checkFromAesonInstance :: Spec
+checkFromAesonInstance = do
+    describe "fromAeson should transform" $ do
+        it "Aeson.String to JsonString" $ do
+            fromAeson (String "Hello") `shouldBe` v
+        it "Aeson.Object to JsonObject" $ do
+            fromAeson (object ["intro" .= String "Hello"]) `shouldBe` j
+        it "JsonList to Aeson.List" $ do
+            fromAeson (listValue id [Bool False, Null, Number 42]) `shouldBe` r

--- a/tests/TestSuite.hs
+++ b/tests/TestSuite.hs
@@ -4,6 +4,7 @@ import CheckArgumentsParsing (checkArgumentsParsing)
 import CheckBytesBehaviour
 import CheckContainerBehaviour
 import CheckExternalizing (checkExternalizing)
+import CheckFromAesonInstance
 import CheckJsonWrapper
 import CheckProgramMonad
 import CheckRopeBehaviour (checkRopeBehaviour)
@@ -29,3 +30,4 @@ suite = do
     checkProgramMonad
     checkTelemetryMachinery
     checkWebserverIntegration
+    checkFromAesonInstance

--- a/unbeliever.cabal
+++ b/unbeliever.cabal
@@ -119,6 +119,7 @@ test-suite check
       CheckRopeBehaviour
       CheckTelemetryMachinery
       CheckTimeStamp
+      CheckFromAesonInstance
       CheckWebserverIntegration
   hs-source-dirs:
       tests


### PR DESCRIPTION
I spent an inordinate time this afternoon on `ToJSON` and `FromJSON` only to realise the internal `Parser` type in **Aeson** is from **Attoparsec** and is really concerned with `ByteString`.

While what I needed was interoperability between `JsonValue` and `Aeson.Value`. Yes, the easiest win would always be to use `fromAeson`, which I did.

This is all so we don't waste time transforming strings. Maybe we should just expose `fromAeson` as it was before and be done with it.