### PR TITLE
Fix spurious timeout when using execute in GHCi

### DIFF
--- a/core-program/core-program.cabal
+++ b/core-program/core-program.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           core-program
-version:        0.6.5.0
+version:        0.6.5.1
 synopsis:       Opinionated Haskell Interoperability
 description:    A library to help build command-line programs, both tools and
                 longer-running daemons.

--- a/core-program/package.yaml
+++ b/core-program/package.yaml
@@ -1,5 +1,5 @@
 name: core-program
-version: 0.6.5.0
+version: 0.6.5.1
 synopsis: Opinionated Haskell Interoperability
 description: |
   A library to help build command-line programs, both tools and


### PR DESCRIPTION
You can use `execute` or `executeWith` in GHCi, but after 10 seconds we were getting an message about a timeout and an exit code. This was of course the 10 second timeout used to terminate the program in the event that graceful shutdown of the output and telemetry channels fails. Strangely, though, it was coming out only in GHCi.

Inspection showed the reason, pretty silly; a running process that exits eliminates the timer thread but in GHCi it runs to completion.

Simple fix: explicitly end the timeout thread before exiting.