### PR TITLE
Adopt new OpenTelemetry HTTP attribute names

### DIFF
--- a/core-webserver-warp/core-webserver-warp.cabal
+++ b/core-webserver-warp/core-webserver-warp.cabal
@@ -1,11 +1,11 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.2.
+-- This file has been generated from package.yaml by hpack version 0.36.0.
 --
 -- see: https://github.com/sol/hpack
 
 name:           core-webserver-warp
-version:        0.2.1.2
+version:        0.3.0.0
 synopsis:       Interoperability with Wai/Warp
 description:    This is part of a library to help build command-line programs, both tools and
                 longer-running daemons.
@@ -24,7 +24,7 @@ license:        MIT
 license-file:   LICENSE
 build-type:     Simple
 tested-with:
-    GHC == 8.10.7, GHC == 9.2.7, GHC == 9.4.5
+    GHC == 8.10.7, GHC == 9.2.7, GHC == 9.4.8
 
 source-repository head
   type: git

--- a/core-webserver-warp/lib/Core/Webserver/Warp.hs
+++ b/core-webserver-warp/lib/Core/Webserver/Warp.hs
@@ -208,10 +208,10 @@ loggingMiddleware (context0 :: Context τ) application request sendResponse = do
 
                             subProgram context1 $ do
                                 telemetry
-                                    [ metric "request.method" method
-                                    , metric "request.path" path
-                                    , if nullRope query then metric "request.query" () else metric "request.query" query
-                                    , metric "response.status_code" code
+                                    [ metric "http.request.method" method
+                                    , metric "http.request.path" path
+                                    , if nullRope query then metric "http.request.query" () else metric "http.request.query" query
+                                    , metric "http.response.status_code" code
                                     ]
 
                             -- actually handle the request
@@ -227,10 +227,10 @@ loggingMiddleware (context0 :: Context τ) application request sendResponse = do
                                 warn "Trapped internal exception"
                                 debug "e" text
                                 telemetry
-                                    [ metric "request.method" method
-                                    , metric "request.path" path
-                                    , if nullRope query then metric "request.query" () else metric "request.query" query
-                                    , metric "response.status_code" code
+                                    [ metric "http.request.method" method
+                                    , metric "http.request.path" path
+                                    , if nullRope query then metric "http.request.query" () else metric "http.request.query" query
+                                    , metric "http.response.status_code" code
                                     , metric "error" text
                                     ]
 

--- a/core-webserver-warp/package.yaml
+++ b/core-webserver-warp/package.yaml
@@ -1,5 +1,5 @@
 name: core-webserver-warp
-version: 0.2.1.2
+version: 0.3.0.0
 synopsis: Interoperability with Wai/Warp
 description: |
   This is part of a library to help build command-line programs, both tools and
@@ -15,7 +15,7 @@ license-file: LICENSE
 author: Andrew Cowie <istathar@gmail.com>
 maintainer: Andrew Cowie <istathar@gmail.com>
 copyright: © 2021-2023 Athae Eredh Siniath and Others
-tested-with: GHC == 8.10.7, GHC == 9.2.7, GHC == 9.4.5
+tested-with: GHC == 8.10.7, GHC == 9.2.7, GHC == 9.4.8
 category: System
 ghc-options: -Wall -Wwarn -fwarn-tabs
 github: aesiniath/unbeliever


### PR DESCRIPTION
As announced at https://www.honeycomb.io/blog/opentelemetry-http-attributes, OpenTelemetry is addopting new stabilized attribute names for HTTP factors. This branch updates the field names sent by Core.Webserver.Warp for requests and responses.