### PR TITLE
Document querying of Git repository information in fromPackage

### DIFF
--- a/core-program/core-program.cabal
+++ b/core-program/core-program.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           core-program
-version:        0.6.7.0
+version:        0.6.7.1
 synopsis:       Opinionated Haskell Interoperability
 description:    A library to help build command-line programs, both tools and
                 longer-running daemons.

--- a/core-program/lib/Core/Program/Arguments.hs
+++ b/core-program/lib/Core/Program/Arguments.hs
@@ -1009,8 +1009,7 @@ buildVersion version =
         description = gitDescriptionFrom version
     in
         pretty project
-            <+> "v"
-                <> pretty number
+            <+> pretty number
                 <> if null description
                     then hardline
                     else "," <+> pretty description <> hardline

--- a/core-program/lib/Core/Program/Metadata.hs
+++ b/core-program/lib/Core/Program/Metadata.hs
@@ -127,9 +127,15 @@ fromPackage :: Q Exp
 fromPackage = do
     pairs <- readCabalFile
 
-    let name = fromMaybe "" . lookupKeyValue "name" $ pairs
-    let synopsis = fromMaybe "" . lookupKeyValue "synopsis" $ pairs
-    let version = fromMaybe "" . lookupKeyValue "version" $ pairs
+    let name = case lookupKeyValue "name" pairs of
+            Nothing -> ""
+            Just value -> value
+    let synopsis = case lookupKeyValue "synopsis" pairs of
+            Nothing -> ""
+            Just value -> value
+    let version = case lookupKeyValue "version" pairs of
+            Nothing -> ""
+            Just value -> "v" <> value
 
     possibleInfo <- readGitRepository
 

--- a/core-program/package.yaml
+++ b/core-program/package.yaml
@@ -1,5 +1,5 @@
 name: core-program
-version: 0.6.7.0
+version: 0.6.7.1
 synopsis: Opinionated Haskell Interoperability
 description: |
   A library to help build command-line programs, both tools and


### PR DESCRIPTION
Expand the Haddock documentation concerning the `fromPackage` splice and the retrieval of the Git information fields of Version.

Simplify the code relating to the use of the symbolic `v` marker in version strings.