### PR TITLE
Introduce worker threads

### DIFF
--- a/core-program/core-program.cabal
+++ b/core-program/core-program.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           core-program
-version:        0.6.9.0
+version:        0.6.9.1
 synopsis:       Opinionated Haskell Interoperability
 description:    A library to help build command-line programs, both tools and
                 longer-running daemons.
@@ -45,6 +45,7 @@ library
       Core.Program.Notify
       Core.Program.Threads
       Core.Program.Unlift
+      Core.Program.Workers
       Core.System
       Core.System.Base
       Core.System.External

--- a/core-program/core-program.cabal
+++ b/core-program/core-program.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           core-program
-version:        0.6.9.1
+version:        0.6.9.2
 synopsis:       Opinionated Haskell Interoperability
 description:    A library to help build command-line programs, both tools and
                 longer-running daemons.

--- a/core-program/lib/Core/Program.hs
+++ b/core-program/lib/Core/Program.hs
@@ -22,6 +22,7 @@ module Core.Program
       -- and more.
       module Core.Program.Execute
     , module Core.Program.Threads
+    , module Core.Program.Workers
     , module Core.Program.Unlift
     , module Core.Program.Metadata
     , module Core.Program.Exceptions
@@ -55,3 +56,4 @@ import Core.Program.Metadata
 import Core.Program.Notify
 import Core.Program.Threads
 import Core.Program.Unlift
+import Core.Program.Workers

--- a/core-program/lib/Core/Program/Workers.hs
+++ b/core-program/lib/Core/Program/Workers.hs
@@ -1,0 +1,152 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StrictData #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# OPTIONS_HADDOCK prune #-}
+
+{- |
+Utility functions for building programs which consume work off of a queue.
+-}
+module Core.Program.Workers
+    ( -- * Concurrency
+      runWorkers_
+    , mapWorkers
+
+      -- * Internals
+    ) where
+
+import Control.Concurrent.STM (atomically)
+import Control.Concurrent.STM.TQueue (TQueue, flushTQueue, newTQueueIO, readTQueue, unGetTQueue, writeTQueue)
+import Control.Monad
+    ( forM
+    )
+import Core.Program.Context
+import Core.Program.Threads
+import Core.System.Base
+
+{-
+-- or perhaps Foldable?
+runConcurrentThreads :: Traversable ω => Int -> (α -> Program τ β) -> ω α -> Program τ (ω β)
+runConcurrentThreads :: Limit -> (α -> Program τ β) -> [α] -> Program τ [β]
+-}
+
+{- |
+Run a pool of worker threads which consume items off a queue.
+
+You create the work queue of items by initializing a queue of 'Maybe' @α@ with
+this:
+
+@
+import "Control.Concurrent.STM.TQueue" (TQueue, newTQueueIO)
+@
+
+and
+
+@
+    queue :: 'TQueue' ('Maybe' Thing) <- 'liftIO' $ do
+        'newTQueueIO'
+
+    runWorkers_ 16 worker queue
+@
+
+If this was a queue of @α@s then it would never return. Instead it's a queue
+of 'Maybe' @α@s so that you can signal end-of-work by writing a 'Nothing' down
+the pipeline when you're finished generating input.
+
+It is assumed that the workers have a way of communicating their results
+onwards (either because they are side-effecting in the real world themselves,
+or because you have passed in some queue to collect the results, for example).
+
+@since 0.6.9
+-}
+runWorkers_ :: Int -> (α -> Program τ ()) -> TQueue (Maybe α) -> Program τ ()
+runWorkers_ n action queue = do
+    createScope $ do
+        ts <- forM [1 .. n] $ \_ -> do
+            forkThread $ do
+                loop
+        _ <- waitThreads' ts
+        pure ()
+  where
+    loop = do
+        possibleItem <- liftIO $ do
+            atomically $ do
+                readTQueue queue -- blocks
+        case possibleItem of
+            Nothing -> do
+                --
+                -- We put the Nothing back so that other workers can also shutdown.
+                --
+                liftIO $ do
+                    atomically $ do
+                        unGetTQueue queue Nothing
+            Just item -> do
+                --
+                -- Do the work
+                --
+                action item
+                loop
+
+{- |
+Map a pool of workers over a list concurrently.
+
+Simply forking one Haskell thread for every item in a list is a suprisingly
+reasonable choice in many circumstances given how good Haskell's concurrency
+machinery is, and in this library can be achieved by 'Control.Monad.forM'ing
+'forkThread' over a list of items. But if you need tighter control over the
+amount of concurrency—as is often the case when doing something
+computationally heavy or making requests of an external service with known
+limitations—then you are better off using this function.
+
+(this was originally modelled on __async__\'s
+'Control.Concurrent.Async.mapConcurrently'. That function has the drawback
+that the number of threads created is set by the size of the structure being
+traversed)
+
+@since 0.6.9
+-}
+mapWorkers :: Int -> (α -> Program τ β) -> [α] -> Program τ [β]
+mapWorkers n action list = do
+    inputs <- liftIO $ do
+        newTQueueIO :: IO (TQueue (Maybe α))
+
+    outputs <- liftIO $ do
+        newTQueueIO :: IO (TQueue β)
+
+    --
+    -- Load the input list into a queue followed by a terminator.
+    --
+
+    liftIO $ do
+        atomically $ do
+            mapM_
+                ( \item ->
+                    writeTQueue inputs (Just item)
+                )
+                list
+            writeTQueue inputs Nothing
+
+    --
+    -- Invoke the general concurrent workers tool above to process the queue.
+    --
+
+    runWorkers_
+        n
+        ( \item -> do
+            result <- action item
+            liftIO $ do
+                atomically $ do
+                    writeTQueue outputs result
+        )
+        inputs
+
+    --
+    -- Convert the results back to a list.
+
+    liftIO $ do
+        atomically $ do
+            flushTQueue outputs

--- a/core-program/lib/Core/Program/Workers.hs
+++ b/core-program/lib/Core/Program/Workers.hs
@@ -104,7 +104,7 @@ Add a list of items to the queue.
 
 @since 0.6.9
 -}
-writeQueue' :: Queue α -> [α] -> Program τ ()
+writeQueue' :: Foldable ω => Queue α -> ω α -> Program τ ()
 writeQueue' (Queue queue) items = do
     liftIO $ do
         atomically $ do

--- a/core-program/lib/Core/Program/Workers.hs
+++ b/core-program/lib/Core/Program/Workers.hs
@@ -62,12 +62,6 @@ getMachineSize :: Program τ Int
 getMachineSize = liftIO $ do
     getNumCapabilities
 
-{-
--- or perhaps Foldable?
-runConcurrentThreads :: Traversable ω => Int -> (α -> Program τ β) -> ω α -> Program τ (ω β)
-runConcurrentThreads :: Limit -> (α -> Program τ β) -> [α] -> Program τ [β]
--}
-
 {- |
 A queue which has an end, someday.
 

--- a/core-program/package.yaml
+++ b/core-program/package.yaml
@@ -1,5 +1,5 @@
 name: core-program
-version: 0.6.9.0
+version: 0.6.9.1
 synopsis: Opinionated Haskell Interoperability
 description: |
   A library to help build command-line programs, both tools and
@@ -63,6 +63,7 @@ library:
    - Core.Program.Notify
    - Core.Program.Threads
    - Core.Program.Unlift
+   - Core.Program.Workers
    - Core.System
    - Core.System.Base
    - Core.System.External

--- a/core-program/package.yaml
+++ b/core-program/package.yaml
@@ -1,5 +1,5 @@
 name: core-program
-version: 0.6.9.1
+version: 0.6.9.2
 synopsis: Opinionated Haskell Interoperability
 description: |
   A library to help build command-line programs, both tools and


### PR DESCRIPTION
A long standing feature request has been for a mechanism to run a specified number of worker threads over a queue.

This branch introduces `runWorkers_` in new module Core.Program.Workers which runs over a TQueue and processes work as available.

(I wanted to call the function `exploitingTheWorkers` but then I'd need to add Monty Python jokes all through the library and that's already been done by another language)
