### PR TITLE
Support GHC 9.6.6

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,5 @@
-resolver: lts-22.23
-compiler: ghc-9.6.5
+resolver: lts-22.38
+compiler: ghc-9.6.6
 packages:
  - ./core-data
  - ./core-text


### PR DESCRIPTION
Bump resolver to lts-22.38 and GHC 9.6.6.