### PR TITLE
Support GHC 9.6.4

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,8 +1,7 @@
-resolver: lts-22.9
+resolver: lts-22.22
 compiler: ghc-9.6.4
 packages:
  - ./core-data
- - ./core-effect-effectful
  - ./core-text
  - ./core-program
  - ./core-telemetry

--- a/stack.yaml
+++ b/stack.yaml
@@ -9,3 +9,6 @@ packages:
  - ./core-webserver-warp
  - .
 extra-deps: []
+
+ghc-options:
+  HsOpenSSL: -optc=-Wno-incompatible-pointer-types

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,5 @@
-resolver: lts-21.23
-compiler: ghc-9.4.8
+resolver: lts-22.9
+compiler: ghc-9.6.4
 packages:
  - ./core-data
  - ./core-effect-effectful


### PR DESCRIPTION
Bump resolver to lts-22.9 which builds against GHC 9.6.4 for testing. Testing with VS Code and **haskell-language-server** 2.6.0.0 via GHCup.