### PR TITLE
Support GHC 9.4.5

### DIFF
--- a/core-data/package.yaml
+++ b/core-data/package.yaml
@@ -17,7 +17,7 @@ license-file: LICENSE
 author: Andrew Cowie <istathar@gmail.com>
 maintainer: Andrew Cowie <istathar@gmail.com>
 copyright: © 2018-2023 Athae Eredh Siniath and Others
-tested-with: GHC == 8.10.7, GHC == 9.2.5
+tested-with: GHC == 8.10.7, GHC == 9.2.7, GHC == 9.4.5
 category: System
 ghc-options: -Wall -Wwarn -fwarn-tabs
 github: aesiniath/unbeliever

--- a/core-effect-effectful/package.yaml
+++ b/core-effect-effectful/package.yaml
@@ -17,7 +17,7 @@ license-file: LICENSE
 author: Juan Raphael Diaz Simões <juanrapha@gmail.com>
 maintainer: Andrew Cowie <istathar@gmail.com>
 copyright: © 2023- Athae Eredh Siniath and Others
-tested-with: GHC == 9.2.5
+tested-with: GHC == 9.2.7, GHC == 9.4.5
 category: System
 ghc-options: -Wall -Wwarn -fwarn-tabs
 github: aesiniath/unbeliever

--- a/core-program/package.yaml
+++ b/core-program/package.yaml
@@ -18,7 +18,7 @@ license-file: LICENSE
 author: Andrew Cowie <istathar@gmail.com>
 maintainer: Andrew Cowie <istathar@gmail.com>
 copyright: © 2018-2023 Athae Eredh Siniath and Others
-tested-with: GHC == 8.10.7, GHC == 9.2.7
+tested-with: GHC == 8.10.7, GHC == 9.2.7, GHC == 9.4.5
 category: System
 ghc-options: -Wall -Wwarn -fwarn-tabs
 github: aesiniath/unbeliever

--- a/core-telemetry/package.yaml
+++ b/core-telemetry/package.yaml
@@ -19,7 +19,7 @@ license-file: LICENSE
 author: Andrew Cowie <istathar@gmail.com>
 maintainer: Andrew Cowie <istathar@gmail.com>
 copyright: © 2021-2023 Athae Eredh Siniath and Others
-tested-with: GHC == 8.10.7, GHC == 9.2.7
+tested-with: GHC == 8.10.7, GHC == 9.2.7, GHC == 9.4.5
 category: System
 ghc-options: -Wall -Wwarn -fwarn-tabs
 github: aesiniath/unbeliever

--- a/core-text/package.yaml
+++ b/core-text/package.yaml
@@ -23,7 +23,7 @@ license-file: LICENSE
 author: Andrew Cowie <istathar@gmail.com>
 maintainer: Andrew Cowie <istathar@gmail.com>
 copyright: © 2018-2023 Athae Eredh Siniath and Others
-tested-with: GHC == 8.10.7, GHC == 9.2.5
+tested-with: GHC == 8.10.7, GHC == 9.2.7, GHC == 9.4.5
 category: System
 ghc-options: -Wall -Wwarn -fwarn-tabs
 github: aesiniath/unbeliever

--- a/core-webserver-servant/package.yaml
+++ b/core-webserver-servant/package.yaml
@@ -15,7 +15,7 @@ license-file: LICENSE
 author: Carlos D'Agostino <carlos.dagostino@gmail.com>
 maintainer: Andrew Cowie <istathar@gmail.com>
 copyright: © 2021-2023 Athae Eredh Siniath and Others
-tested-with: GHC == 8.10.7, GHC == 9.2.5
+tested-with: GHC == 8.10.7, GHC == 9.2.7, GHC == 9.4.5
 category: System
 ghc-options: -Wall -Wwarn -fwarn-tabs
 github: aesiniath/unbeliever

--- a/core-webserver-warp/package.yaml
+++ b/core-webserver-warp/package.yaml
@@ -15,7 +15,7 @@ license-file: LICENSE
 author: Andrew Cowie <istathar@gmail.com>
 maintainer: Andrew Cowie <istathar@gmail.com>
 copyright: © 2021-2023 Athae Eredh Siniath and Others
-tested-with: GHC == 8.10.7, GHC == 9.2.5
+tested-with: GHC == 8.10.7, GHC == 9.2.7, GHC == 9.4.5
 category: System
 ghc-options: -Wall -Wwarn -fwarn-tabs
 github: aesiniath/unbeliever

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,5 @@
-resolver: lts-20.18
-compiler: ghc-9.2.7
+resolver: lts-21.0
+compiler: ghc-9.4.5
 packages:
  - ./core-data
  - ./core-effect-effectful


### PR DESCRIPTION
Bump resolver to `lts-21.0` which builds against GHC 9.4.5 for testing. Tested with VS Code and **haskell-language-server** 0.2.0.0 via GHCup.

No code changes were necessary. Well done Stackage team and everyone in the Haskell community!