### PR TITLE
Fix forward links, again

### DIFF
--- a/core-text/lib/Core/Text/Utilities.hs
+++ b/core-text/lib/Core/Text/Utilities.hs
@@ -94,8 +94,9 @@ Types which can be rendered "prettily", that is, formatted by a pretty printer
 and embossed with beautiful ANSI colours when printed to the terminal.
 
 Use 'render' to build text object for later use, or
-"Control.Program.Logging"'s 'Core.Program.Logging.writeR' if you're writing
-directly to console now.
+[Control.Program.Logging](https://hackage.haskell.org/package/core-program/docs/Core-Program-Logging.html)'s
+[writeR](https://hackage.haskell.org/package/core-program/docs/Core-Program-Logging.html#v:writeR)
+if you're writing directly to console right now.
 -}
 class Render α where
     -- | Which type are the annotations of your 'Doc' going to be expressed in?


### PR DESCRIPTION
Another attempt to fix the Haddock links from [Render](https://hackage.haskell.org/package/core-text-0.3.8.1/docs/Core-Text-Utilities.html#t:Render). The last attempt in #174 didn't work because it's still trying to find the target module in **core-text** and not in **core-program**. Presumably it would work if the latter was in scope and imported, but it's not, so boo.

According to https://haskell-haddock.readthedocs.io/en/latest/markup.html#links the Markdown style `[text](url)` syntax should work, but when I do the Haddock generation locally it doesn't render properly.

(which is ironic given this is in a typeclass named Render)

Maybe this will work on Hackage but boo.