### PR TITLE
Allow override of dataset in Honeycomb telemetry

### DIFF
--- a/core-program/lib/Core/Program/Context.hs
+++ b/core-program/lib/Core/Program/Context.hs
@@ -79,6 +79,7 @@ data Datum = Datum
     , spanNameFrom :: Rope
     , serviceNameFrom :: Maybe Rope
     , spanTimeFrom :: Time
+    , datasetFrom :: Maybe Rope
     , traceIdentifierFrom :: Maybe Trace
     , parentIdentifierFrom :: Maybe Span
     , durationFrom :: Maybe Int64
@@ -93,6 +94,7 @@ emptyDatum =
         , spanNameFrom = emptyRope
         , serviceNameFrom = Nothing
         , spanTimeFrom = epochTime
+        , datasetFrom = Nothing
         , traceIdentifierFrom = Nothing
         , parentIdentifierFrom = Nothing
         , durationFrom = Nothing
@@ -313,7 +315,7 @@ getContext :: Program τ (Context τ)
 getContext = do
     context <- ask
     pure context
-{-# INLINABLE getContext #-}
+{-# INLINEABLE getContext #-}
 
 {- |
 Run a subprogram from within a lifted @IO@ block.

--- a/core-telemetry/core-telemetry.cabal
+++ b/core-telemetry/core-telemetry.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           core-telemetry
-version:        0.2.8.0
+version:        0.2.9.0
 synopsis:       Advanced telemetry
 description:    This is part of a library to help build command-line programs, both tools and
                 longer-running daemons.
@@ -28,7 +28,7 @@ license:        MIT
 license-file:   LICENSE
 build-type:     Simple
 tested-with:
-    GHC == 8.10.7, GHC == 9.2.5
+    GHC == 8.10.7, GHC == 9.2.7
 extra-doc-files:
     HoneycombTraceExample.png
     honeycomb-sad-trace.png

--- a/core-telemetry/package.yaml
+++ b/core-telemetry/package.yaml
@@ -1,5 +1,5 @@
 name: core-telemetry
-version: 0.2.8.0
+version: 0.2.9.0
 synopsis: Advanced telemetry
 description: |
   This is part of a library to help build command-line programs, both tools and
@@ -19,7 +19,7 @@ license-file: LICENSE
 author: Andrew Cowie <istathar@gmail.com>
 maintainer: Andrew Cowie <istathar@gmail.com>
 copyright: © 2021-2023 Athae Eredh Siniath and Others
-tested-with: GHC == 8.10.7, GHC == 9.2.5
+tested-with: GHC == 8.10.7, GHC == 9.2.7
 category: System
 ghc-options: -Wall -Wwarn -fwarn-tabs
 github: aesiniath/unbeliever


### PR DESCRIPTION
Add a `setDatasetName` function to allow override of the dataset being used for telemetry being sent to Honeycomb.

This involved partitioning telemetry Datums by which Dataset they were assigned to, then making different requests in each burst of telemetry accordingly (annoyingly, it's not a field but rather part of the context path in the API request).