### PR TITLE
Render numbers properly

### DIFF
--- a/core-data/core-data.cabal
+++ b/core-data/core-data.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           core-data
-version:        0.3.9.0
+version:        0.3.9.1
 synopsis:       Convenience wrappers around common data structures and encodings
 description:    Wrappers around common data structures and encodings.
                 .

--- a/core-data/lib/Core/Encoding/Json.hs
+++ b/core-data/lib/Core/Encoding/Json.hs
@@ -100,11 +100,11 @@ import Core.Text.Utilities
     , breakRope
     )
 import Data.Aeson (FromJSON, Value (String))
-import qualified Data.Aeson as Aeson
+import Data.Aeson qualified as Aeson
 import Data.Char (intToDigit)
 import Data.Coerce
 import Data.Hashable (Hashable)
-import qualified Data.List as List
+import Data.List qualified as List
 import Data.Scientific
     ( FPFormat (..)
     , Scientific
@@ -112,8 +112,8 @@ import Data.Scientific
     , isFloating
     )
 import Data.String (IsString (..))
-import qualified Data.Text as T
-import qualified Data.Vector as V
+import Data.Text qualified as T
+import Data.Vector qualified as V
 import GHC.Generics
 import Prettyprinter
     ( Doc
@@ -134,7 +134,6 @@ import Prettyprinter
     , rbracket
     , sep
     , unAnnotate
-    , viaShow
     , vsep
     , (<+>)
     )
@@ -425,7 +424,12 @@ prettyValue value = case value of
         annotate QuoteToken dquote
             <> annotate StringToken (escapeText x)
             <> annotate QuoteToken dquote
-    JsonNumber x -> annotate NumberToken (viaShow x)
+    JsonNumber x ->
+        let num =
+                if isFloating x
+                    then pretty (formatScientific Generic Nothing x)
+                    else pretty (formatScientific Fixed (Just 0) x)
+        in  annotate NumberToken num
     JsonBool x -> case x of
         True -> annotate BooleanToken "true"
         False -> annotate BooleanToken "false"

--- a/core-data/lib/Core/Encoding/Json.hs
+++ b/core-data/lib/Core/Encoding/Json.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE StrictData #-}

--- a/core-data/package.yaml
+++ b/core-data/package.yaml
@@ -1,5 +1,5 @@
 name: core-data
-version: 0.3.9.0
+version: 0.3.9.1
 synopsis: Convenience wrappers around common data structures and encodings
 description: |
   Wrappers around common data structures and encodings.

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-20.11
+resolver: lts-20.15
 compiler: ghc-9.2.5
 packages:
  - ./core-data


### PR DESCRIPTION
When using the Render instance (ie `writeR` or `debugR`) on a JsonValue, numbers were showing up as `200.0` even when they weren't floating point. I thought we'd fixed that, and we HAD, but for actually encoding JsonValues to Rope / Bytes! but not when Rendering.

Replicate the trick used when actually encoding in `encodeToRope` to the Render instance.