### PR TITLE
Support TLS when launching webservers

### DIFF
--- a/core-webserver-warp/core-webserver-warp.cabal
+++ b/core-webserver-warp/core-webserver-warp.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           core-webserver-warp
-version:        0.2.0.1
+version:        0.2.1.0
 synopsis:       Interoperability with Wai/Warp
 description:    This is part of a library to help build command-line programs, both tools and
                 longer-running daemons.
@@ -53,4 +53,5 @@ library
     , vault
     , wai
     , warp
+    , warp-tls
   default-language: Haskell2010

--- a/core-webserver-warp/lib/Core/Webserver/Warp.hs
+++ b/core-webserver-warp/lib/Core/Webserver/Warp.hs
@@ -115,6 +115,10 @@ import Network.Wai.Handler.WarpTLS qualified as Warp
 Given a WAI 'Application', run a Warp webserver on the specified port from
 within the 'Program' monad.
 
+@
+    'launchWebserver' 80 application
+@
+
 (this wraps the __warp__ package)
 -}
 launchWebserver :: Port -> Application -> Program τ ()
@@ -141,7 +145,7 @@ with a TLS connection.
 For the common case of supplying a certificate and private key, you can do:
 
 @
-    let crypto = 'tlsSettings' "/path/to/certificate.crt" "/path/to/private.key"
+    let crypto = 'tlsSettings' \"\/path\/to\/certificate.crt\" \"\/path\/to\/private.key\"
     'launchWebserverTLS' crypto 443 application
 @
 

--- a/core-webserver-warp/lib/Core/Webserver/Warp.hs
+++ b/core-webserver-warp/lib/Core/Webserver/Warp.hs
@@ -69,6 +69,7 @@ observability service; this will be the root span of a trace.
 module Core.Webserver.Warp
     ( Port
     , launchWebserver
+    , launchWebserverTLS
     , requestContextKey
     , contextFromRequest
     , ContextNotFoundInRequest (..)
@@ -107,10 +108,14 @@ import Network.HTTP2.Frame
 import Network.Wai
 import Network.Wai.Handler.Warp (InvalidRequest, Port)
 import Network.Wai.Handler.Warp qualified as Warp
+import Network.Wai.Handler.WarpTLS (TLSSettings)
+import Network.Wai.Handler.WarpTLS qualified as Warp
 
 {- |
 Given a WAI 'Application', run a Warp webserver on the specified port from
 within the 'Program' monad.
+
+(this wraps the __warp__ package)
 -}
 launchWebserver :: Port -> Application -> Program τ ()
 launchWebserver port application = do
@@ -122,6 +127,40 @@ launchWebserver port application = do
                 $ Warp.defaultSettings
     liftIO $ do
         Warp.runSettings
+            settings
+            ( loggingMiddleware
+                context
+                application
+            )
+
+{- |
+Given a WAI 'Application', run a Warp webserver on the specified port from
+within the 'Program' monad. This variant of 'launchWebserver' runs the server
+with a TLS connection.
+
+For the common case of supplying a certificate and private key, you can do:
+
+@
+    let crypto = 'tlsSettings' "/path/to/certificate.crt" "/path/to/private.key"
+    'launchWebserverTLS' crypto 443 application
+@
+
+(this wraps the __warp-tls__ package; for more complex certificate management
+requirements see the documentation for the 'TLSSettings' type there)
+
+@since 0.2.1
+-}
+launchWebserverTLS :: TLSSettings -> Port -> Application -> Program τ ()
+launchWebserverTLS crypto port application = do
+    context <- getContext
+    let settings =
+            Warp.setOnException
+                (onExceptionHandler context)
+                . Warp.setPort port
+                $ Warp.defaultSettings
+    liftIO $ do
+        Warp.runTLS
+            crypto
             settings
             ( loggingMiddleware
                 context

--- a/core-webserver-warp/package.yaml
+++ b/core-webserver-warp/package.yaml
@@ -1,5 +1,5 @@
 name: core-webserver-warp
-version: 0.2.0.1
+version: 0.2.1.0
 synopsis: Interoperability with Wai/Warp
 description: |
   This is part of a library to help build command-line programs, both tools and
@@ -36,6 +36,7 @@ dependencies:
  - vault
  - wai
  - warp
+ - warp-tls
 
 library:
   dependencies: []

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-20.15
+resolver: lts-20.17
 compiler: ghc-9.2.5
 packages:
  - ./core-data


### PR DESCRIPTION
Add a new function `launchWebserverTLS` using the facilities of **warp-tls** to allow a webserver to be launched that serves requests within a TLS connection.