### PR TITLE
Add timeout helper function

### DIFF
--- a/core-program/core-program.cabal
+++ b/core-program/core-program.cabal
@@ -1,11 +1,11 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.1.
+-- This file has been generated from package.yaml by hpack version 0.35.2.
 --
 -- see: https://github.com/sol/hpack
 
 name:           core-program
-version:        0.6.8.0
+version:        0.6.9.0
 synopsis:       Opinionated Haskell Interoperability
 description:    A library to help build command-line programs, both tools and
                 longer-running daemons.

--- a/core-program/lib/Core/Program/Threads.hs
+++ b/core-program/lib/Core/Program/Threads.hs
@@ -518,7 +518,7 @@ linkThread _ = pure ()
 {-|
 If a timeout is exceeded this exception will be thrown by 'timeoutThread'.
 
-@since 0.6.8
+@since 0.6.9
 -}
 data Timeout = Timeout deriving (Show)
 

--- a/core-program/lib/Core/Program/Threads.hs
+++ b/core-program/lib/Core/Program/Threads.hs
@@ -40,6 +40,8 @@ module Core.Program.Threads
     , concurrentThreads_
     , raceThreads
     , raceThreads_
+    , timeoutThread
+    , Timeout
 
       -- * Internals
     , Thread
@@ -60,6 +62,7 @@ import Control.Monad
 import Control.Monad.Reader.Class (MonadReader (ask))
 import Core.Data.Structures
 import Core.Program.Context
+import Core.Program.Execute
 import Core.Program.Logging
 import Core.System.Base
 import Core.Text.Rope
@@ -511,3 +514,29 @@ raceThreads_ one two = void (raceThreads one two)
 linkThread :: Thread α -> Program τ ()
 linkThread _ = pure ()
 {-# DEPRECATED linkThread "Exceptions are bidirectional so linkThread no longer needed" #-}
+
+data Timeout = Timeout deriving (Show)
+
+instance Exception Timeout
+
+{- |
+Run a program that needs to complete before the given number of seconds have
+elapsed. This will return the result of the sub program or throw the 'Timeout'
+exception if the limit is exceeded.
+
+@since 0.6.9
+-}
+timeoutThread :: Rational -> Program τ α -> Program τ α
+timeoutThread seconds program = do
+    result <-
+        raceThreads
+            ( do
+                sleepThread seconds
+                pure Timeout
+            )
+            ( do
+                program
+            )
+    case result of
+        Left e -> throw e
+        Right a -> pure a

--- a/core-program/lib/Core/Program/Threads.hs
+++ b/core-program/lib/Core/Program/Threads.hs
@@ -41,12 +41,12 @@ module Core.Program.Threads
     , raceThreads
     , raceThreads_
     , timeoutThread
-    , Timeout
 
       -- * Internals
     , Thread
     , unThread
     , Terminator (..)
+    , Timeout (..)
     ) where
 
 import Control.Concurrent (ThreadId, forkIO, killThread)
@@ -515,6 +515,11 @@ linkThread :: Thread α -> Program τ ()
 linkThread _ = pure ()
 {-# DEPRECATED linkThread "Exceptions are bidirectional so linkThread no longer needed" #-}
 
+{-|
+If a timeout is exceeded this exception will be thrown by 'timeoutThread'.
+
+@since 0.6.8
+-}
 data Timeout = Timeout deriving (Show)
 
 instance Exception Timeout

--- a/core-program/package.yaml
+++ b/core-program/package.yaml
@@ -1,5 +1,5 @@
 name: core-program
-version: 0.6.8.0
+version: 0.6.9.0
 synopsis: Opinionated Haskell Interoperability
 description: |
   A library to help build command-line programs, both tools and


### PR DESCRIPTION
Add new little helper function `timeoutThread` which runs a sub program with a time limit.

I'm not _entirely_ convinced that this is the right way to do this, given all the caveats listed in System.Timeout's `timeout` function, but on the other hand they rely on interrupting non-blocking I/O so presumably we would be leveraging the same thing.