### PR TITLE
Add file dependencies to Git files

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,12 +1,13 @@
-resolver: lts-21.0
-compiler: ghc-9.4.5
+resolver: lts-21.9
+compiler: ghc-9.4.6
 packages:
- - ./core-data
- - ./core-effect-effectful
- - ./core-text
- - ./core-program
- - ./core-telemetry
- - ./core-webserver-servant
- - ./core-webserver-warp
- - .
-extra-deps: []
+- ./core-data
+- ./core-effect-effectful
+- ./core-text
+- ./core-program
+- ./core-telemetry
+- ./core-webserver-servant
+- ./core-webserver-warp
+- .
+extra-deps:
+- githash-0.1.7.0

--- a/tests/SimpleExperiment.hs
+++ b/tests/SimpleExperiment.hs
@@ -98,7 +98,7 @@ program = do
     info "Brr! It's cold"
 
 version :: Version
-version = $(fromPackage)
+version = $$fromPackage
 
 main :: IO ()
 main = do

--- a/unbeliever.cabal
+++ b/unbeliever.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           unbeliever
-version:        0.11.3.2
+version:        0.11.3.3
 synopsis:       Opinionated Haskell Interoperability
 description:    A library to help build command-line programs, both tools and
                 longer-running daemons. Its @Program@ type provides unified ouptut &
@@ -70,7 +70,7 @@ executable experiment
     , core-text
     , prettyprinter
     , unordered-containers
-  buildable: False
+  buildable: True
   default-language: Haskell2010
 
 executable snippet


### PR DESCRIPTION
This adds file dependencies to Git files in the TH code we had for getting versions. By itself, it didn't work as I expected. I wanted:

- Do a commit
- Package recompiles to update version

However, if we run with `--force-dirty`, it seems to work well. That is, one should be able to choose when the version should reload or not.

To test:

- Run `stack run unbeliever:exe:experiment --force-dirty -- --version`, and see the current version
- Do some commit which does not change the Haskell code.
- Run `stack run unbeliever:exe:experiment --force-dirty -- --version` again. The version should be different, and compatible with the new git commit.