### PR TITLE
Defensive upper bound on http2 package

### DIFF
--- a/core-webserver-warp/core-webserver-warp.cabal
+++ b/core-webserver-warp/core-webserver-warp.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           core-webserver-warp
-version:        0.2.1.0
+version:        0.2.1.1
 synopsis:       Interoperability with Wai/Warp
 description:    This is part of a library to help build command-line programs, both tools and
                 longer-running daemons.
@@ -47,7 +47,7 @@ library
     , core-telemetry >=0.2.7
     , core-text
     , http-types
-    , http2
+    , http2 <4
     , mtl
     , safe-exceptions
     , vault

--- a/core-webserver-warp/package.yaml
+++ b/core-webserver-warp/package.yaml
@@ -1,5 +1,5 @@
 name: core-webserver-warp
-version: 0.2.1.0
+version: 0.2.1.1
 synopsis: Interoperability with Wai/Warp
 description: |
   This is part of a library to help build command-line programs, both tools and
@@ -30,7 +30,7 @@ dependencies:
  - core-telemetry >= 0.2.7
  - core-text
  - http-types
- - http2
+ - http2 < 4
  - mtl
  - safe-exceptions
  - vault


### PR DESCRIPTION
I noticed that the documentation for **core-webserver-warp** wasn't building because **http2** has had a number of breaking changes related to error handling. Right now Stackage has 3.0 and upstream is at 4.1 so that'll be a mess at some point, but no biggie. Add a defensive upper bound on **http2** for the time being.