### PR TITLE
Retry if Honeycomb is having a transient problem

### DIFF
--- a/core-telemetry/core-telemetry.cabal
+++ b/core-telemetry/core-telemetry.cabal
@@ -1,11 +1,11 @@
 cabal-version: 1.18
 
--- This file has been generated from package.yaml by hpack version 0.35.1.
+-- This file has been generated from package.yaml by hpack version 0.35.2.
 --
 -- see: https://github.com/sol/hpack
 
 name:           core-telemetry
-version:        0.2.9.2
+version:        0.2.9.3
 synopsis:       Advanced telemetry
 description:    This is part of a library to help build command-line programs, both tools and
                 longer-running daemons.

--- a/core-telemetry/package.yaml
+++ b/core-telemetry/package.yaml
@@ -1,5 +1,5 @@
 name: core-telemetry
-version: 0.2.9.2
+version: 0.2.9.3
 synopsis: Advanced telemetry
 description: |
   This is part of a library to help build command-line programs, both tools and


### PR DESCRIPTION
Change behaviour of the `honeycombExporter` in Core.Telemetry.Honeycomb if the Honeycomb ingestion service is having a (hopefully transient) internal problem. Now it will retry (and keep retrying) up to 1000 times with 1 second delay between attempts.

Clean up some of the internal printf's.

Closes #189.