### PR TITLE
Don't reset telemetry when forking a thread

### DIFF
--- a/core-program/core-program.cabal
+++ b/core-program/core-program.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           core-program
-version:        0.6.9.4
+version:        0.6.10.0
 synopsis:       Opinionated Haskell Interoperability
 description:    A library to help build command-line programs, both tools and
                 longer-running daemons.

--- a/core-program/core-program.cabal
+++ b/core-program/core-program.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           core-program
-version:        0.6.10.1
+version:        0.7.0.0
 synopsis:       Opinionated Haskell Interoperability
 description:    A library to help build command-line programs, both tools and
                 longer-running daemons.

--- a/core-program/core-program.cabal
+++ b/core-program/core-program.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           core-program
-version:        0.6.10.0
+version:        0.6.10.1
 synopsis:       Opinionated Haskell Interoperability
 description:    A library to help build command-line programs, both tools and
                 longer-running daemons.

--- a/core-program/lib/Core/Program/Threads.hs
+++ b/core-program/lib/Core/Program/Threads.hs
@@ -155,9 +155,9 @@ happens.
 /Concerning telemetry/
 
 Note that threads inherit the telemetry state from their parent. If you are
-using the tracing features from __core-telemetry__ any telemetry
-registered in that side task will be included in the enclosing span active in the thread
-that spawned the thread:
+using the tracing features from __core-telemetry__ any telemetry registered in
+that side task will be included in the enclosing span active in the parent
+thread that spawned the thread:
 
 @
     t2 <- 'forkThread' $ do
@@ -169,9 +169,9 @@ that spawned the thread:
 
 @
 
-In this case the @\"counter\"@ field in the parent span will get the value
-@42@. This is appropriate for the common case where you are doing small side
-tasks concurrently to accelerate a larger computation.
+In this case the @\"counter\"@ field in the parent thread's current span will
+get the value @42@. This is appropriate for the common case where you are doing
+small side tasks concurrently to accelerate a larger computation.
 
 But at other times you are launching off a fully independent control flow and
 want it to have its own telemetry. In those cases, you'll want to start a new

--- a/core-program/lib/Core/Program/Threads.hs
+++ b/core-program/lib/Core/Program/Threads.hs
@@ -126,8 +126,23 @@ Fork a thread. The child thread will run in the same 'Context' as the calling
 'Program', including sharing the user-defined application state value.
 
 If you want to find out what the result of a thread was use 'waitThread' on
-the 'Thread' object returned from this function. If you don't need the
-result, use 'forkThread_' instead.
+the 'Thread' object returned from this function. For example:
+
+@
+    t1 <- 'forkThread' $ do
+        'Core.Program.Logging.info' \"Doing interesting stuff concurrently\"
+        'pure' True
+
+    ...
+
+    result <- 'waitThread' t1
+
+    if result
+        then -- expected
+        else -- not good
+@
+
+If you don't need the result, you can use 'forkThread_' instead.
 
 Threads that are launched off as children are on their own! If the code in the
 child thread throws an exception that is /not/ caught within that thread, the
@@ -135,9 +150,41 @@ exception will kill the thread. Threads dying without telling anyone is a bit
 of an anti-pattern, so this library logs a warning-level log message if this
 happens.
 
-Note that threads inherit the telemetry state of their parent.
+(this function wraps __base__'s 'Control.Concurrent.forkIO')
 
-(this wraps __base__'s 'Control.Concurrent.forkIO')
+/Concerning telemetry/
+
+Note that threads inherit the telemetry state from their parent. If you are
+using the tracing features from __core-telemetry__ any telemetry
+registered in that side task will be included in the enclosing span active in the thread
+that spawned the thread:
+
+@
+    t2 <- 'forkThread' $ do
+        'Core.Program.Logging.info' \"Performing quick side task\"
+        'Core.Telemetry.Observability.telemetry'
+            [ ''Core.Telemetry.Observability.metric' \"counter\" 42
+            ]
+        ...
+
+@
+
+In this case the @\"counter\"@ field in the parent span will get the value
+@42@. This is appropriate for the common case where you are doing small side
+tasks concurrently to accelerate a larger computation.
+
+But at other times you are launching off a fully independent control flow and
+want it to have its own telemetry. In those cases, you'll want to start a new
+span (or even a new trace) immediately after forking the thread:
+
+@
+    'forkThread_' $ do
+        'Core.Telemetry.Observability.encloseSpan' \"subTask\" $ do
+            ...
+@
+
+any telemetry from this worker thread will be appropriately nested in a new
+child span called @\"subTask\"@.
 
 @since 0.2.7
 -}

--- a/core-program/package.yaml
+++ b/core-program/package.yaml
@@ -1,5 +1,5 @@
 name: core-program
-version: 0.6.9.4
+version: 0.6.10.0
 synopsis: Opinionated Haskell Interoperability
 description: |
   A library to help build command-line programs, both tools and

--- a/core-program/package.yaml
+++ b/core-program/package.yaml
@@ -1,5 +1,5 @@
 name: core-program
-version: 0.6.10.1
+version: 0.7.0.0
 synopsis: Opinionated Haskell Interoperability
 description: |
   A library to help build command-line programs, both tools and

--- a/core-program/package.yaml
+++ b/core-program/package.yaml
@@ -1,5 +1,5 @@
 name: core-program
-version: 0.6.10.0
+version: 0.6.10.1
 synopsis: Opinionated Haskell Interoperability
 description: |
   A library to help build command-line programs, both tools and

--- a/unbeliever.cabal
+++ b/unbeliever.cabal
@@ -84,6 +84,7 @@ executable snippet
     , core-data
     , core-program
     , core-text
+  buildable: False
   default-language: Haskell2010
 
 executable webserver


### PR DESCRIPTION
Change `forkThread` to no longer fork the Datum object, as this had the result of silently discarding telemetry that the user thought they were adding to the in-flight enclosing span

As discussed in 

- #200 

this is not ideal, so this branch changes this built in behaviour. The major version of **core-program** is bumped to 0.7.0 by way of signalling this change.

Closes #200 