### PR TITLE
Enable launching child processes

### DIFF
--- a/core-program/core-program.cabal
+++ b/core-program/core-program.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           core-program
-version:        0.6.7.1
+version:        0.6.8.0
 synopsis:       Opinionated Haskell Interoperability
 description:    A library to help build command-line programs, both tools and
                 longer-running daemons.

--- a/core-program/core-program.cabal
+++ b/core-program/core-program.cabal
@@ -68,6 +68,7 @@ library
     , hourglass
     , mtl
     , prettyprinter >=1.6.2
+    , process
     , safe-exceptions
     , stm
     , template-haskell >=2.14 && <3

--- a/core-program/lib/Core/Program/Execute.hs
+++ b/core-program/lib/Core/Program/Execute.hs
@@ -784,7 +784,30 @@ execProcess_ (cmd : args) = do
                 -- does not return
                 _ <- Posix.executeFile cmd' True args' Nothing
                 pure ()
+{- |
+Execute an external child process and wait for it to finish. The command is
+specified first and and subsequent arguments as elements of the list. This
+helper then logs the command being executed to the debug output, which can be
+useful when you're trying to find out what exactly what program is being
+invoked.
 
+The output of the child process (its @stdout@) will go to the terminal console
+independently of your parent process's output. If your Haskell program does
+anything concurrently then anything it 'Core.Program.Logging.write's will be
+interleaved and probably make a mess of the child's output. So don't do that.
+
+See the similar 'readProcess' for an action which executes an external program
+but which returns its output.
+
+If the thread invoking 'callProcess' receives an interrupting asynchronous
+exception then it will terminate the child, waiting for it to exit.
+
+(this wraps __typed-process__'s 'System.Process.Typed.runProcess' but follows
+the naming convention of the underlying 'System.Process.callProcess' code from
+__process__.)
+
+@since 0.6.8
+-}
 callProcess :: [Rope] -> Program τ ExitCode
 callProcess [] = error "No command provided"
 callProcess (cmd : args) =

--- a/core-program/package.yaml
+++ b/core-program/package.yaml
@@ -28,28 +28,29 @@ dependencies:
  - bytestring
  - hashable >= 1.2
  - prettyprinter >= 1.6.2
+ - directory
+ - exceptions
+ - filepath
+ - fsnotify
+ - githash
+ - hourglass
+ - mtl
+ - process
+ - safe-exceptions
+ - stm
  - template-haskell >= 2.14 && < 3
+ - terminal-size
  - text
  - text-short
+ - transformers
  - typed-process
+ - unix
+ - unliftio-core
 
 library:
   dependencies:
    - core-text >= 0.3.8
    - core-data >= 0.3.8
-   - directory
-   - exceptions
-   - filepath
-   - fsnotify
-   - githash
-   - hourglass
-   - mtl
-   - safe-exceptions
-   - stm
-   - terminal-size
-   - transformers
-   - unix
-   - unliftio-core
   source-dirs: lib
   exposed-modules:
    - Core.Program

--- a/core-program/package.yaml
+++ b/core-program/package.yaml
@@ -1,5 +1,5 @@
 name: core-program
-version: 0.6.7.1
+version: 0.6.8.0
 synopsis: Opinionated Haskell Interoperability
 description: |
   A library to help build command-line programs, both tools and

--- a/core-telemetry/lib/Core/Telemetry/Honeycomb.hs
+++ b/core-telemetry/lib/Core/Telemetry/Honeycomb.hs
@@ -368,7 +368,6 @@ postEventToHoneycombAPI r honeycombHost apikey dataset json = attempt False
                 cleanupConnection r
                 case retrying of
                     False -> do
-                        putStrLn "internal: Reconnecting to Honeycomb"
                         attempt True
                     True -> do
                         putStrLn "internal: Failed to re-establish connection to Honeycomb"

--- a/core-webserver-warp/lib/Core/Webserver/Warp.hs
+++ b/core-webserver-warp/lib/Core/Webserver/Warp.hs
@@ -40,7 +40,7 @@ You can then describe your webservice 'Application', for example
 @
 application :: 'Application'
 application = request sendResponse =
-    sendResponse ('Network.WAI.responseLBS' 'Network.HTTP.Types.status200' [] \"Hello World\")
+    sendResponse ('Network.Wai.responseLBS' 'Network.HTTP.Types.status200' [] \"Hello World\")
 @
 
 performs the heroic duty of replying to you with the given string. In

--- a/tests/Snippet.hs
+++ b/tests/Snippet.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# OPTIONS_GHC -fno-warn-missing-signatures #-}
 {-# OPTIONS_GHC -fno-warn-unused-do-bind #-}
 {-# OPTIONS_GHC -fno-warn-unused-imports #-}


### PR DESCRIPTION
A variant of `readProcess` (which gets the child's output) is `callProcess`, which just runs a child and waits for it to finish. This branch adds a wrapper around that function.