### PR TITLE
Ensure metrics evaluated before adding

### DIFF
--- a/core-telemetry/core-telemetry.cabal
+++ b/core-telemetry/core-telemetry.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           core-telemetry
-version:        0.2.9.1
+version:        0.2.9.2
 synopsis:       Advanced telemetry
 description:    This is part of a library to help build command-line programs, both tools and
                 longer-running daemons.

--- a/core-telemetry/lib/Core/Telemetry/Observability.hs
+++ b/core-telemetry/lib/Core/Telemetry/Observability.hs
@@ -203,7 +203,7 @@ JSON values of type string, number, or boolean. You create these using the
 -- a bit specific to Honeycomb's very limited data model, but what else is
 -- there?
 data MetricValue
-    = MetricValue JsonKey JsonValue
+    = MetricValue !JsonKey !JsonValue
     deriving (Show)
 
 {- |
@@ -661,14 +661,14 @@ telemetry values = do
         modifyMVar_
             v
             ( \datum -> do
-                let meta = attachedMetadataFrom datum
+                let !meta = attachedMetadataFrom datum
 
                 -- update the map
-                let meta' = List.foldl' f meta values
+                let !meta' = List.foldl' f meta values
 
                 -- replace the map back into the Datum (and thereby back into the
                 -- Context), updating it
-                let datum' =
+                let !datum' =
                         datum
                             { attachedMetadataFrom = meta'
                             }
@@ -676,7 +676,7 @@ telemetry values = do
             )
   where
     f :: Map JsonKey JsonValue -> MetricValue -> Map JsonKey JsonValue
-    f acc (MetricValue k@(JsonKey text) v) =
+    f !acc (MetricValue !k@(JsonKey text) !v) =
         if nullRope text
             then error "Empty metric field name not allowed"
             else insertKeyValue k v acc
@@ -711,12 +711,12 @@ sendEvent label values = do
         let v = currentDatumFrom context
         datum <- readMVar v
 
-        let meta = attachedMetadataFrom datum
+        let !meta = attachedMetadataFrom datum
 
         -- update the map
-        let meta' = List.foldl' f meta values
+        let !meta' = List.foldl' f meta values
         -- replace the map back into the Datum and queue for sending
-        let datum' =
+        let !datum' =
                 datum
                     { spanNameFrom = label
                     , spanIdentifierFrom = Nothing
@@ -730,7 +730,7 @@ sendEvent label values = do
             writeTQueue tel (Just datum')
   where
     f :: Map JsonKey JsonValue -> MetricValue -> Map JsonKey JsonValue
-    f acc (MetricValue k@(JsonKey text) v) =
+    f !acc (MetricValue !k@(JsonKey text) !v) =
         if nullRope text
             then error "Empty metric field name not allowed"
             else insertKeyValue k v acc

--- a/core-telemetry/package.yaml
+++ b/core-telemetry/package.yaml
@@ -1,5 +1,5 @@
 name: core-telemetry
-version: 0.2.9.1
+version: 0.2.9.2
 synopsis: Advanced telemetry
 description: |
   This is part of a library to help build command-line programs, both tools and


### PR DESCRIPTION
We've had some suggestions that _maybe_ we're getting a bit of delayed exception problems when using `encloseSpan`. The evidence is circumstantial, but it could be that the `catch ... SomeException` in Core.Telemetry.Honeycomb is at last what's actually forcing a value that was, in fact, going to bear an exception.

We know we are using the telemetry values submitted, so better to just get on with evaluating them at the use site rather than risking it for later.