### PR TITLE
Soften requirement of http2

### DIFF
--- a/core-webserver-warp/core-webserver-warp.cabal
+++ b/core-webserver-warp/core-webserver-warp.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           core-webserver-warp
-version:        0.2.1.1
+version:        0.2.1.2
 synopsis:       Interoperability with Wai/Warp
 description:    This is part of a library to help build command-line programs, both tools and
                 longer-running daemons.
@@ -47,7 +47,7 @@ library
     , core-telemetry >=0.2.7
     , core-text
     , http-types
-    , http2 <4
+    , http2
     , mtl
     , safe-exceptions
     , vault

--- a/core-webserver-warp/lib/Core/Webserver/Warp.hs
+++ b/core-webserver-warp/lib/Core/Webserver/Warp.hs
@@ -96,14 +96,8 @@ import Network.HTTP.Types
     ( Status
     , hContentType
     , status400
-    , status413
-    , status431
     , status500
     , statusCode
-    )
-import Network.HTTP2.Frame
-    ( ErrorCodeId (UnknownErrorCode)
-    , HTTP2Error (ConnectionError)
     )
 import Network.Wai
 import Network.Wai.Handler.Warp (InvalidRequest, Port)
@@ -253,12 +247,6 @@ assignException e
     | Just (_ :: InvalidRequest) <-
         fromException e =
         (status400, intoRope (displayException e))
-    | Just (ConnectionError (UnknownErrorCode 413) t) <-
-        fromException e =
-        (status413, intoRope t)
-    | Just (ConnectionError (UnknownErrorCode 431) t) <-
-        fromException e =
-        (status431, intoRope t)
     | otherwise =
         (status500, "Internal Server Error")
 

--- a/core-webserver-warp/package.yaml
+++ b/core-webserver-warp/package.yaml
@@ -1,5 +1,5 @@
 name: core-webserver-warp
-version: 0.2.1.1
+version: 0.2.1.2
 synopsis: Interoperability with Wai/Warp
 description: |
   This is part of a library to help build command-line programs, both tools and
@@ -30,7 +30,7 @@ dependencies:
  - core-telemetry >= 0.2.7
  - core-text
  - http-types
- - http2 < 4
+ - http2
  - mtl
  - safe-exceptions
  - vault


### PR DESCRIPTION
The more recent **http2** packages have changed the internal error handling. In #186 we added an upper bound to avoid this, which is fine for Stackage `lts-20` and GHC 9.2 but if you want to move forward `nightly` has the more recent **http2** in it and that breaks things.

This branch removes the _incredibly cool_ use of guards to identify internal HTTP/2 problems and represent them as HTTP 4XX series response codes. Which was, as I say, incredibly cool, except that I'm not sure I've ever seen them actually appear.

When someone starts using HTTP/2 in anger against this library then we can certainly revisit this but in the mean time we'll soften the dependency on **http2** by not trying to use the error constructors that have been changing. That allows **core-webserver-warp** to build on GHC 9.4 and `nightly`.